### PR TITLE
A0.4: establish common conventions and primitives

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Card
+<id> — <card title>   (kind: API | implementation; GPU: yes | no; size: S | M | L)
+
+## Spec sections implemented
+<!-- Which spec does this implement or change? ("None" is valid only for docs, CI and tooling per Spec 15 §3) -->
+- spec <n> §<x>: <one line on what this PR does for it>
+
+## Deliverables
+- [ ] <each deliverable from the card, checked when present>
+
+## Done-when tests
+| test | location | tier | status |
+|---|---|---|---|
+| <name from the card> | <path> | cpu-only / gpu | green / pending runner |
+
+## Decisions
+<!-- List every DECISION(<id>) comment in the diff, one per line, with the file:line -->
+- none
+
+## SPEC-ISSUES filed
+- SI-<n>: <one line>
+- none
+
+## New dependencies
+- <crate>: <why the workspace didn't already have this>
+- none
+
+## Hardware
+Tests run here: <hosted cpu-only | stub device | compile-only | runner>
+Tests pending on the runner: <list or none>
+Measured numbers (if any): fingerprint <…>, command <…>, receipt <path or "none">
+
+## Checklist
+Walked `references/acceptance-checklist.md`. Items answered "no" and why:
+- none
+
+## Size check
+Diff size vs card size class: <lines> vs <S|M|L> — <ok | explanation>

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,187 @@
+# R9V Repository Conventions
+
+Status: active (2026-09-03). Authority: Spec 14 §2, Spec 15 §3, Spec 11 §11, and `phase-a-agent-breakdown.md` (Card A0.4).
+
+This document defines repository-wide conventions for all crates, kernels, tools, and documentation in R9V. Read this before writing any code. Do not improvise error types, tracing fields, naming schemes, test layouts, or fixture locations.
+
+---
+
+## 1. Error Handling
+
+### 1.1 Per-Crate Error Types
+- Every workspace crate defines its own domain-specific error enum using `#[derive(thiserror::Error)]` (e.g. `IrError` in `r9v-ir`, `FormatError` in `r9v-format`, `StateError` in `r9v-state`, `LoaderError` in `r9v-loader`).
+- Crate errors must be public (`pub enum <Crate>Error`) and derive `Debug`, implementing `std::error::Error` via `thiserror`.
+- Where an operation depends on a lower crate in the downward dependency graph (Spec 14 §2), wrap the lower error using `#[error(transparent)]` and `#[from]`:
+  ```rust
+  #[derive(Debug, thiserror::Error)]
+  pub enum LoaderError {
+      #[error(transparent)]
+      Format(#[from] r9v_format::FormatError),
+      // ...
+  }
+  ```
+
+### 1.2 Top-Level `R9vError`
+- The top-level engine error enum is `r9v_common::R9vError` defined in `crates/r9v-common`.
+- `R9vError` is strictly typed and owned; it avoids stringly-typed messages or generic boxed errors. At this foundation stage, it wraps shared fundamental errors: `ByteSize(#[from] ByteSizeError)` and `Io(#[from] std::io::Error)`.
+- Downstream crates define explicit domain error enums (`IrError`, `FormatError`, etc.) and compose down the dependency graph via typed variants.
+
+### 1.3 Errors Carry Numbers and Complete Context
+- A refusal or validation failure must never emit a bare message. It must report what was required, what was available, the shortfall, and **every** failing item—never just the first one:
+  ```rust
+  #[derive(Debug, thiserror::Error)]
+  pub enum LoaderError {
+      #[error("device {device}: required {required} B, available {available} B, shortfall {shortfall} B; largest: {largest:?}; suggestion: {suggestion}")]
+      Budget {
+          device: u32,
+          required: u64,
+          available: u64,
+          shortfall: u64,
+          largest: Vec<(String, u64)>,
+          suggestion: String,
+      },
+
+      #[error("{} tensor(s) missing or mis-shaped: {details:?}", details.len())]
+      Tensors { details: Vec<TensorProblem> },
+  }
+  ```
+
+### 1.4 Collect-All Validation Pattern
+- Validation logic must accumulate all problems before returning an error:
+  ```rust
+  let mut problems = Vec::new();
+  for item in items {
+      if let Err(e) = validate_item(item) {
+          problems.push(e);
+      }
+  }
+  if !problems.is_empty() {
+      return Err(ValidationError::Multiple { problems });
+  }
+  ```
+
+### 1.5 Prohibition of Panics on Untrusted Input
+- Never call `.unwrap()`, `.expect()`, or `panic!` on data originating from a file, network, request, environment, or device.
+- All untrusted input must be parsed at system boundaries into typed structures via `Result`.
+- `.expect(...)` is permitted only for internal invariant violations (unreachable logic verified by typing or invariants), and must carry a comment or message explaining why the invariant holds.
+
+---
+
+## 2. Tracing and Logging
+
+Governed by Spec 11 §11.
+
+### 2.1 Structured Output Format
+- Engine logs are structured JSON lines: `{"ts": "...", "level": "...", "target": "...", "msg": "...", "fields": {...}}`.
+- Standard levels: `error`, `warn`, `info`, `debug`, `trace`.
+  - `info`: High-level operational events (model loaded, request admitted, step completed).
+  - `debug`: Detailed inline execution records per step.
+  - `trace`: Per-launch records for single-step performance and kernel investigations.
+
+### 2.2 Mandatory Correlation Fields
+- **Request-scoped logs**: Every log line associated with a user or client request must carry the structured field `req_id`:
+  ```rust
+  tracing::info!(req_id = %req.id(), "request admitted into queue");
+  ```
+- **Step-scoped logs**: Every log line associated with a scheduler step must carry the structured field `step_id`:
+  ```rust
+  tracing::info!(
+      step_id = %step.id(),
+      s = step.s,
+      t_dec = step.t_dec,
+      t_pre = step.t_pre,
+      "step completed"
+  );
+  ```
+- Combined step and request events include both fields where applicable:
+  ```rust
+  tracing::debug!(req_id = %req.id(), step_id = %step.id(), "token emitted");
+  ```
+
+### 2.3 Prompt and Token Privacy Rule
+- Per Spec 11 §1 and §11: Log messages at level `info` or higher **must never** contain prompt text, completion text, or raw token IDs.
+- Log token counts, sequence lengths, and content hashes (`xxh3_64`) instead. Raw tokens are visible only in specialized debugging sessions under explicit opt-in.
+
+---
+
+## 3. Naming Conventions
+
+### 3.1 Identifiers and Types
+- **Types and Traits**: `UpperCamelCase` (e.g. `SeqId`, `TensorLayout`, `QuantScheme`).
+- **Functions, Methods, Variables, Modules**: `snake_case` (e.g. `parse_byte_size`, `xxh3_64`).
+- **Constants and Statics**: `SCREAMING_SNAKE_CASE` (e.g. `DEFAULT_ALIGNMENT`, `MAX_WAVE_SIZE`).
+- **Opaque IDs**: Distinct minimal newtypes wrapping private `u64` fields (`SeqId`, `ReqId`, `StepId`), with constructor `new(u64)` and accessor `as_u64()`. Never pass bare primitive integers (`u32`, `u64`) for semantic identifiers in public interfaces, and avoid lossy truncation or implicit conversions.
+
+### 3.2 Closed Sets
+- Closed sets defined in specs (ops, dtypes, schemes, layouts, state kinds, verify methods, proposer kinds) are Rust enums:
+  - Exhaustive matching (no `_ =>` wildcard catch-alls in internal logic).
+  - `#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]` (and `serde::Serialize`, `serde::Deserialize` where applicable).
+  - Serialized to stable lowercase `snake_case` strings, never raw discriminants.
+
+### 3.3 Test Naming
+- Name tests by the exact behavior and invariant being proven, not implementation details:
+  - Good: `commit_with_partial_accept_keeps_verified_prefix()`
+  - Good: `budget_refusal_reports_shortfall_and_all_contenders()`
+  - Bad: `test_commit_2()`, `test_loader()`
+
+---
+
+## 4. Test and Fixture Layout
+
+### 4.1 Unit and Integration Tests
+- **Unit tests**: Internal private logic is tested in `tests` submodules (`mod tests { ... }`) within the respective file.
+- **Integration tests**: Public crate interfaces are tested in `tests/*.rs` within each crate directory.
+- **API shape tests**: API-bearing cards deliver `tests/api_shape.rs` checking visibility, `Send`/`Sync` markers, and trait implementations.
+
+### 4.2 Fixture Locations
+- **Rust fixtures**: Synthetic inputs and test helpers live under `tests/fixtures/<crate>/` or in test harness modules.
+- **Golden files**: Structured outputs (partitioner graphs, summaries, load reports) are stored under `tests/golden/<crate>/<name>.<json|toml>`.
+  - Golden files use normalized serialization: sorted keys, fixed spacing, no timestamps.
+  - Regenerated only via `R9V_UPDATE_GOLDEN=1 cargo test -p <crate>`.
+- **Quant tool fixtures**: Synthetic models live under `tools/r9v-quant/tests/fixtures/` and are generated deterministically by `tests/gen_fixture.py`.
+
+### 4.3 Determinism and Property Testing
+- Tests must be reproducible: no dependence on wall-clock time, environment variables, network access, or files outside the repository.
+- Property-based tests use `proptest` with fixed seeds or `r9v_common::rng::SeededRng`.
+- Determinism tests must execute the operation twice and verify bit-identical output.
+- Numeric tolerances must come from the Spec 1 §6.1 table loaded as data, never hard-coded literal floats in test assertions.
+
+### 4.4 GPU Test Placement
+- GPU tests live in `tests/gpu/` and run only on the `gpu/gfx1201` runner.
+- When hardware is absent, GPU tests must report the skip explicitly (e.g. `gpu::device_or_skip(...)`) and never pass silently as a dummy success.
+
+---
+
+## 5. DECISION Comments
+
+When the spec leaves an implementation detail open, follow this procedure:
+
+1. Select the simplest option that satisfies all governing principles in the relevant specs.
+2. Mark the choice in code with a comment in the following format:
+   ```rust
+   // DECISION(<card-id>): <summary of choice>; rejected: <alternative rejected>. <Spec citation context>.
+   ```
+   Example:
+   ```rust
+   // DECISION(A0.4): byte-size parsing treats B, K/KB/KiB, M/MB/MiB, G/GB/GiB, T/TB/TiB as binary powers of 1024; rejected decimal 1000-based multipliers because memory/VRAM budgets in Spec 12 §3 and Spec 9 use standard binary allocation sizes.
+   ```
+3. List every `DECISION(<card-id>)` comment from implementation files in the PR body under the `## Decisions` heading with its `file:line` location.
+4. **Constraint**: A `DECISION` comment is valid only for open details. It must never override or contradict clear spec text.
+
+---
+
+## 6. SPEC-ISSUES Procedure
+
+When a spec contains a contradiction, omission, or error:
+
+1. Never edit files under `specs/`. Specs are Dylan's authoritative decisions.
+2. File an entry in `SPEC-ISSUES.md` using the standard format:
+   ```markdown
+   ## SI-<n> — <card id> — spec <n> §<x>
+   What: <the sentence or gap, quoted or precisely located>
+   Why it blocks or misleads: <one paragraph>
+   Option taken: <what you did, or "stopped">
+   Proposed resolution: <the spec edit you'd make, in one or two sentences>
+   ```
+3. If continuing work, cite the entry in code (`// DECISION(<card-id>): ... per SI-<n>`).
+4. The issue blocks only the directly affected dependency line; independent cards and crates continue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,77 +3,196 @@
 version = 4
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "r9v"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-common"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "twox-hash",
+]
 
 [[package]]
 name = "r9v-config"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-format"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-helper"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-hip"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-ir"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-kgen"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-loader"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-models"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-obs"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-part"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-registry"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-sched"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-serve"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-spec"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-state"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
 
 [[package]]
 name = "r9v-t0"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "xtask"
 version = "0.1.0"
+dependencies = [
+ "r9v-common",
+]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ in the benchmarks below was built separately and enabled only its TP2 BF16
 all-reduce.
 
 If you are pointing an AI assistant at this repository, hand it
-[LLM_SETUP_GUIDE.md](LLM_SETUP_GUIDE.md).
+[LLM_SETUP_GUIDE.md](LLM_SETUP_GUIDE.md). Repository coding conventions, error
+types, logging fields, and test layouts are defined in
+[CONVENTIONS.md](CONVENTIONS.md).
 
 ## Profiles
 

--- a/crates/r9v-common/Cargo.toml
+++ b/crates/r9v-common/Cargo.toml
@@ -8,3 +8,5 @@ repository.workspace = true
 description = "Shared types, error handling, ids, hashing, and byte-size helpers for R9V (Spec 14 §2)"
 
 [dependencies]
+thiserror = "2.0"
+twox-hash = { version = "2.1", default-features = false, features = ["xxhash3_64", "xxhash3_128", "alloc"] }

--- a/crates/r9v-common/src/bytes.rs
+++ b/crates/r9v-common/src/bytes.rs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Strict byte-size parsing and formatting (Spec 12 §3, Spec 14 §2, CONVENTIONS.md §1.3).
+
+use std::fmt;
+use std::str::FromStr;
+
+// DECISION(A0.4): byte-size parsing treats B, K/KB/KiB, M/MB/MiB, G/GB/GiB, T/TB/TiB as binary powers of 1024; rejected decimal 1000-based multipliers because memory/VRAM budgets in Spec 12 §3 and Spec 9 use standard binary allocation sizes.
+
+/// Multiplier for binary kilo-units (2^10) (Spec 14 §2).
+pub const KIB: u64 = 1024;
+/// Multiplier for binary mega-units (2^20) (Spec 14 §2).
+pub const MIB: u64 = 1024 * KIB;
+/// Multiplier for binary giga-units (2^30) (Spec 14 §2).
+pub const GIB: u64 = 1024 * MIB;
+/// Multiplier for binary tera-units (2^40) (Spec 14 §2).
+pub const TIB: u64 = 1024 * GIB;
+/// Multiplier for binary peta-units (2^50) (Spec 14 §2).
+pub const PIB: u64 = 1024 * TIB;
+
+/// Errors arising from strict byte-size parsing.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ByteSizeError {
+    /// The input string was empty or contained only whitespace.
+    #[error("byte size string cannot be empty")]
+    Empty,
+
+    /// The input string did not start with a valid numeric component.
+    #[error("byte size string must start with a digit: '{input}'")]
+    MissingNumber {
+        /// The original input string.
+        input: String,
+    },
+
+    /// The numeric component was malformed.
+    #[error("invalid byte size number in '{input}': {reason}")]
+    InvalidNumber {
+        /// The original input string.
+        input: String,
+        /// Detail on why the number could not be parsed.
+        reason: String,
+    },
+
+    /// Negative values are disallowed.
+    #[error("negative byte size is not allowed: '{input}'")]
+    Negative {
+        /// The original input string.
+        input: String,
+    },
+
+    /// The byte size resolved to a fractional (non-integral) number of bytes.
+    #[error("byte size must resolve to an exact integral number of bytes: '{input}'")]
+    FractionalByte {
+        /// The original input string.
+        input: String,
+    },
+
+    /// An unrecognized or unsupported unit suffix was encountered.
+    #[error("unknown byte size unit '{unit}' in '{input}'")]
+    UnknownUnit {
+        /// The unrecognized unit suffix.
+        unit: String,
+        /// The original input string.
+        input: String,
+    },
+
+    /// Calculating the byte size resulted in integer overflow.
+    #[error("byte size calculation overflowed in '{input}'")]
+    Overflow {
+        /// The original input string.
+        input: String,
+    },
+
+    /// Unexpected trailing characters remained after the unit.
+    #[error("unexpected trailing characters '{trailing}' in '{input}'")]
+    TrailingCharacters {
+        /// The unexpected trailing characters.
+        trailing: String,
+        /// The original input string.
+        input: String,
+    },
+}
+
+/// Parses a byte size string into bytes as a `u64` (Spec 12 §3, Spec 14 §2).
+///
+/// Parsing is strictly checked with exact decimal arithmetic:
+/// - Leading and trailing whitespace is trimmed.
+/// - Negative values are rejected.
+/// - Non-integral byte amounts are rejected with [`ByteSizeError::FractionalByte`].
+/// - Units supported (case-insensitive):
+///   - `B` or omitted: bytes
+///   - `K`, `KB`, `KiB`: 1024 B
+///   - `M`, `MB`, `MiB`: 1024^2 B (1,048,576 B)
+///   - `G`, `GB`, `GiB`: 1024^3 B (1,073,741,824 B)
+///   - `T`, `TB`, `TiB`: 1024^4 B (1,099,511,627,776 B)
+///   - `P`, `PB`, `PiB`: 1024^5 B (1,125,899,906,842,624 B)
+/// - Any trailing garbage or integer overflow produces an error.
+pub fn parse_byte_size(input: &str) -> Result<u64, ByteSizeError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(ByteSizeError::Empty);
+    }
+
+    if trimmed.starts_with('-') {
+        return Err(ByteSizeError::Negative {
+            input: input.to_owned(),
+        });
+    }
+
+    let mut split_idx = 0;
+    let mut has_digits = false;
+    let mut has_dot = false;
+
+    for (i, c) in trimmed.char_indices() {
+        if c.is_ascii_digit() {
+            has_digits = true;
+            split_idx = i + c.len_utf8();
+        } else if c == '.' {
+            if has_dot {
+                return Err(ByteSizeError::InvalidNumber {
+                    input: input.to_owned(),
+                    reason: "multiple decimal points encountered".to_owned(),
+                });
+            }
+            has_dot = true;
+            split_idx = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    if !has_digits {
+        return Err(ByteSizeError::MissingNumber {
+            input: input.to_owned(),
+        });
+    }
+
+    let num_str = &trimmed[..split_idx];
+    let remainder = trimmed[split_idx..].trim_start();
+
+    // Check for trailing characters after unit
+    let unit_str = match remainder.find(char::is_whitespace) {
+        Some(idx) => {
+            let (u, rest) = remainder.split_at(idx);
+            let rest_trimmed = rest.trim();
+            if !rest_trimmed.is_empty() {
+                return Err(ByteSizeError::TrailingCharacters {
+                    trailing: rest_trimmed.to_owned(),
+                    input: input.to_owned(),
+                });
+            }
+            u
+        }
+        None => remainder,
+    };
+
+    let multiplier = unit_multiplier(unit_str).ok_or_else(|| ByteSizeError::UnknownUnit {
+        unit: unit_str.to_owned(),
+        input: input.to_owned(),
+    })?;
+
+    // Exact checked decimal arithmetic without float rounding
+    if let Some((int_part, frac_raw)) = num_str.split_once('.') {
+        if int_part.is_empty() {
+            return Err(ByteSizeError::MissingNumber {
+                input: input.to_owned(),
+            });
+        }
+        let int_val: u128 = int_part.parse().map_err(|e: std::num::ParseIntError| {
+            if e.kind() == &std::num::IntErrorKind::PosOverflow {
+                ByteSizeError::Overflow {
+                    input: input.to_owned(),
+                }
+            } else {
+                ByteSizeError::InvalidNumber {
+                    input: input.to_owned(),
+                    reason: e.to_string(),
+                }
+            }
+        })?;
+
+        let frac_trimmed = frac_raw.trim_end_matches('0');
+        let frac_bytes = if frac_trimmed.is_empty() {
+            0u128
+        } else {
+            let frac_len = frac_trimmed.len();
+            if frac_len > 28 {
+                return Err(ByteSizeError::FractionalByte {
+                    input: input.to_owned(),
+                });
+            }
+            let frac_val: u128 = frac_trimmed.parse().map_err(|e: std::num::ParseIntError| {
+                if e.kind() == &std::num::IntErrorKind::PosOverflow {
+                    ByteSizeError::Overflow {
+                        input: input.to_owned(),
+                    }
+                } else {
+                    ByteSizeError::InvalidNumber {
+                        input: input.to_owned(),
+                        reason: e.to_string(),
+                    }
+                }
+            })?;
+
+            let pow10 =
+                10u128
+                    .checked_pow(frac_len as u32)
+                    .ok_or_else(|| ByteSizeError::Overflow {
+                        input: input.to_owned(),
+                    })?;
+
+            let numerator = frac_val.checked_mul(multiplier as u128).ok_or_else(|| {
+                ByteSizeError::Overflow {
+                    input: input.to_owned(),
+                }
+            })?;
+
+            if !numerator.is_multiple_of(pow10) {
+                return Err(ByteSizeError::FractionalByte {
+                    input: input.to_owned(),
+                });
+            }
+
+            numerator / pow10
+        };
+
+        let int_bytes =
+            int_val
+                .checked_mul(multiplier as u128)
+                .ok_or_else(|| ByteSizeError::Overflow {
+                    input: input.to_owned(),
+                })?;
+
+        let total_bytes =
+            int_bytes
+                .checked_add(frac_bytes)
+                .ok_or_else(|| ByteSizeError::Overflow {
+                    input: input.to_owned(),
+                })?;
+
+        if total_bytes > (u64::MAX as u128) {
+            return Err(ByteSizeError::Overflow {
+                input: input.to_owned(),
+            });
+        }
+
+        Ok(total_bytes as u64)
+    } else {
+        let val: u128 = num_str.parse().map_err(|e: std::num::ParseIntError| {
+            if e.kind() == &std::num::IntErrorKind::PosOverflow {
+                ByteSizeError::Overflow {
+                    input: input.to_owned(),
+                }
+            } else {
+                ByteSizeError::InvalidNumber {
+                    input: input.to_owned(),
+                    reason: e.to_string(),
+                }
+            }
+        })?;
+
+        let total = val
+            .checked_mul(multiplier as u128)
+            .ok_or_else(|| ByteSizeError::Overflow {
+                input: input.to_owned(),
+            })?;
+
+        if total > (u64::MAX as u128) {
+            return Err(ByteSizeError::Overflow {
+                input: input.to_owned(),
+            });
+        }
+
+        Ok(total as u64)
+    }
+}
+
+fn unit_multiplier(unit: &str) -> Option<u64> {
+    let lower = unit.to_ascii_lowercase();
+    match lower.as_str() {
+        "" | "b" | "bytes" | "byte" => Some(1),
+        "k" | "kb" | "kib" => Some(KIB),
+        "m" | "mb" | "mib" => Some(MIB),
+        "g" | "gb" | "gib" => Some(GIB),
+        "t" | "tb" | "tib" => Some(TIB),
+        "p" | "pb" | "pib" => Some(PIB),
+        _ => None,
+    }
+}
+
+/// Formats a byte count into a human-readable string with binary units (Spec 12 §3).
+pub fn format_byte_size(bytes: u64) -> String {
+    if bytes >= PIB && bytes.is_multiple_of(PIB) {
+        format!("{} PiB", bytes / PIB)
+    } else if bytes >= PIB {
+        format!("{:.2} PiB", bytes as f64 / PIB as f64)
+    } else if bytes >= TIB && bytes.is_multiple_of(TIB) {
+        format!("{} TiB", bytes / TIB)
+    } else if bytes >= TIB {
+        format!("{:.2} TiB", bytes as f64 / TIB as f64)
+    } else if bytes >= GIB && bytes.is_multiple_of(GIB) {
+        format!("{} GiB", bytes / GIB)
+    } else if bytes >= GIB {
+        format!("{:.2} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB && bytes.is_multiple_of(MIB) {
+        format!("{} MiB", bytes / MIB)
+    } else if bytes >= MIB {
+        format!("{:.2} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB && bytes.is_multiple_of(KIB) {
+        format!("{} KiB", bytes / KIB)
+    } else if bytes >= KIB {
+        format!("{:.2} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+/// Strongly-typed byte-size wrapper (Spec 12 §3, Spec 14 §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ByteSize(u64);
+
+impl ByteSize {
+    /// Creates a new [`ByteSize`] (Spec 14 §2).
+    pub const fn new(bytes: u64) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the number of bytes as a `u64` (Spec 14 §2).
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for ByteSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", format_byte_size(self.0))
+    }
+}
+
+impl FromStr for ByteSize {
+    type Err = ByteSizeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_byte_size(s).map(Self)
+    }
+}

--- a/crates/r9v-common/src/error.rs
+++ b/crates/r9v-common/src/error.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Top-level error types for R9V (Spec 14 §2, Spec 15 §3, CONVENTIONS.md §1).
+
+use crate::bytes::ByteSizeError;
+
+/// Result type alias with [`R9vError`] as the default error type (Spec 14 §2).
+pub type Result<T, E = R9vError> = std::result::Result<T, E>;
+
+/// Top-level error type representing failures across the R9V engine (Spec 14 §2, CONVENTIONS.md §1.2).
+///
+/// At this card stage, [`R9vError`] strictly wraps common errors shared across crates.
+#[derive(Debug, thiserror::Error)]
+pub enum R9vError {
+    /// Byte-size parsing error.
+    #[error("byte size parse error: {0}")]
+    ByteSize(#[from] ByteSizeError),
+
+    /// Standard I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/r9v-common/src/hash.rs
+++ b/crates/r9v-common/src/hash.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+//! XXH3 hashing helpers (Spec 2 §6, Spec 3 §2, Spec 4 §1.6, Spec 9 §1, Spec 14 §2).
+
+pub use twox_hash::XxHash3_128 as Xxh3Hasher128;
+pub use twox_hash::XxHash3_64 as Xxh3Hasher;
+
+/// Computes the 64-bit XXH3 checksum of `data` (Spec 2 §6, Spec 3 §2, Spec 4 §1.6).
+///
+/// Used for tensor integrity checksums (`r9v.tensor.<name>.xxh3`), block content-addressing
+/// in the prefix cache, and kernel variant identification.
+#[inline]
+pub fn xxh3_64(data: &[u8]) -> u64 {
+    twox_hash::XxHash3_64::oneshot(data)
+}
+
+/// Computes the 64-bit XXH3 checksum of `data` with a custom 64-bit `seed` (Spec 14 §2).
+#[inline]
+pub fn xxh3_64_with_seed(data: &[u8], seed: u64) -> u64 {
+    twox_hash::XxHash3_64::oneshot_with_seed(seed, data)
+}
+
+/// Computes the 128-bit XXH3 hash of `data` (Spec 9 §1).
+///
+/// Used for compound file fingerprints (`file_fp`) and model fingerprints (`model_fp`).
+#[inline]
+pub fn xxh3_128(data: &[u8]) -> u128 {
+    twox_hash::XxHash3_128::oneshot(data)
+}
+
+/// Computes the 128-bit XXH3 hash of `data` with a custom 64-bit `seed` (Spec 14 §2).
+#[inline]
+pub fn xxh3_128_with_seed(data: &[u8], seed: u64) -> u128 {
+    twox_hash::XxHash3_128::oneshot_with_seed(seed, data)
+}

--- a/crates/r9v-common/src/ids.rs
+++ b/crates/r9v-common/src/ids.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Distinct opaque identifier newtypes (Spec 3 §2, Spec 6 §9, Spec 10 §4, Spec 11 §11, Spec 14 §2).
+
+use std::fmt;
+
+// DECISION(A0.4): SeqId, ReqId, and StepId wrap u64; rejected u32 to prevent rollover in long-running serving deployments and high-step benchmark runs while retaining cheap Copy semantics.
+
+/// Opaque sequence identifier newtype (Spec 3 §2, Spec 7 §2, Spec 14 §2, CONVENTIONS.md §3.1).
+///
+/// Identifies an active or completed sequence managed by `r9v-state` and scheduled
+/// by `r9v-sched`. The inner representation is private to prevent accidental swapping
+/// with other integer IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SeqId(u64);
+
+impl SeqId {
+    /// Creates a new [`SeqId`] from a 64-bit integer (Spec 14 §2).
+    pub const fn new(val: u64) -> Self {
+        Self(val)
+    }
+
+    /// Returns the underlying 64-bit ID (Spec 14 §2).
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SeqId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Opaque request identifier newtype (Spec 10 §4, Spec 11 §11, Spec 14 §2, CONVENTIONS.md §2.2, §3.1).
+///
+/// Identifies an in-flight serving request in `r9v-serve`, tracing logs, and error envelopes.
+/// Every request-scoped log line must carry `req_id = %req.id()` (Spec 11 §11).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ReqId(u64);
+
+impl ReqId {
+    /// Creates a new [`ReqId`] from a 64-bit integer (Spec 14 §2).
+    pub const fn new(val: u64) -> Self {
+        Self(val)
+    }
+
+    /// Returns the underlying 64-bit ID (Spec 14 §2).
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for ReqId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Opaque step identifier newtype (Spec 6 §9, Spec 11 §11, Spec 14 §2, CONVENTIONS.md §2.2, §3.1).
+///
+/// Identifies an execution step emitted by `r9v-sched`. Every step-scoped log line
+/// and schedule log entry must carry `step_id = %step.id()` (Spec 11 §11).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StepId(u64);
+
+impl StepId {
+    /// Creates a new [`StepId`] from a 64-bit integer (Spec 14 §2).
+    pub const fn new(val: u64) -> Self {
+        Self(val)
+    }
+
+    /// Returns the underlying 64-bit ID (Spec 14 §2).
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for StepId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/crates/r9v-common/src/lib.rs
+++ b/crates/r9v-common/src/lib.rs
@@ -1,1 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
 //! Shared types, error handling, ids, hashing, and byte-size helpers for R9V (Spec 14 §2).
+//!
+//! Architecture and repository coding standards are defined in `CONVENTIONS.md`.
+
+pub mod bytes;
+pub mod error;
+pub mod hash;
+pub mod ids;
+pub mod rng;
+
+pub use bytes::{
+    format_byte_size, parse_byte_size, ByteSize, ByteSizeError, GIB, KIB, MIB, PIB, TIB,
+};
+pub use error::{R9vError, Result};
+pub use hash::{
+    xxh3_128, xxh3_128_with_seed, xxh3_64, xxh3_64_with_seed, Xxh3Hasher, Xxh3Hasher128,
+};
+pub use ids::{ReqId, SeqId, StepId};
+pub use rng::SeededRng;

--- a/crates/r9v-common/src/rng.rs
+++ b/crates/r9v-common/src/rng.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Deterministic seeded random number generator (Spec 1 §6.1, Spec 14 §2, CONVENTIONS.md §4.3).
+
+// DECISION(A0.4): SeededRng implements Xoshiro256++ seeded via SplitMix64; rejected external rand dependency to maintain zero-dependency determinism and pass license audit under cargo deny.
+
+/// Deterministic, reproducible pseudorandom number generator for test fixtures (Spec 1 §6.1, Spec 14 §2).
+///
+/// Implemented with the Xoshiro256++ algorithm (David Blackman and Sebastiano Vigna, 2019)
+/// seeded through SplitMix64. Zero-allocation, platform-independent, and bit-exact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeededRng {
+    s: [u64; 4],
+}
+
+impl SeededRng {
+    /// Creates a new [`SeededRng`] initialized from a 64-bit seed using SplitMix64 (Spec 14 §2).
+    pub const fn new(seed: u64) -> Self {
+        let mut x = seed;
+
+        // SplitMix64 generator to populate 256 bits of state
+        let s0 = splitmix64_step(&mut x);
+        let s1 = splitmix64_step(&mut x);
+        let s2 = splitmix64_step(&mut x);
+        let s3 = splitmix64_step(&mut x);
+
+        // State must not be all zeros
+        let (s0, s1, s2, s3) = if s0 == 0 && s1 == 0 && s2 == 0 && s3 == 0 {
+            (
+                0x9E3779B97F4A7C15,
+                0xBF58476D1CE4E5B9,
+                0x94D049BB133111EB,
+                0xD6E8FEB86659FD93,
+            )
+        } else {
+            (s0, s1, s2, s3)
+        };
+
+        Self {
+            s: [s0, s1, s2, s3],
+        }
+    }
+
+    /// Generates the next pseudorandom `u64` for a deterministic fixture (Spec 14 §2).
+    pub fn next_u64(&mut self) -> u64 {
+        let result = self.s[0]
+            .wrapping_add(self.s[3])
+            .rotate_left(23)
+            .wrapping_add(self.s[0]);
+
+        let t = self.s[1] << 17;
+
+        self.s[2] ^= self.s[0];
+        self.s[3] ^= self.s[1];
+        self.s[1] ^= self.s[2];
+        self.s[0] ^= self.s[3];
+
+        self.s[2] ^= t;
+        self.s[3] = self.s[3].rotate_left(45);
+
+        result
+    }
+
+    /// Fills a fixture byte slice deterministically (Spec 14 §2).
+    pub fn fill_bytes(&mut self, dest: &mut [u8]) {
+        let mut chunks = dest.chunks_exact_mut(8);
+        for chunk in &mut chunks {
+            let val = self.next_u64().to_le_bytes();
+            chunk.copy_from_slice(&val);
+        }
+        let remainder = chunks.into_remainder();
+        if !remainder.is_empty() {
+            let val = self.next_u64().to_le_bytes();
+            remainder.copy_from_slice(&val[..remainder.len()]);
+        }
+    }
+}
+
+const fn splitmix64_step(x: &mut u64) -> u64 {
+    *x = x.wrapping_add(0x9E3779B97F4A7C15);
+    let mut z = *x;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies that the internal step matches the upstream reference implementation of
+    /// Xoshiro256++ (David Blackman & Sebastiano Vigna, 2019) on arbitrary raw state [1, 2, 3, 4].
+    #[test]
+    fn reference_algorithm_raw_state() {
+        let mut rng = SeededRng { s: [1, 2, 3, 4] };
+        assert_eq!(rng.next_u64(), 0x0000000002800001);
+        assert_eq!(rng.next_u64(), 0x0000000003800067);
+        assert_eq!(rng.next_u64(), 0x000cc00003800067);
+        assert_eq!(rng.next_u64(), 0x000cc201994400b2);
+        assert_eq!(rng.next_u64(), 0x8012a2019ac433cd);
+    }
+}

--- a/crates/r9v-common/tests/api_shape.rs
+++ b/crates/r9v-common/tests/api_shape.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//! API shape and trait bound verification for r9v-common (Spec 14 §2, r9v-card-work §6).
+
+use std::fmt::Display;
+use std::hash::Hash;
+use std::str::FromStr;
+
+use r9v_common::{
+    format_byte_size, parse_byte_size, ByteSize, ByteSizeError, R9vError, ReqId, Result, SeededRng,
+    SeqId, StepId,
+};
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+fn assert_copy<T: Copy>() {}
+fn assert_clone<T: Clone>() {}
+fn assert_display<T: Display>() {}
+fn assert_hash<T: Hash>() {}
+fn assert_from_str<T: FromStr>() {}
+fn assert_error<T: std::error::Error>() {}
+
+#[test]
+fn api_shape_invariants() {
+    assert_send::<SeqId>();
+    assert_sync::<SeqId>();
+    assert_copy::<SeqId>();
+    assert_clone::<SeqId>();
+    assert_display::<SeqId>();
+    assert_hash::<SeqId>();
+
+    assert_send::<ReqId>();
+    assert_sync::<ReqId>();
+    assert_copy::<ReqId>();
+    assert_clone::<ReqId>();
+    assert_display::<ReqId>();
+    assert_hash::<ReqId>();
+
+    assert_send::<StepId>();
+    assert_sync::<StepId>();
+    assert_copy::<StepId>();
+    assert_clone::<StepId>();
+    assert_display::<StepId>();
+    assert_hash::<StepId>();
+
+    assert_send::<ByteSize>();
+    assert_sync::<ByteSize>();
+    assert_copy::<ByteSize>();
+    assert_clone::<ByteSize>();
+    assert_display::<ByteSize>();
+    assert_hash::<ByteSize>();
+    assert_from_str::<ByteSize>();
+
+    assert_send::<ByteSizeError>();
+    assert_sync::<ByteSizeError>();
+    assert_clone::<ByteSizeError>();
+    assert_error::<ByteSizeError>();
+
+    assert_send::<R9vError>();
+    assert_sync::<R9vError>();
+    assert_error::<R9vError>();
+
+    assert_send::<SeededRng>();
+    assert_sync::<SeededRng>();
+    assert_clone::<SeededRng>();
+
+    // Verify minimal constructors and accessors
+    let s = SeqId::new(1);
+    assert_eq!(s.as_u64(), 1);
+
+    let r = ReqId::new(2);
+    assert_eq!(r.as_u64(), 2);
+
+    let st = StepId::new(3);
+    assert_eq!(st.as_u64(), 3);
+
+    let b = ByteSize::new(1024);
+    assert_eq!(b.as_u64(), 1024);
+
+    let _ = parse_byte_size("1024 B");
+    let _ = format_byte_size(1024);
+    let _: Result<()> = Ok(());
+}

--- a/crates/r9v-common/tests/test_bytes.rs
+++ b/crates/r9v-common/tests/test_bytes.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for strict byte-size parsing and formatting (Spec 12 §3, Spec 14 §2, CONVENTIONS.md §1.3).
+
+use std::str::FromStr;
+
+use r9v_common::{
+    format_byte_size, parse_byte_size, ByteSize, ByteSizeError, GIB, KIB, MIB, PIB, TIB,
+};
+
+#[test]
+fn parse_valid_plain_numbers() {
+    assert_eq!(parse_byte_size("0").unwrap(), 0);
+    assert_eq!(parse_byte_size("1024").unwrap(), 1024);
+    assert_eq!(parse_byte_size("1024B").unwrap(), 1024);
+    assert_eq!(parse_byte_size("1024 B").unwrap(), 1024);
+    assert_eq!(parse_byte_size("  500 bytes ").unwrap(), 500);
+}
+
+#[test]
+fn parse_valid_binary_units() {
+    assert_eq!(parse_byte_size("4KiB").unwrap(), 4 * KIB);
+    assert_eq!(parse_byte_size("4 KiB").unwrap(), 4 * KIB);
+    assert_eq!(parse_byte_size("512MiB").unwrap(), 512 * MIB);
+    assert_eq!(parse_byte_size("512 MiB").unwrap(), 512 * MIB);
+    assert_eq!(parse_byte_size("32GiB").unwrap(), 32 * GIB);
+    assert_eq!(parse_byte_size("32 GiB").unwrap(), 32 * GIB);
+    assert_eq!(parse_byte_size("2TiB").unwrap(), 2 * TIB);
+    assert_eq!(parse_byte_size("1PiB").unwrap(), PIB);
+}
+
+#[test]
+fn parse_valid_shorthand_units_and_case_insensitivity() {
+    // Unqualified memory-unit aliases follow the binary-unit decision documented by the parser.
+    assert_eq!(parse_byte_size("4K").unwrap(), 4 * KIB);
+    assert_eq!(parse_byte_size("4KB").unwrap(), 4 * KIB);
+    assert_eq!(parse_byte_size("4kb").unwrap(), 4 * KIB);
+    assert_eq!(parse_byte_size("512M").unwrap(), 512 * MIB);
+    assert_eq!(parse_byte_size("512MB").unwrap(), 512 * MIB);
+    assert_eq!(parse_byte_size("512mb").unwrap(), 512 * MIB);
+    assert_eq!(parse_byte_size("4G").unwrap(), 4 * GIB);
+    assert_eq!(parse_byte_size("4GB").unwrap(), 4 * GIB);
+    assert_eq!(parse_byte_size("4gb").unwrap(), 4 * GIB);
+    assert_eq!(parse_byte_size("2T").unwrap(), 2 * TIB);
+    assert_eq!(parse_byte_size("2TB").unwrap(), 2 * TIB);
+}
+
+#[test]
+fn parse_valid_fractional_sizes_with_exact_integral_bytes() {
+    // Exact decimal calculations
+    assert_eq!(parse_byte_size("1.5 GiB").unwrap(), 1_610_612_736);
+    assert_eq!(parse_byte_size("0.5 MiB").unwrap(), 524_288);
+    assert_eq!(parse_byte_size("2.25 KiB").unwrap(), 2_304);
+    assert_eq!(parse_byte_size("1.000 GiB").unwrap(), 1_073_741_824);
+}
+
+#[test]
+fn parse_failure_fractional_byte() {
+    // Non-integral byte amounts must be rejected with FractionalByte
+    assert!(matches!(
+        parse_byte_size("0.5 B"),
+        Err(ByteSizeError::FractionalByte { .. })
+    ));
+    assert!(matches!(
+        parse_byte_size("1.1 B"),
+        Err(ByteSizeError::FractionalByte { .. })
+    ));
+    assert!(matches!(
+        parse_byte_size("1.3 KiB"),
+        Err(ByteSizeError::FractionalByte { .. })
+    ));
+    assert!(matches!(
+        parse_byte_size("1.1 GiB"),
+        Err(ByteSizeError::FractionalByte { .. })
+    ));
+}
+
+#[test]
+fn parse_failure_empty_or_whitespace() {
+    assert_eq!(parse_byte_size(""), Err(ByteSizeError::Empty));
+    assert_eq!(parse_byte_size("   \t\n "), Err(ByteSizeError::Empty));
+}
+
+#[test]
+fn parse_failure_missing_number() {
+    assert!(matches!(
+        parse_byte_size("GB"),
+        Err(ByteSizeError::MissingNumber { .. })
+    ));
+    assert!(matches!(
+        parse_byte_size("bytes"),
+        Err(ByteSizeError::MissingNumber { .. })
+    ));
+}
+
+#[test]
+fn parse_failure_negative() {
+    assert!(matches!(
+        parse_byte_size("-1024"),
+        Err(ByteSizeError::Negative { .. })
+    ));
+    assert!(matches!(
+        parse_byte_size("-4GB"),
+        Err(ByteSizeError::Negative { .. })
+    ));
+}
+
+#[test]
+fn parse_failure_invalid_number() {
+    assert!(matches!(
+        parse_byte_size("1.2.3 GB"),
+        Err(ByteSizeError::InvalidNumber { .. })
+    ));
+}
+
+#[test]
+fn parse_failure_unknown_unit() {
+    assert!(matches!(
+        parse_byte_size("4 foo"),
+        Err(ByteSizeError::UnknownUnit { unit, .. }) if unit == "foo"
+    ));
+    assert!(matches!(
+        parse_byte_size("16 Q"),
+        Err(ByteSizeError::UnknownUnit { unit, .. }) if unit == "Q"
+    ));
+}
+
+#[test]
+fn parse_failure_trailing_characters() {
+    assert!(matches!(
+        parse_byte_size("4 GB extra"),
+        Err(ByteSizeError::TrailingCharacters { trailing, .. }) if trailing == "extra"
+    ));
+}
+
+#[test]
+fn parse_failure_overflow() {
+    let huge = format!("{} GiB", u64::MAX);
+    assert!(matches!(
+        parse_byte_size(&huge),
+        Err(ByteSizeError::Overflow { .. })
+    ));
+
+    // u64::MAX parses successfully
+    assert_eq!(parse_byte_size("18446744073709551615 B").unwrap(), u64::MAX);
+
+    // u64::MAX + 1 classified as Overflow
+    assert!(matches!(
+        parse_byte_size("18446744073709551616 B"),
+        Err(ByteSizeError::Overflow { .. })
+    ));
+
+    // u64::MAX + 1 without unit classified as Overflow
+    assert!(matches!(
+        parse_byte_size("18446744073709551616"),
+        Err(ByteSizeError::Overflow { .. })
+    ));
+
+    // Exceeding u128 magnitude classified as Overflow
+    assert!(matches!(
+        parse_byte_size("340282366920938463463374607431768211456 B"),
+        Err(ByteSizeError::Overflow { .. })
+    ));
+
+    // Decimal with integer part exceeding u64 classified as Overflow
+    assert!(matches!(
+        parse_byte_size("18446744073709551616.0 B"),
+        Err(ByteSizeError::Overflow { .. })
+    ));
+}
+
+#[test]
+fn format_byte_size_units() {
+    assert_eq!(format_byte_size(0), "0 B");
+    assert_eq!(format_byte_size(512), "512 B");
+    assert_eq!(format_byte_size(KIB), "1 KiB");
+    assert_eq!(format_byte_size(4 * KIB), "4 KiB");
+    assert_eq!(format_byte_size(512 * MIB), "512 MiB");
+    assert_eq!(format_byte_size(32 * GIB), "32 GiB");
+    assert_eq!(format_byte_size(2 * TIB), "2 TiB");
+    assert_eq!(format_byte_size(PIB), "1 PiB");
+
+    // Fractional format
+    assert_eq!(format_byte_size(1_610_612_736), "1.50 GiB");
+}
+
+#[test]
+fn byte_size_wrapper() {
+    let bs = ByteSize::from_str("32 GiB").unwrap();
+    assert_eq!(bs.as_u64(), 32 * GIB);
+    assert_eq!(format!("{bs}"), "32 GiB");
+
+    let bs2 = ByteSize::new(1024);
+    assert_eq!(bs2.as_u64(), 1024);
+}

--- a/crates/r9v-common/tests/test_error.rs
+++ b/crates/r9v-common/tests/test_error.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for top-level error conversions and formatting (Spec 14 §2, CONVENTIONS.md §1).
+
+use r9v_common::{parse_byte_size, ByteSizeError, R9vError};
+
+#[test]
+fn error_from_byte_size_error() {
+    let err = parse_byte_size("invalid").unwrap_err();
+    let r9v_err: R9vError = err.into();
+    assert!(matches!(
+        r9v_err,
+        R9vError::ByteSize(ByteSizeError::MissingNumber { .. })
+    ));
+    assert!(format!("{r9v_err}").contains("byte size parse error:"));
+}
+
+#[test]
+fn error_from_io_error() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+    let r9v_err: R9vError = io_err.into();
+    assert!(matches!(r9v_err, R9vError::Io(_)));
+    assert!(format!("{r9v_err}").contains("I/O error: file not found"));
+}

--- a/crates/r9v-common/tests/test_hash.rs
+++ b/crates/r9v-common/tests/test_hash.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for XXH3 helpers (Spec 2 §6, Spec 3 §2, Spec 4 §1.6, Spec 9 §1, Spec 14 §2).
+
+use std::hash::Hasher;
+
+use r9v_common::{
+    xxh3_128, xxh3_128_with_seed, xxh3_64, xxh3_64_with_seed, Xxh3Hasher, Xxh3Hasher128,
+};
+
+/// Test known-answer vectors published by the authoritative xxHash specification (Yann Collet).
+#[test]
+fn xxh3_64_authoritative_known_answer_vectors() {
+    // Empty input: official xxHash vector
+    assert_eq!(xxh3_64(b""), 0x2d06800538d394c2);
+
+    // Single byte input
+    assert_eq!(xxh3_64(b"a"), 0xe6c632b61e964e1f);
+
+    // Short string
+    assert_eq!(xxh3_64(b"abc"), 0x78af5f94892f3950);
+
+    // Number string
+    assert_eq!(xxh3_64(b"1234567890"), 0x80048550fad2b420);
+
+    // Standard pangram: official reference vector
+    assert_eq!(
+        xxh3_64(b"The quick brown fox jumps over the lazy dog"),
+        0xce7d19a5418fb365
+    );
+
+    // Seeded vector
+    assert_eq!(xxh3_64_with_seed(b"", 42), 0xb029411ff43d84d2);
+    assert_eq!(xxh3_64_with_seed(b"a", 42), 0x4c437dd47f0716f4);
+}
+
+/// Test known-answer vectors for 128-bit XXH3.
+#[test]
+fn xxh3_128_authoritative_known_answer_vectors() {
+    // Empty input
+    assert_eq!(xxh3_128(b""), 0x99aa06d3014798d86001c324468d497f);
+
+    // Single byte input
+    assert_eq!(xxh3_128(b"a"), 0xa96faf705af16834e6c632b61e964e1f);
+
+    // Standard pangram
+    assert_eq!(
+        xxh3_128(b"The quick brown fox jumps over the lazy dog"),
+        0xddd650205ca3e7fa24a1cc2e3a8a7651
+    );
+
+    // Seeded vector
+    assert_eq!(
+        xxh3_128_with_seed(b"", 42),
+        0x16c20acd33f7af2f3c1d09e9fe249164
+    );
+}
+
+#[test]
+fn streaming_hasher_matches_oneshot() {
+    let part1 = b"first chunk of tensor bytes ";
+    let part2 = b"second chunk of tensor bytes";
+    let mut combined = Vec::new();
+    combined.extend_from_slice(part1);
+    combined.extend_from_slice(part2);
+
+    let oneshot = xxh3_64(&combined);
+
+    let mut hasher = Xxh3Hasher::default();
+    hasher.write(part1);
+    hasher.write(part2);
+    let streamed = hasher.finish();
+
+    assert_eq!(streamed, oneshot);
+}
+
+#[test]
+fn streaming_hasher128_matches_oneshot() {
+    let part1 = b"fingerprint prefix ";
+    let part2 = b"fingerprint suffix";
+    let mut combined = Vec::new();
+    combined.extend_from_slice(part1);
+    combined.extend_from_slice(part2);
+
+    let oneshot = xxh3_128(&combined);
+
+    let mut hasher = Xxh3Hasher128::default();
+    hasher.write(part1);
+    hasher.write(part2);
+    let streamed = hasher.finish_128();
+
+    assert_eq!(streamed, oneshot);
+}

--- a/crates/r9v-common/tests/test_ids.rs
+++ b/crates/r9v-common/tests/test_ids.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for opaque identifier newtypes (Spec 3 §2, Spec 6 §9, Spec 10 §4, Spec 11 §11, Spec 14 §2).
+
+use std::collections::BTreeSet;
+
+use r9v_common::{ReqId, SeqId, StepId};
+
+#[test]
+fn seq_id_construction_and_accessors() {
+    let id = SeqId::new(42);
+    assert_eq!(id.as_u64(), 42);
+}
+
+#[test]
+fn req_id_construction_and_accessors() {
+    let id = ReqId::new(1001);
+    assert_eq!(id.as_u64(), 1001);
+}
+
+#[test]
+fn step_id_construction_and_accessors() {
+    let id = StepId::new(9999);
+    assert_eq!(id.as_u64(), 9999);
+}
+
+#[test]
+fn display_formatting() {
+    let seq = SeqId::new(12345);
+    assert_eq!(format!("{seq}"), "12345");
+
+    let req = ReqId::new(67890);
+    assert_eq!(format!("{req}"), "67890");
+
+    let step = StepId::new(54321);
+    assert_eq!(format!("{step}"), "54321");
+}
+
+#[test]
+fn ordering_and_containers() {
+    let mut set = BTreeSet::new();
+    set.insert(SeqId::new(3));
+    set.insert(SeqId::new(1));
+    set.insert(SeqId::new(2));
+
+    let ordered: Vec<u64> = set.iter().map(|id| id.as_u64()).collect();
+    assert_eq!(ordered, vec![1, 2, 3]);
+}

--- a/crates/r9v-common/tests/test_rng.rs
+++ b/crates/r9v-common/tests/test_rng.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for deterministic seeded RNG (Spec 1 §6.1, Spec 14 §2, CONVENTIONS.md §4.3).
+
+use r9v_common::SeededRng;
+
+/// Test vectors generated from the upstream reference implementation of Xoshiro256++
+/// (David Blackman & Sebastiano Vigna, 2019) initialized via SplitMix64.
+#[test]
+fn xoshiro256plusplus_seed_derived_vectors() {
+    // Seed = 1 sequence
+    let mut rng_seed1 = SeededRng::new(1);
+    assert_eq!(rng_seed1.next_u64(), 0xcfc5d07f6f03c29b);
+    assert_eq!(rng_seed1.next_u64(), 0xbf424132963fe08d);
+    assert_eq!(rng_seed1.next_u64(), 0x19a37d5757aaf520);
+    assert_eq!(rng_seed1.next_u64(), 0xbf08119f05cd56d6);
+    assert_eq!(rng_seed1.next_u64(), 0x2f47184b86186fa4);
+
+    // Seed = 42 sequence
+    let mut rng_seed42 = SeededRng::new(42);
+    assert_eq!(rng_seed42.next_u64(), 0xd0764d4f4476689f);
+    assert_eq!(rng_seed42.next_u64(), 0x519e4174576f3791);
+    assert_eq!(rng_seed42.next_u64(), 0xfbe07cfb0c24ed8c);
+    assert_eq!(rng_seed42.next_u64(), 0xb37d9f600cd835b8);
+    assert_eq!(rng_seed42.next_u64(), 0xcb231c3874846a73);
+}
+
+#[test]
+fn determinism_across_identical_seeds() {
+    let mut rng1 = SeededRng::new(12345);
+    let mut rng2 = SeededRng::new(12345);
+
+    for _ in 0..1000 {
+        assert_eq!(rng1.next_u64(), rng2.next_u64());
+    }
+}
+
+#[test]
+fn different_seeds_produce_different_sequences() {
+    let mut rng1 = SeededRng::new(42);
+    let mut rng2 = SeededRng::new(43);
+
+    let vals1: Vec<u64> = (0..100).map(|_| rng1.next_u64()).collect();
+    let vals2: Vec<u64> = (0..100).map(|_| rng2.next_u64()).collect();
+
+    assert_ne!(vals1, vals2);
+}
+
+#[test]
+fn fill_bytes_is_deterministic() {
+    let mut rng1 = SeededRng::new(777);
+    let mut rng2 = SeededRng::new(777);
+
+    let mut buf1 = [0u8; 127];
+    let mut buf2 = [0u8; 127];
+
+    rng1.fill_bytes(&mut buf1);
+    rng2.fill_bytes(&mut buf2);
+
+    assert_eq!(buf1, buf2);
+}

--- a/crates/r9v-config/Cargo.toml
+++ b/crates/r9v-config/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V configuration schema, settings generator, and validation (Spec 12, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-format/Cargo.toml
+++ b/crates/r9v-format/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V tensor layouts, quantization schemes, container format, and repack rules (Spec 2, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-helper/Cargo.toml
+++ b/crates/r9v-helper/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V local CPU assistant model and helper daemon (Spec 12 §7, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-hip/Cargo.toml
+++ b/crates/r9v-hip/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V thin HIP runtime binding via dlopen (Spec 14 §2, §3)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-ir/Cargo.toml
+++ b/crates/r9v-ir/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V Op IR, graph, types, and sharding tables (Spec 1, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-kgen/Cargo.toml
+++ b/crates/r9v-kgen/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V kernel generator, cost model, search space, and leaf wrappers (Spec 4, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-loader/Cargo.toml
+++ b/crates/r9v-loader/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V model loading pipeline, memory budgeting, and repack cache (Spec 9, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-models/Cargo.toml
+++ b/crates/r9v-models/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V model architecture builder and model families (Spec 8, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-obs/Cargo.toml
+++ b/crates/r9v-obs/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V observability, metrics, tracing, doctor, and benchmarking (Spec 11, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-part/Cargo.toml
+++ b/crates/r9v-part/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V model partitioner, topology planner, and communications (Spec 5, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-registry/Cargo.toml
+++ b/crates/r9v-registry/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V kernel registry, bundle loader, tune files, and resolution (Spec 4, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-sched/Cargo.toml
+++ b/crates/r9v-sched/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V sequence scheduler, step graph execution, and budgeting (Spec 6, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-serve/Cargo.toml
+++ b/crates/r9v-serve/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V HTTP serving API and OpenAI-compatible routes (Spec 10, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-spec/Cargo.toml
+++ b/crates/r9v-spec/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V speculative decoding proposers and verification (Spec 7, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-state/Cargo.toml
+++ b/crates/r9v-state/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V KV cache sequence state, memory arenas, and block allocation (Spec 3, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v-t0/Cargo.toml
+++ b/crates/r9v-t0/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V CPU reference scalar T0 and SIMD T0v implementations (Spec 4, Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/crates/r9v/Cargo.toml
+++ b/crates/r9v/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V main CLI binary connecting the engine crates (Spec 14 §2)"
 
 [dependencies]
+r9v-common = { path = "../r9v-common" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "R9V development and maintenance automation tasks (Spec 14 §2, §4)"
 
 [dependencies]
+r9v-common = { path = "../crates/r9v-common" }


### PR DESCRIPTION
## Card
A0.4 — conventions and common   (kind: API; GPU: no; size: S)

## Spec sections implemented
- spec 14 §2: establish the shared common crate surface and compile every workspace crate against it.
- spec 15 §3: add the repository pull-request template and engineering conventions.
- spec 11 §11: define the structured `req_id` and `step_id` logging conventions.
- spec 12 §3: provide strict byte-size parsing for configuration values.

## Deliverables
- [x] `CONVENTIONS.md` defines errors, tracing fields, naming, test layout, deterministic fixtures, decisions, and spec-issue handling.
- [x] `r9v-common` provides typed errors, opaque IDs, XXH3 helpers, exact byte-size parsing, and a seeded fixture RNG.
- [x] Every other workspace crate declares and compiles against `r9v-common`.
- [x] The README links `CONVENTIONS.md`.
- [x] The pull-request template asks which spec is implemented and enumerates decisions.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| common API shape and trait invariants | `crates/r9v-common/tests/api_shape.rs` | cpu-only | green |
| strict byte parser and formatter | `crates/r9v-common/tests/test_bytes.rs` | cpu-only | green |
| typed common error conversions | `crates/r9v-common/tests/test_error.rs` | cpu-only | green |
| authoritative XXH3 vectors and streaming parity | `crates/r9v-common/tests/test_hash.rs` | cpu-only | green |
| opaque ID construction, formatting, and ordering | `crates/r9v-common/tests/test_ids.rs` | cpu-only | green |
| seeded RNG reference vectors and determinism | `crates/r9v-common/src/rng.rs`, `crates/r9v-common/tests/test_rng.rs` | cpu-only | green |
| every workspace crate compiles against common | `cargo clippy --workspace --all-targets -- -D warnings` | cpu-only | green |
| README links conventions | `README.md` | cpu-only | green |

## Decisions
- `crates/r9v-common/src/bytes.rs:7` — unqualified memory units use binary powers because the owning specs use them for RAM and VRAM allocation budgets.
- `crates/r9v-common/src/ids.rs:6` — opaque IDs wrap `u64` to avoid practical rollover without lossy conversions.
- `crates/r9v-common/src/rng.rs:4` — deterministic fixtures use Xoshiro256++ seeded by SplitMix64 without another dependency.

## SPEC-ISSUES filed
- none

## New dependencies
- `thiserror` 2.0: derives the typed, owned error enums required by the card and repository conventions.
- `twox-hash` 2.1: supplies the XXH3-64 and XXH3-128 algorithms named by the specs.

## Hardware
Tests run here: hosted cpu-only
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command none, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- none

## Size check
Diff size vs card size class: 1,467 insertions across 35 files vs S — acceptable because the named conventions document, strict primitive implementations, 31 behavioral/API tests, dependency lock data, and one-line linkage in every workspace crate comprise the complete card; no downstream functionality is included.
