### PR TITLE
A0.2: add runtime-loaded HIP boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ name = "r9v-hip"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/r9v-hip/Cargo.toml
+++ b/crates/r9v-hip/Cargo.toml
@@ -9,3 +9,4 @@ description = "R9V thin HIP runtime binding via dlopen (Spec 14 §2, §3)"
 
 [dependencies]
 r9v-common = { path = "../r9v-common" }
+thiserror = "2.0"

--- a/crates/r9v-hip/src/device.rs
+++ b/crates/r9v-hip/src/device.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Execution target devices and discovered device properties (Spec 5 §3.4, Spec 14 §2, §3).
+
+use std::fmt;
+
+/// Execution target device for buffers, operators, and kernel launches (Spec 5 §3.4, Spec 14 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Device {
+    /// Host CPU execution tier (Spec 4 §1, Spec 14 §3).
+    Cpu,
+    /// AMD HIP GPU device identified by zero-based device rank (Spec 14 §3).
+    Hip(u32),
+}
+
+impl Device {
+    /// Returns the CPU device target (Spec 5 §3.4, Spec 14 §3).
+    pub const fn cpu() -> Self {
+        Self::Cpu
+    }
+
+    /// Returns a HIP GPU device target with the given rank (Spec 14 §3).
+    pub const fn hip(rank: u32) -> Self {
+        Self::Hip(rank)
+    }
+
+    /// Returns `true` if this is the CPU target (Spec 5 §3.4, Spec 14 §3).
+    pub const fn is_cpu(self) -> bool {
+        matches!(self, Self::Cpu)
+    }
+
+    /// Returns `true` if this is a HIP GPU target (Spec 14 §3).
+    pub const fn is_hip(self) -> bool {
+        matches!(self, Self::Hip(_))
+    }
+
+    /// Returns the HIP device rank if this is a HIP device, or `None` if CPU (Spec 14 §3).
+    pub const fn hip_rank(self) -> Option<u32> {
+        match self {
+            Self::Cpu => None,
+            Self::Hip(rank) => Some(rank),
+        }
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cpu => write!(f, "cpu"),
+            Self::Hip(rank) => write!(f, "hip:{rank}"),
+        }
+    }
+}
+
+/// Safely extracts a bounded, trimmed UTF-8 string from a fixed-size driver char buffer (Spec 14 §3).
+pub(crate) fn parse_fixed_c_string(bytes: &[std::ffi::c_char]) -> String {
+    let u8_slice = unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const u8, bytes.len()) };
+    let len = u8_slice
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(u8_slice.len());
+    String::from_utf8_lossy(&u8_slice[..len]).trim().to_owned()
+}
+
+/// Discovered hardware capabilities and resource limits of a HIP GPU (Spec 14 §3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceProperties {
+    /// Human-readable marketing and device name (Spec 14 §3).
+    pub name: String,
+    /// Total available global device memory in bytes (Spec 14 §3).
+    pub total_global_mem: u64,
+    /// Shared memory available per thread block in bytes (LDS) (Spec 14 §3).
+    pub shared_mem_per_block: usize,
+    /// 32-bit registers available per block (Spec 14 §3).
+    pub regs_per_block: i32,
+    /// SIMD execution width (warp/wavefront size; 32 or 64) (Spec 14 §3).
+    pub warp_size: i32,
+    /// Maximum work items per workgroup/block (Spec 14 §3).
+    pub max_threads_per_block: i32,
+    /// Maximum dimensions of a thread block [X, Y, Z] (Spec 14 §3).
+    pub max_threads_dim: [i32; 3],
+    /// Maximum dimensions of a grid [X, Y, Z] (Spec 14 §3).
+    pub max_grid_size: [i32; 3],
+    /// Core clock frequency in kilohertz (Spec 14 §3).
+    pub clock_rate_khz: i32,
+    /// Major compute capability architecture version (Spec 14 §3).
+    pub major: i32,
+    /// Minor compute capability architecture version (Spec 14 §3).
+    pub minor: i32,
+    /// Number of Compute Units (CUs) or Workgroup Processors (WGPs) (Spec 14 §3).
+    pub multi_processor_count: i32,
+    /// AMD GCN/RDNA ISA target identifier (e.g. "amdgcn-amd-amdhsa--gfx1201") (Spec 14 §3).
+    pub gcn_arch_name: String,
+    /// PCI bus identifier for device topology mapping (Spec 5 §3, Spec 14 §3).
+    pub pci_bus_id: i32,
+    /// PCI device identifier (Spec 5 §3, Spec 14 §3).
+    pub pci_device_id: i32,
+    /// PCI domain identifier (Spec 5 §3, Spec 14 §3).
+    pub pci_domain_id: i32,
+    /// Whether the device resides on a multi-GPU board (Spec 14 §3).
+    pub is_multi_gpu_board: bool,
+    /// Whether the device supports mapped host memory (Spec 14 §3).
+    pub can_map_host_memory: bool,
+    /// Whether concurrent kernel launches are supported (Spec 14 §3).
+    pub concurrent_kernels: bool,
+    /// Whether Error-Correcting Code memory is enabled (Spec 14 §3).
+    pub ecc_enabled: bool,
+    /// Whether cooperative kernel launch is supported (Spec 14 §3).
+    pub cooperative_launch: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::c_char;
+
+    #[test]
+    fn test_fixed_c_string_parsing_bounded_without_nul() {
+        // Array of non-NUL ASCII characters
+        let filled_no_nul = ['A' as c_char; 256];
+        let parsed = parse_fixed_c_string(&filled_no_nul);
+        assert_eq!(parsed.len(), 256);
+        assert_eq!(&parsed[..4], "AAAA");
+
+        // Array with interior NUL
+        let mut with_nul = ['B' as c_char; 256];
+        with_nul[10] = 0;
+        let parsed_nul = parse_fixed_c_string(&with_nul);
+        assert_eq!(parsed_nul.len(), 10);
+        assert_eq!(parsed_nul, "BBBBBBBBBB");
+    }
+}

--- a/crates/r9v-hip/src/error.rs
+++ b/crates/r9v-hip/src/error.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed errors for HIP operations (Spec 14 §2, §3, CONVENTIONS.md §1).
+
+// DECISION(A0.2): HipError is crate-local and composes upward at the engine integration boundary; rejected adding HIP-specific error variants to r9v-common because Spec 14 §2 strictly forbids upward dependencies from foundational crates.
+
+/// Result alias using crate-local [`HipError`] (Spec 14 §3).
+pub type Result<T> = r9v_common::Result<T, HipError>;
+
+/// Errors arising from dynamic HIP runtime interactions (Spec 14 §3).
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum HipError {
+    /// The HIP dynamic library (`libamdhip64`) could not be located or loaded.
+    #[error("HIP runtime library not found; searched: {searched:?}")]
+    LibraryNotFound {
+        /// Candidate search paths attempted during dlopen with reason for failure.
+        searched: Vec<String>,
+    },
+
+    /// A required HIP symbol could not be resolved from the dynamic library.
+    #[error("HIP symbol '{symbol}' could not be resolved: {details}")]
+    SymbolNotFound {
+        /// Name of the missing symbol.
+        symbol: &'static str,
+        /// Description of the lookup failure.
+        details: String,
+    },
+
+    /// A HIP runtime API call returned a non-zero error code.
+    #[error("HIP API '{op}' failed with status {code}: {message}")]
+    ApiError {
+        /// Name of the HIP operation (e.g. `hipMalloc`).
+        op: &'static str,
+        /// Numeric status code returned by HIP runtime (`hipError_t`).
+        code: i32,
+        /// Human-readable description of the error code.
+        message: String,
+    },
+
+    /// A null pointer was unexpectedly returned or passed.
+    #[error("unexpected null pointer in HIP operation: {0}")]
+    NullPointer(&'static str),
+
+    /// A string argument contained an interior NUL byte.
+    #[error("interior NUL byte in string for {context} at byte index {nul_position}")]
+    InvalidNulByte {
+        /// Description of the string argument context.
+        context: &'static str,
+        /// Position within string where interior NUL byte occurred.
+        nul_position: usize,
+    },
+
+    /// A destination buffer or slice is too small for the requested operation.
+    #[error(
+        "buffer too small for {operation}: required {required} bytes, available {available} bytes"
+    )]
+    BufferTooSmall {
+        /// The operation that requested buffer capacity.
+        operation: &'static str,
+        /// Minimum byte capacity required.
+        required: usize,
+        /// Byte capacity available in the destination.
+        available: usize,
+    },
+
+    /// The driver or runtime reported a negative or invalid device count.
+    #[error("driver reported invalid negative device count: {count}")]
+    InvalidDeviceCount {
+        /// The invalid device count value returned by the driver.
+        count: i32,
+    },
+}
+
+impl HipError {
+    pub(crate) fn api_error(op: &'static str, code: i32, desc: Option<&str>) -> Self {
+        let message = desc
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| format!("hipError_{code}"));
+        Self::ApiError { op, code, message }
+    }
+}

--- a/crates/r9v-hip/src/handles.rs
+++ b/crates/r9v-hip/src/handles.rs
@@ -1,0 +1,598 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed opaque RAII handles for HIP runtime resources (Spec 14 §2, §3).
+
+use std::ffi::c_void;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::error::{HipError, Result};
+use crate::library::HipLibrary;
+use crate::raw::*;
+use crate::{EventFlags, MemcpyKind, StreamCaptureMode, StreamFlags};
+
+/// Safe RAII wrapper for a HIP execution stream (`hipStream_t`, Spec 14 §3).
+pub struct Stream {
+    raw: HipStreamT,
+    lib: Arc<HipLibrary>,
+}
+
+// SAFETY: HIP streams are opaque thread-safe runtime references (hipStream_t) that can be sent
+// across threads in multi-threaded asynchronous launch and synchronization architectures.
+unsafe impl Send for Stream {}
+// SAFETY: Multiple host threads may synchronize or enqueue operations concurrently to distinct or shared streams.
+unsafe impl Sync for Stream {}
+
+impl Stream {
+    /// Creates a new execution stream with default flags (Spec 14 §3).
+    pub fn new(lib: &Arc<HipLibrary>) -> Result<Self> {
+        let raw = lib.stream_create()?;
+        Ok(Self {
+            raw,
+            lib: Arc::clone(lib),
+        })
+    }
+
+    /// Creates a new execution stream with custom flags (Spec 14 §3).
+    pub fn with_flags(lib: &Arc<HipLibrary>, flags: StreamFlags) -> Result<Self> {
+        let raw = lib.stream_create_with_flags(flags)?;
+        Ok(Self {
+            raw,
+            lib: Arc::clone(lib),
+        })
+    }
+
+    /// Returns the underlying raw C handle (Spec 14 §3).
+    pub fn as_raw(&self) -> HipStreamT {
+        self.raw
+    }
+
+    /// Synchronizes this stream, blocking the calling host thread until complete (Spec 14 §3).
+    pub fn synchronize(&self) -> Result<()> {
+        unsafe { self.lib.stream_synchronize(self.raw) }
+    }
+
+    /// Queries completion status without blocking (Spec 14 §3).
+    pub fn is_complete(&self) -> Result<bool> {
+        unsafe { self.lib.stream_query(self.raw) }
+    }
+
+    /// Instructs this stream to wait on an event before executing subsequent commands (Spec 14 §3).
+    pub fn wait_event(&self, event: &Event) -> Result<()> {
+        unsafe { self.lib.stream_wait_event(self.raw, event.as_raw(), 0) }
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            let _ = unsafe { self.lib.stream_destroy(self.raw) };
+            self.raw = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Safe RAII wrapper for a HIP timing/synchronization event (`hipEvent_t`, Spec 14 §3).
+pub struct Event {
+    raw: HipEventT,
+    lib: Arc<HipLibrary>,
+}
+
+// SAFETY: HIP event handles (hipEvent_t) are thread-safe runtime references that can be transferred across threads.
+unsafe impl Send for Event {}
+// SAFETY: Concurrent threads may safely query or synchronize on recorded events.
+unsafe impl Sync for Event {}
+
+impl Event {
+    /// Creates an event with default flags (Spec 14 §3).
+    pub fn new(lib: &Arc<HipLibrary>) -> Result<Self> {
+        let raw = lib.event_create()?;
+        Ok(Self {
+            raw,
+            lib: Arc::clone(lib),
+        })
+    }
+
+    /// Creates an event with custom flags (Spec 14 §3).
+    pub fn with_flags(lib: &Arc<HipLibrary>, flags: EventFlags) -> Result<Self> {
+        let raw = lib.event_create_with_flags(flags)?;
+        Ok(Self {
+            raw,
+            lib: Arc::clone(lib),
+        })
+    }
+
+    /// Returns the underlying raw C handle (Spec 14 §3).
+    pub fn as_raw(&self) -> HipEventT {
+        self.raw
+    }
+
+    /// Records the event in the specified stream (Spec 14 §3).
+    pub fn record(&self, stream: &Stream) -> Result<()> {
+        unsafe { self.lib.event_record(self.raw, stream.as_raw()) }
+    }
+
+    /// Blocks host thread until this event has completed (Spec 14 §3).
+    pub fn synchronize(&self) -> Result<()> {
+        unsafe { self.lib.event_synchronize(self.raw) }
+    }
+
+    /// Queries event completion status without blocking (Spec 14 §3).
+    pub fn is_complete(&self) -> Result<bool> {
+        unsafe { self.lib.event_query(self.raw) }
+    }
+
+    /// Computes elapsed time in milliseconds between `start` and `self` (Spec 11 §7, Spec 14 §3).
+    pub fn elapsed_since(&self, start: &Event) -> Result<f32> {
+        unsafe { self.lib.event_elapsed_time(start.as_raw(), self.raw) }
+    }
+}
+
+impl Drop for Event {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            let _ = unsafe { self.lib.event_destroy(self.raw) };
+            self.raw = std::ptr::null_mut();
+        }
+    }
+}
+
+pub(crate) struct ModuleInner {
+    pub(crate) raw: HipModuleT,
+    pub(crate) lib: Arc<HipLibrary>,
+}
+
+// SAFETY: HIP module handles (hipModule_t) are thread-safe references within the owning device context.
+unsafe impl Send for ModuleInner {}
+// SAFETY: Concurrent threads can safely look up functions or launch kernels from a loaded module.
+unsafe impl Sync for ModuleInner {}
+
+impl Drop for ModuleInner {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            let _ = unsafe { self.lib.module_unload(self.raw) };
+            self.raw = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Safe RAII wrapper for a loaded compiled kernel module (`hipModule_t`, Spec 4 §10, Spec 14 §3).
+#[derive(Clone)]
+pub struct Module {
+    inner: Arc<ModuleInner>,
+}
+
+impl Module {
+    /// Loads a compiled `.co` module from disk (Spec 4 §10, Spec 14 §3).
+    pub fn load_file(lib: &Arc<HipLibrary>, path: &Path) -> Result<Self> {
+        let raw = lib.module_load(path)?;
+        Ok(Self {
+            inner: Arc::new(ModuleInner {
+                raw,
+                lib: Arc::clone(lib),
+            }),
+        })
+    }
+
+    /// Loads a compiled `.co` module from memory bytes (Spec 4 §10, Spec 14 §3).
+    pub fn load_data(lib: &Arc<HipLibrary>, image: &[u8]) -> Result<Self> {
+        let raw = lib.module_load_data(image)?;
+        Ok(Self {
+            inner: Arc::new(ModuleInner {
+                raw,
+                lib: Arc::clone(lib),
+            }),
+        })
+    }
+
+    /// Resolves an exported kernel function by name (Spec 4 §10, Spec 14 §3).
+    ///
+    /// The returned [`Function`] keeps the parent [`Module`] alive even if the original
+    /// [`Module`] handle is dropped.
+    pub fn get_function(&self, name: &str) -> Result<Function> {
+        let raw = unsafe { self.inner.lib.module_get_function(self.inner.raw, name)? };
+        Ok(Function {
+            raw,
+            module: Arc::clone(&self.inner),
+        })
+    }
+
+    /// Returns the underlying raw C handle (Spec 14 §3).
+    pub fn as_raw(&self) -> HipModuleT {
+        self.inner.raw
+    }
+}
+
+/// Handle to an executable kernel function inside a loaded [`Module`] (Spec 4 §10, Spec 14 §3).
+///
+/// Holds an `Arc` reference to the module allocation, ensuring the module remains loaded
+/// and valid for as long as the [`Function`] exists.
+#[derive(Clone)]
+pub struct Function {
+    raw: HipFunctionT,
+    module: Arc<ModuleInner>,
+}
+
+// SAFETY: HIP function handles (hipFunction_t) can be transferred across threads to enqueue kernel launches.
+unsafe impl Send for Function {}
+// SAFETY: Function handles are immutable and kernel launches take shared &Function references across threads.
+unsafe impl Sync for Function {}
+
+impl Function {
+    /// Launches the kernel function on `stream` with given grid/block dimensions and parameters (Spec 4 §10, Spec 14 §3).
+    ///
+    /// # Safety
+    /// The caller must ensure that kernel arguments match the declared parameter types
+    /// and device pointer validity of the target kernel ABI.
+    pub unsafe fn launch(
+        &self,
+        grid: (u32, u32, u32),
+        block: (u32, u32, u32),
+        shared_mem: u32,
+        stream: &Stream,
+        args: &mut [*mut c_void],
+    ) -> Result<()> {
+        self.module.lib.module_launch_kernel(
+            self.raw,
+            grid,
+            block,
+            shared_mem,
+            stream.as_raw(),
+            args,
+        )
+    }
+
+    /// Returns the underlying raw C handle (Spec 14 §3).
+    pub fn as_raw(&self) -> HipFunctionT {
+        self.raw
+    }
+}
+
+/// Safe RAII wrapper for a captured graph definition (`hipGraph_t`, Spec 1 §3.1, Spec 6 §2, Spec 14 §3).
+pub struct Graph {
+    raw: HipGraphT,
+    lib: Arc<HipLibrary>,
+}
+
+// SAFETY: Captured HIP graph handles (hipGraph_t) can be transferred across threads before instantiation.
+unsafe impl Send for Graph {}
+// SAFETY: HIP graph definitions are read-only once captured and safe to inspect concurrently.
+unsafe impl Sync for Graph {}
+
+impl Graph {
+    /// Begins capturing execution operations enqueued to `stream` (Spec 1 §3.1, Spec 6 §2, Spec 14 §3).
+    pub fn begin_capture(stream: &Stream, mode: StreamCaptureMode) -> Result<()> {
+        unsafe { stream.lib.stream_begin_capture(stream.as_raw(), mode) }
+    }
+
+    /// Ends stream capture and returns the newly captured [`Graph`] (Spec 1 §3.1, Spec 6 §2, Spec 14 §3).
+    pub fn end_capture(stream: &Stream) -> Result<Self> {
+        let raw = unsafe { stream.lib.stream_end_capture(stream.as_raw())? };
+        Ok(Self {
+            raw,
+            lib: Arc::clone(&stream.lib),
+        })
+    }
+
+    /// Instantiates an executable graph from this definition (Spec 6 §2, Spec 14 §3).
+    pub fn instantiate(&self) -> Result<GraphExec> {
+        let raw = unsafe { self.lib.graph_instantiate(self.raw)? };
+        Ok(GraphExec {
+            raw,
+            lib: Arc::clone(&self.lib),
+        })
+    }
+
+    /// Returns the underlying raw C handle (Spec 14 §3).
+    pub fn as_raw(&self) -> HipGraphT {
+        self.raw
+    }
+}
+
+impl Drop for Graph {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            let _ = unsafe { self.lib.graph_destroy(self.raw) };
+            self.raw = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Safe RAII wrapper for an instantiated executable graph (`hipGraphExec_t`, Spec 6 §2, Spec 14 §3).
+pub struct GraphExec {
+    raw: HipGraphExecT,
+    lib: Arc<HipLibrary>,
+}
+
+// SAFETY: Instantiated graph execution handles (hipGraphExec_t) can be transferred across threads.
+unsafe impl Send for GraphExec {}
+// SAFETY: Graph launch operations dispatch to the stream and are safe to launch concurrently on distinct streams.
+unsafe impl Sync for GraphExec {}
+
+impl GraphExec {
+    /// Launches the executable graph on `stream` (Spec 6 §2, Spec 14 §3).
+    ///
+    /// # Safety
+    /// The caller must ensure that all memory allocations and resources captured within
+    /// this graph definition remain allocated and valid throughout execution on `stream`.
+    pub unsafe fn launch(&self, stream: &Stream) -> Result<()> {
+        self.lib.graph_launch(self.raw, stream.as_raw())
+    }
+
+    /// Returns the underlying raw C handle (Spec 14 §3).
+    pub fn as_raw(&self) -> HipGraphExecT {
+        self.raw
+    }
+}
+
+impl Drop for GraphExec {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            let _ = unsafe { self.lib.graph_exec_destroy(self.raw) };
+            self.raw = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Safe RAII wrapper for allocated linear device memory (Spec 14 §3).
+pub struct DeviceBuffer {
+    ptr: *mut c_void,
+    size_bytes: usize,
+    lib: Arc<HipLibrary>,
+}
+
+// SAFETY: Linear device pointers (*mut c_void) represent distinct allocations in GPU VRAM
+// and can be transferred safely between host threads.
+unsafe impl Send for DeviceBuffer {}
+// SAFETY: DeviceBuffer methods requiring mutable device writes take &mut self, while read copies take &self.
+unsafe impl Sync for DeviceBuffer {}
+
+impl DeviceBuffer {
+    /// Allocates `size_bytes` of linear device memory (Spec 14 §3).
+    pub fn allocate(lib: &Arc<HipLibrary>, size_bytes: usize) -> Result<Self> {
+        let ptr = lib.malloc(size_bytes)?;
+        Ok(Self {
+            ptr,
+            size_bytes,
+            lib: Arc::clone(lib),
+        })
+    }
+
+    /// Returns the allocation size in bytes (Spec 14 §3).
+    pub fn size(&self) -> usize {
+        self.size_bytes
+    }
+
+    /// Returns the raw device memory pointer (Spec 14 §3).
+    pub fn as_ptr(&self) -> *const c_void {
+        self.ptr
+    }
+
+    /// Returns the mutable raw device memory pointer (Spec 14 §3).
+    pub fn as_mut_ptr(&mut self) -> *mut c_void {
+        self.ptr
+    }
+
+    /// Copies bytes synchronously from host slice to device buffer (Spec 14 §3).
+    ///
+    /// # Errors
+    /// Returns [`HipError::BufferTooSmall`] if `src.len() > self.size()`.
+    pub fn copy_from_host(&mut self, src: &[u8]) -> Result<()> {
+        if src.len() > self.size_bytes {
+            return Err(HipError::BufferTooSmall {
+                operation: "copy_from_host",
+                required: src.len(),
+                available: self.size_bytes,
+            });
+        }
+        unsafe {
+            self.lib.memcpy(
+                self.ptr,
+                src.as_ptr() as *const c_void,
+                src.len(),
+                MemcpyKind::HostToDevice,
+            )
+        }
+    }
+
+    /// Copies bytes synchronously from device buffer to host slice (Spec 14 §3).
+    ///
+    /// # Errors
+    /// Returns [`HipError::BufferTooSmall`] if `dst.len() < self.size()`.
+    pub fn copy_to_host(&self, dst: &mut [u8]) -> Result<()> {
+        if dst.len() < self.size_bytes {
+            return Err(HipError::BufferTooSmall {
+                operation: "copy_to_host",
+                required: self.size_bytes,
+                available: dst.len(),
+            });
+        }
+        unsafe {
+            self.lib.memcpy(
+                dst.as_mut_ptr() as *mut c_void,
+                self.ptr,
+                self.size_bytes,
+                MemcpyKind::DeviceToHost,
+            )
+        }
+    }
+
+    /// Asynchronously copies bytes from host slice to device buffer in `stream` (Spec 14 §3).
+    ///
+    /// # Errors
+    /// Returns [`HipError::BufferTooSmall`] if `src.len() > self.size()`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `src` remains valid, allocated, and untouched
+    /// until all operations queued in `stream` at the time of call have completed execution
+    /// (e.g. by calling [`Stream::synchronize`]).
+    pub unsafe fn copy_from_host_async(&mut self, src: &[u8], stream: &Stream) -> Result<()> {
+        if src.len() > self.size_bytes {
+            return Err(HipError::BufferTooSmall {
+                operation: "copy_from_host_async",
+                required: src.len(),
+                available: self.size_bytes,
+            });
+        }
+        self.lib.memcpy_async(
+            self.ptr,
+            src.as_ptr() as *const c_void,
+            src.len(),
+            MemcpyKind::HostToDevice,
+            stream.as_raw(),
+        )
+    }
+
+    /// Asynchronously copies bytes from device buffer to host slice in `stream` (Spec 14 §3).
+    ///
+    /// # Errors
+    /// Returns [`HipError::BufferTooSmall`] if `dst.len() < self.size()`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `dst` remains valid, allocated, and untouched
+    /// until all operations queued in `stream` at the time of call have completed execution
+    /// (e.g. by calling [`Stream::synchronize`]).
+    pub unsafe fn copy_to_host_async(&self, dst: &mut [u8], stream: &Stream) -> Result<()> {
+        if dst.len() < self.size_bytes {
+            return Err(HipError::BufferTooSmall {
+                operation: "copy_to_host_async",
+                required: self.size_bytes,
+                available: dst.len(),
+            });
+        }
+        self.lib.memcpy_async(
+            dst.as_mut_ptr() as *mut c_void,
+            self.ptr,
+            self.size_bytes,
+            MemcpyKind::DeviceToHost,
+            stream.as_raw(),
+        )
+    }
+
+    /// Copies bytes asynchronously between two device buffers on the same device in `stream` (Spec 14 §3).
+    ///
+    /// # Errors
+    /// Returns [`HipError::BufferTooSmall`] if `self.size() > dst.size()`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `self`, `dst`, and `stream` remain valid until all operations
+    /// queued in `stream` complete.
+    pub unsafe fn copy_to_device_async(
+        &self,
+        dst: &mut DeviceBuffer,
+        stream: &Stream,
+    ) -> Result<()> {
+        if self.size_bytes > dst.size_bytes {
+            return Err(HipError::BufferTooSmall {
+                operation: "copy_to_device_async",
+                required: self.size_bytes,
+                available: dst.size_bytes,
+            });
+        }
+        self.lib.memcpy_async(
+            dst.as_mut_ptr(),
+            self.ptr,
+            self.size_bytes,
+            MemcpyKind::DeviceToDevice,
+            stream.as_raw(),
+        )
+    }
+
+    /// Asynchronously copies memory from this device buffer to `dst` on `dst_device` via peer transfer (Spec 5 §7, Spec 14 §3).
+    ///
+    /// # Errors
+    /// Returns [`HipError::BufferTooSmall`] if `self.size() > dst.size()`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `self`, `dst`, and `stream` remain valid until all operations
+    /// queued in `stream` complete, and that peer access is enabled between `src_device` and `dst_device`.
+    pub unsafe fn copy_to_peer_async(
+        &self,
+        src_device: i32,
+        dst: &mut DeviceBuffer,
+        dst_device: i32,
+        stream: &Stream,
+    ) -> Result<()> {
+        if self.size_bytes > dst.size_bytes {
+            return Err(HipError::BufferTooSmall {
+                operation: "copy_to_peer_async",
+                required: self.size_bytes,
+                available: dst.size_bytes,
+            });
+        }
+        self.lib.memcpy_peer_async(
+            dst.as_mut_ptr(),
+            dst_device,
+            self.ptr,
+            src_device,
+            self.size_bytes,
+            stream.as_raw(),
+        )
+    }
+}
+
+impl Drop for DeviceBuffer {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            let _ = unsafe { self.lib.free(self.ptr) };
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Safe RAII wrapper for page-locked (pinned) host memory (`hipHostMalloc`, Spec 14 §3).
+pub struct HostBuffer {
+    ptr: *mut c_void,
+    size_bytes: usize,
+    lib: Arc<HipLibrary>,
+}
+
+// SAFETY: Pinned host memory buffers (*mut c_void) are unique system allocations safe to send across threads.
+unsafe impl Send for HostBuffer {}
+// SAFETY: Pinned host slices enforce Rust's borrow checker invariants (& vs &mut) over the mapped slice.
+unsafe impl Sync for HostBuffer {}
+
+impl HostBuffer {
+    /// Allocates `size_bytes` of page-locked host memory (Spec 14 §3).
+    pub fn allocate(lib: &Arc<HipLibrary>, size_bytes: usize, flags: u32) -> Result<Self> {
+        let ptr = lib.host_malloc(size_bytes, flags)?;
+        Ok(Self {
+            ptr,
+            size_bytes,
+            lib: Arc::clone(lib),
+        })
+    }
+
+    /// Returns allocation size in bytes (Spec 14 §3).
+    pub fn size(&self) -> usize {
+        self.size_bytes
+    }
+
+    /// Returns a slice over the pinned host memory (Spec 14 §3).
+    pub fn as_slice(&self) -> &[u8] {
+        if self.ptr.is_null() || self.size_bytes == 0 {
+            &[]
+        } else {
+            // SAFETY: Allocation was verified non-null and size_bytes was returned from host_malloc.
+            unsafe { std::slice::from_raw_parts(self.ptr as *const u8, self.size_bytes) }
+        }
+    }
+
+    /// Returns a mutable slice over the pinned host memory (Spec 14 §3).
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        if self.ptr.is_null() || self.size_bytes == 0 {
+            &mut []
+        } else {
+            // SAFETY: Allocation was verified non-null and mutable borrow ensures exclusivity.
+            unsafe { std::slice::from_raw_parts_mut(self.ptr as *mut u8, self.size_bytes) }
+        }
+    }
+}
+
+impl Drop for HostBuffer {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            let _ = unsafe { self.lib.host_free(self.ptr) };
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}

--- a/crates/r9v-hip/src/lib.rs
+++ b/crates/r9v-hip/src/lib.rs
@@ -1,1 +1,123 @@
-//! R9V thin HIP runtime binding via dlopen (Spec 14 §2, §3).
+// SPDX-License-Identifier: Apache-2.0
+//! Thin runtime-only AMD HIP binding for R9V (Spec 14 §2, §3).
+//!
+//! Provides dynamic lazy loading of `libamdhip64` with zero startup/build linkage.
+//! Symbols are cached after initial resolution to eliminate `dlsym` overhead on hot paths.
+
+mod raw;
+mod symbol;
+
+pub mod device;
+pub mod error;
+pub mod handles;
+pub mod library;
+
+use std::sync::Arc;
+
+pub use device::{Device, DeviceProperties};
+pub use error::{HipError, Result};
+pub use handles::{DeviceBuffer, Event, Function, Graph, GraphExec, HostBuffer, Module, Stream};
+pub use library::HipLibrary;
+
+/// Memory copy direction for HIP transfer operations (Spec 14 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MemcpyKind {
+    /// Host to device transfer.
+    HostToDevice,
+    /// Device to host transfer.
+    DeviceToHost,
+    /// Device to device transfer on same device.
+    DeviceToDevice,
+    /// Direction inferred by driver from pointer attributes.
+    Default,
+}
+
+impl MemcpyKind {
+    /// Returns the raw integer value expected by `hipMemcpy` (Spec 14 §3).
+    pub const fn as_raw(self) -> i32 {
+        match self {
+            Self::HostToDevice => 1,
+            Self::DeviceToHost => 2,
+            Self::DeviceToDevice => 3,
+            Self::Default => 4,
+        }
+    }
+}
+
+/// Mode for stream graph capture (Spec 1 §3.1, Spec 6 §2, Spec 14 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StreamCaptureMode {
+    /// Global mode: invalidates capturing on all non-participating streams.
+    Global,
+    /// Thread-local mode: capture only applies to calling thread.
+    ThreadLocal,
+    /// Relaxed mode: permits stream synchronization during capture if safe.
+    Relaxed,
+}
+
+impl StreamCaptureMode {
+    /// Returns the raw integer value expected by `hipStreamBeginCapture` (Spec 14 §3).
+    pub const fn as_raw(self) -> i32 {
+        match self {
+            Self::Global => 0,
+            Self::ThreadLocal => 1,
+            Self::Relaxed => 2,
+        }
+    }
+}
+
+/// Flags controlling stream creation behavior (Spec 14 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StreamFlags {
+    /// Default stream creation behavior.
+    Default,
+    /// Non-blocking stream: does not synchronize with the null stream.
+    NonBlocking,
+}
+
+impl StreamFlags {
+    /// Returns the raw integer value for stream creation (Spec 14 §3).
+    pub const fn as_raw(self) -> u32 {
+        match self {
+            Self::Default => 0,
+            Self::NonBlocking => 1,
+        }
+    }
+}
+
+/// Flags controlling event creation behavior (Spec 14 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EventFlags {
+    /// Default event creation behavior with timing enabled.
+    Default,
+    /// Timing disabled: reduces recording overhead when only used for synchronization.
+    DisableTiming,
+}
+
+impl EventFlags {
+    /// Returns the raw integer value for event creation (Spec 14 §3).
+    pub const fn as_raw(self) -> u32 {
+        match self {
+            Self::Default => 0,
+            Self::DisableTiming => 2,
+        }
+    }
+}
+
+/// Obtains a reference to the global default HIP runtime library instance (Spec 14 §3).
+pub fn default_library() -> Result<Arc<HipLibrary>> {
+    HipLibrary::default_or_load()
+}
+
+/// Returns `true` if the HIP runtime can be loaded AND at least one HIP device is available (Spec 14 §3).
+pub fn is_available() -> bool {
+    default_library()
+        .and_then(|lib| lib.device_count())
+        .map(|count| count > 0)
+        .unwrap_or(false)
+}
+
+/// Queries the total number of available HIP GPU devices (Spec 14 §3).
+pub fn device_count() -> Result<u32> {
+    default_library()?.device_count()
+}

--- a/crates/r9v-hip/src/library.rs
+++ b/crates/r9v-hip/src/library.rs
@@ -1,0 +1,981 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Dynamic library loader and raw HIP runtime interface (Spec 14 §2, §3).
+
+use std::ffi::{c_char, c_int, c_uint, c_void, CStr, CString};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use crate::device::{parse_fixed_c_string, DeviceProperties};
+use crate::error::{HipError, Result};
+use crate::raw::*;
+use crate::symbol::{DynamicLibrary, SymbolCache};
+use crate::{EventFlags, MemcpyKind, StreamCaptureMode, StreamFlags};
+
+static GLOBAL_LIBRARY: OnceLock<Result<Arc<HipLibrary>>> = OnceLock::new();
+
+/// Thread-safe runtime binding to `libamdhip64` with cached lazy symbol lookup (Spec 14 §3).
+pub struct HipLibrary {
+    lib: DynamicLibrary,
+    symbols: SymbolCache,
+}
+
+impl HipLibrary {
+    /// Loads the default system HIP runtime library, or returns the cached instance (Spec 14 §3).
+    ///
+    /// Resolves search paths in order:
+    /// 1. `R9V_HIP_PATH` environment variable
+    /// 2. `ROCM_PATH/lib/libamdhip64.so.7` or `ROCM_PATH/lib/libamdhip64.so`
+    /// 3. `/opt/rocm/lib/libamdhip64.so.7` or `/opt/rocm/lib/libamdhip64.so`
+    /// 4. System library search paths (`libamdhip64.so.7`, `libamdhip64.so`)
+    pub fn default_or_load() -> Result<Arc<Self>> {
+        GLOBAL_LIBRARY
+            .get_or_init(Self::load_system)
+            .as_ref()
+            .map(Arc::clone)
+            .map_err(|e| e.clone())
+    }
+
+    /// Loads the system HIP library from standard candidate locations (Spec 14 §3).
+    pub fn load_system() -> Result<Arc<Self>> {
+        let mut searched = Vec::new();
+
+        // 1. Explicit R9V_HIP_PATH environment variable
+        if let Ok(path_str) = std::env::var("R9V_HIP_PATH") {
+            let p = PathBuf::from(&path_str);
+            if p.is_file() {
+                match Self::load_from_path(&p) {
+                    Ok(lib) => return Ok(Arc::new(lib)),
+                    Err(e) => searched.push(format!("{}: {e}", p.display())),
+                }
+            } else if p.is_dir() {
+                let cand1 = p.join("lib/libamdhip64.so.7");
+                if cand1.is_file() {
+                    match Self::load_from_path(&cand1) {
+                        Ok(lib) => return Ok(Arc::new(lib)),
+                        Err(e) => searched.push(format!("{}: {e}", cand1.display())),
+                    }
+                } else {
+                    searched.push(format!("{}: file not found", cand1.display()));
+                }
+
+                let cand2 = p.join("libamdhip64.so.7");
+                if cand2.is_file() {
+                    match Self::load_from_path(&cand2) {
+                        Ok(lib) => return Ok(Arc::new(lib)),
+                        Err(e) => searched.push(format!("{}: {e}", cand2.display())),
+                    }
+                } else {
+                    searched.push(format!("{}: file not found", cand2.display()));
+                }
+            } else {
+                searched.push(format!("{path_str}: path does not exist"));
+            }
+        }
+
+        // 2. Explicit ROCM_PATH environment variable
+        if let Ok(rocm_path) = std::env::var("ROCM_PATH") {
+            let p = PathBuf::from(rocm_path);
+            let candidates = [p.join("lib/libamdhip64.so.7"), p.join("lib/libamdhip64.so")];
+            for cand in candidates {
+                if cand.is_file() {
+                    match Self::load_from_path(&cand) {
+                        Ok(lib) => return Ok(Arc::new(lib)),
+                        Err(e) => searched.push(format!("{}: {e}", cand.display())),
+                    }
+                } else {
+                    searched.push(format!("{}: file not found", cand.display()));
+                }
+            }
+        }
+
+        // 3. Default /opt/rocm paths
+        let opt_rocm_candidates = [
+            "/opt/rocm/lib/libamdhip64.so.7",
+            "/opt/rocm/lib/libamdhip64.so",
+        ];
+        for cand in opt_rocm_candidates {
+            let p = Path::new(cand);
+            if p.is_file() {
+                match Self::load_from_path(p) {
+                    Ok(lib) => return Ok(Arc::new(lib)),
+                    Err(e) => searched.push(format!("{cand}: {e}")),
+                }
+            } else {
+                searched.push(format!("{cand}: file not found"));
+            }
+        }
+
+        // 4. System library sonames for pinned ROCm 7.x matrix
+        let system_names = ["libamdhip64.so.7", "libamdhip64.so"];
+        for name in system_names {
+            match Self::load_from_path(Path::new(name)) {
+                Ok(lib) => return Ok(Arc::new(lib)),
+                Err(e) => searched.push(format!("{name}: {e}")),
+            }
+        }
+
+        Err(HipError::LibraryNotFound { searched })
+    }
+
+    /// Loads a HIP shared library from an explicit path (Spec 14 §3).
+    pub fn load_from_path(path: &Path) -> Result<Self> {
+        let lib = DynamicLibrary::open(path)?;
+        Ok(Self {
+            lib,
+            symbols: SymbolCache::default(),
+        })
+    }
+
+    /// Returns the file system path of the loaded dynamic library (Spec 14 §3).
+    pub fn library_path(&self) -> &Path {
+        self.lib.path()
+    }
+
+    fn check(&self, op: &'static str, code: HipErrorT) -> Result<()> {
+        if code == HIP_SUCCESS {
+            Ok(())
+        } else {
+            let desc = self.get_error_string(code);
+            Err(HipError::api_error(op, code, desc.as_deref()))
+        }
+    }
+
+    fn get_error_string(&self, code: HipErrorT) -> Option<String> {
+        let sym_ptr = self
+            .symbols
+            .resolve(
+                &self.symbols.hip_get_error_string,
+                &self.lib,
+                "hipGetErrorString",
+            )
+            .ok()?;
+        // SAFETY: hipGetErrorString has signature `extern "C" fn(hipError_t) -> *const c_char`.
+        let func: unsafe extern "C" fn(HipErrorT) -> *const c_char =
+            unsafe { std::mem::transmute(sym_ptr) };
+        // SAFETY: Invoking resolved hipGetErrorString with integer error code is safe.
+        let ptr = unsafe { func(code) };
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: The driver returns a static NUL-terminated C string for standard error codes.
+            Some(
+                unsafe { CStr::from_ptr(ptr) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        }
+    }
+
+    // --- Device Management ---
+
+    /// Queries the number of available HIP GPU devices (Spec 14 §3).
+    pub fn device_count(&self) -> Result<u32> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_get_device_count,
+            &self.lib,
+            "hipGetDeviceCount",
+        )?;
+        // SAFETY: hipGetDeviceCount signature is `extern "C" fn(*mut c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut c_int) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut count: c_int = 0;
+        // SAFETY: count is a valid local stack allocation.
+        self.check("hipGetDeviceCount", unsafe { func(&mut count) })?;
+        if count < 0 {
+            return Err(HipError::InvalidDeviceCount { count });
+        }
+        Ok(count as u32)
+    }
+
+    /// Sets the active HIP device ordinal for the calling host thread (Spec 14 §3).
+    pub fn set_device(&self, device_id: i32) -> Result<()> {
+        let sym = self
+            .symbols
+            .resolve(&self.symbols.hip_set_device, &self.lib, "hipSetDevice")?;
+        // SAFETY: hipSetDevice signature is `extern "C" fn(c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(c_int) -> HipErrorT = unsafe { std::mem::transmute(sym) };
+        // SAFETY: Passing integer device ID to hipSetDevice is safe.
+        self.check("hipSetDevice", unsafe { func(device_id) })
+    }
+
+    /// Queries the currently active HIP device ordinal for the calling thread (Spec 14 §3).
+    pub fn get_device(&self) -> Result<i32> {
+        let sym = self
+            .symbols
+            .resolve(&self.symbols.hip_get_device, &self.lib, "hipGetDevice")?;
+        // SAFETY: hipGetDevice signature is `extern "C" fn(*mut c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut c_int) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut dev: c_int = 0;
+        // SAFETY: dev is a valid local stack allocation.
+        self.check("hipGetDevice", unsafe { func(&mut dev) })?;
+        Ok(dev)
+    }
+
+    /// Queries hardware properties and capabilities of a HIP device (Spec 14 §3).
+    pub fn get_device_properties(&self, device_id: i32) -> Result<DeviceProperties> {
+        let sym = self.symbols.resolve_device_properties(&self.lib)?;
+        // SAFETY: hipGetDevicePropertiesR0600 takes a pointer to RawDeviceProp (1472 bytes) and device ID.
+        let func: unsafe extern "C" fn(*mut RawDeviceProp, c_int) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+
+        let mut raw = RawDeviceProp::default();
+        // SAFETY: raw is a valid stack-allocated 1472-byte RawDeviceProp struct.
+        self.check("hipGetDevicePropertiesR0600", unsafe {
+            func(&mut raw, device_id)
+        })?;
+
+        let name = parse_fixed_c_string(&raw.name);
+        let gcn_arch_name = parse_fixed_c_string(&raw.gcn_arch_name);
+
+        Ok(DeviceProperties {
+            name,
+            total_global_mem: raw.total_global_mem as u64,
+            shared_mem_per_block: raw.shared_mem_per_block,
+            regs_per_block: raw.regs_per_block,
+            warp_size: raw.warp_size,
+            max_threads_per_block: raw.max_threads_per_block,
+            max_threads_dim: raw.max_threads_dim,
+            max_grid_size: raw.max_grid_size,
+            clock_rate_khz: raw.clock_rate,
+            major: raw.major,
+            minor: raw.minor,
+            multi_processor_count: raw.multi_processor_count,
+            gcn_arch_name,
+            pci_bus_id: raw.pci_bus_id,
+            pci_device_id: raw.pci_device_id,
+            pci_domain_id: raw.pci_domain_id,
+            is_multi_gpu_board: raw.is_multi_gpu_board != 0,
+            can_map_host_memory: raw.can_map_host_memory != 0,
+            concurrent_kernels: raw.concurrent_kernels != 0,
+            ecc_enabled: raw.ecc_enabled != 0,
+            cooperative_launch: raw.cooperative_launch != 0,
+        })
+    }
+
+    // --- Memory Operations ---
+
+    /// Allocates linear device memory on the current active device (Spec 14 §3).
+    pub fn malloc(&self, size_bytes: usize) -> Result<*mut c_void> {
+        let sym = self
+            .symbols
+            .resolve(&self.symbols.hip_malloc, &self.lib, "hipMalloc")?;
+        // SAFETY: hipMalloc signature is `extern "C" fn(*mut *mut c_void, usize) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut *mut c_void, usize) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut ptr: *mut c_void = std::ptr::null_mut();
+        // SAFETY: ptr is a valid stack-allocated pointer.
+        self.check("hipMalloc", unsafe { func(&mut ptr, size_bytes) })?;
+        if ptr.is_null() && size_bytes > 0 {
+            return Err(HipError::NullPointer("hipMalloc returned null pointer"));
+        }
+        Ok(ptr)
+    }
+
+    /// Frees linear device memory allocated by [`malloc`](Self::malloc) (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `ptr` must be a pointer returned from a HIP memory allocation function or null.
+    pub unsafe fn free(&self, ptr: *mut c_void) -> Result<()> {
+        if ptr.is_null() {
+            return Ok(());
+        }
+        let sym = self
+            .symbols
+            .resolve(&self.symbols.hip_free, &self.lib, "hipFree")?;
+        // SAFETY: hipFree signature is `extern "C" fn(*mut c_void) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut c_void) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees ptr is a valid HIP allocation or null.
+        self.check("hipFree", func(ptr))
+    }
+
+    /// Allocates page-locked (pinned) host memory accessible by device (Spec 14 §3).
+    pub fn host_malloc(&self, size_bytes: usize, flags: u32) -> Result<*mut c_void> {
+        let sym = self.symbols.resolve_host_malloc(&self.lib)?;
+        // SAFETY: hipHostMalloc signature is `extern "C" fn(*mut *mut c_void, usize, c_uint) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut *mut c_void, usize, c_uint) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut ptr: *mut c_void = std::ptr::null_mut();
+        // SAFETY: ptr is a valid stack-allocated pointer.
+        self.check("hipHostMalloc", unsafe {
+            func(&mut ptr, size_bytes, flags)
+        })?;
+        if ptr.is_null() && size_bytes > 0 {
+            return Err(HipError::NullPointer("hipHostMalloc returned null pointer"));
+        }
+        Ok(ptr)
+    }
+
+    /// Frees page-locked host memory allocated by [`host_malloc`](Self::host_malloc) (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `ptr` must be a pointer returned from a HIP host memory allocation function or null.
+    pub unsafe fn host_free(&self, ptr: *mut c_void) -> Result<()> {
+        if ptr.is_null() {
+            return Ok(());
+        }
+        let sym = self.symbols.resolve_host_free(&self.lib)?;
+        // SAFETY: hipHostFree signature is `extern "C" fn(*mut c_void) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut c_void) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees ptr is a valid HIP host allocation or null.
+        self.check("hipHostFree", func(ptr))
+    }
+
+    /// Copies memory synchronously between host and device (Spec 14 §3).
+    ///
+    /// # Safety
+    /// Caller must guarantee `dst` and `src` are valid for read/write of `count` bytes.
+    pub unsafe fn memcpy(
+        &self,
+        dst: *mut c_void,
+        src: *const c_void,
+        count: usize,
+        kind: MemcpyKind,
+    ) -> Result<()> {
+        let sym = self
+            .symbols
+            .resolve(&self.symbols.hip_memcpy, &self.lib, "hipMemcpy")?;
+        // SAFETY: hipMemcpy signature is `extern "C" fn(*mut c_void, *const c_void, usize, c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_int) -> HipErrorT =
+            std::mem::transmute(sym);
+        // SAFETY: Caller guarantees valid pointers for `count` bytes.
+        self.check("hipMemcpy", func(dst, src, count, kind.as_raw()))
+    }
+
+    /// Asynchronously copies memory between host, device, or device peers in a stream (Spec 14 §3).
+    ///
+    /// # Safety
+    /// Caller must guarantee `dst` and `src` are valid for read/write of `count` bytes in `stream`.
+    pub unsafe fn memcpy_async(
+        &self,
+        dst: *mut c_void,
+        src: *const c_void,
+        count: usize,
+        kind: MemcpyKind,
+        stream: HipStreamT,
+    ) -> Result<()> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_memcpy_async, &self.lib, "hipMemcpyAsync")?;
+        // SAFETY: hipMemcpyAsync signature is `extern "C" fn(*mut c_void, *const c_void, usize, c_int, HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(
+            *mut c_void,
+            *const c_void,
+            usize,
+            c_int,
+            HipStreamT,
+        ) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees valid pointers for `count` bytes in `stream`.
+        self.check(
+            "hipMemcpyAsync",
+            func(dst, src, count, kind.as_raw(), stream),
+        )
+    }
+
+    /// Copies memory asynchronously between two distinct device contexts (Spec 5 §7, Spec 14 §3).
+    ///
+    /// # Safety
+    /// Caller must guarantee `dst` and `src` are valid device pointers on `dst_dev` and `src_dev`.
+    pub unsafe fn memcpy_peer_async(
+        &self,
+        dst: *mut c_void,
+        dst_dev: i32,
+        src: *const c_void,
+        src_dev: i32,
+        count: usize,
+        stream: HipStreamT,
+    ) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_memcpy_peer_async,
+            &self.lib,
+            "hipMemcpyPeerAsync",
+        )?;
+        // SAFETY: hipMemcpyPeerAsync signature is `extern "C" fn(*mut c_void, c_int, *const c_void, c_int, usize, HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(
+            *mut c_void,
+            c_int,
+            *const c_void,
+            c_int,
+            usize,
+            HipStreamT,
+        ) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees valid pointers and enabled peer access between devices.
+        self.check(
+            "hipMemcpyPeerAsync",
+            func(dst, dst_dev, src, src_dev, count, stream),
+        )
+    }
+
+    // --- Stream Operations ---
+
+    /// Creates a new execution stream with default flags (Spec 14 §3).
+    pub fn stream_create(&self) -> Result<HipStreamT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_create,
+            &self.lib,
+            "hipStreamCreate",
+        )?;
+        // SAFETY: hipStreamCreate signature is `extern "C" fn(*mut HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipStreamT) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut stream: HipStreamT = std::ptr::null_mut();
+        // SAFETY: stream is a valid local pointer.
+        self.check("hipStreamCreate", unsafe { func(&mut stream) })?;
+        Ok(stream)
+    }
+
+    /// Creates a new execution stream with custom flags (Spec 14 §3).
+    pub fn stream_create_with_flags(&self, flags: StreamFlags) -> Result<HipStreamT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_create_with_flags,
+            &self.lib,
+            "hipStreamCreateWithFlags",
+        )?;
+        // SAFETY: hipStreamCreateWithFlags signature is `extern "C" fn(*mut HipStreamT, c_uint) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipStreamT, c_uint) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut stream: HipStreamT = std::ptr::null_mut();
+        // SAFETY: stream is a valid local pointer.
+        self.check("hipStreamCreateWithFlags", unsafe {
+            func(&mut stream, flags.as_raw())
+        })?;
+        Ok(stream)
+    }
+
+    /// Destroys a stream handle (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `stream` must be a valid HIP stream handle or null.
+    pub unsafe fn stream_destroy(&self, stream: HipStreamT) -> Result<()> {
+        if stream.is_null() {
+            return Ok(());
+        }
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_destroy,
+            &self.lib,
+            "hipStreamDestroy",
+        )?;
+        // SAFETY: hipStreamDestroy signature is `extern "C" fn(HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipStreamT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees stream is a valid handle or null.
+        self.check("hipStreamDestroy", func(stream))
+    }
+
+    /// Blocks host thread until all queued operations in `stream` have completed (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `stream` must be a valid HIP stream handle or null.
+    pub unsafe fn stream_synchronize(&self, stream: HipStreamT) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_synchronize,
+            &self.lib,
+            "hipStreamSynchronize",
+        )?;
+        // SAFETY: hipStreamSynchronize signature is `extern "C" fn(HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipStreamT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees stream is a valid handle or null.
+        self.check("hipStreamSynchronize", func(stream))
+    }
+
+    /// Returns `true` if all operations in `stream` have completed (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `stream` must be a valid HIP stream handle or null.
+    pub unsafe fn stream_query(&self, stream: HipStreamT) -> Result<bool> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_stream_query, &self.lib, "hipStreamQuery")?;
+        // SAFETY: hipStreamQuery signature is `extern "C" fn(HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipStreamT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees stream is a valid handle or null.
+        let code = func(stream);
+        if code == HIP_SUCCESS {
+            Ok(true)
+        } else if code == HIP_ERROR_NOT_READY {
+            Ok(false)
+        } else {
+            self.check("hipStreamQuery", code)?;
+            Ok(true)
+        }
+    }
+
+    /// Enqueues a stream wait on an event (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `stream` and `event` must be valid HIP handles.
+    pub unsafe fn stream_wait_event(
+        &self,
+        stream: HipStreamT,
+        event: HipEventT,
+        flags: u32,
+    ) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_wait_event,
+            &self.lib,
+            "hipStreamWaitEvent",
+        )?;
+        // SAFETY: hipStreamWaitEvent signature is `extern "C" fn(HipStreamT, HipEventT, c_uint) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipStreamT, HipEventT, c_uint) -> HipErrorT =
+            std::mem::transmute(sym);
+        // SAFETY: Caller guarantees stream and event are valid handles.
+        self.check("hipStreamWaitEvent", func(stream, event, flags))
+    }
+
+    // --- Event Operations ---
+
+    /// Creates an event with default flags (Spec 14 §3).
+    pub fn event_create(&self) -> Result<HipEventT> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_event_create, &self.lib, "hipEventCreate")?;
+        // SAFETY: hipEventCreate signature is `extern "C" fn(*mut HipEventT) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipEventT) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut event: HipEventT = std::ptr::null_mut();
+        // SAFETY: event is a valid local pointer.
+        self.check("hipEventCreate", unsafe { func(&mut event) })?;
+        Ok(event)
+    }
+
+    /// Creates an event with custom flags (Spec 14 §3).
+    pub fn event_create_with_flags(&self, flags: EventFlags) -> Result<HipEventT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_event_create_with_flags,
+            &self.lib,
+            "hipEventCreateWithFlags",
+        )?;
+        // SAFETY: hipEventCreateWithFlags signature is `extern "C" fn(*mut HipEventT, c_uint) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipEventT, c_uint) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut event: HipEventT = std::ptr::null_mut();
+        // SAFETY: event is a valid local pointer.
+        self.check("hipEventCreateWithFlags", unsafe {
+            func(&mut event, flags.as_raw())
+        })?;
+        Ok(event)
+    }
+
+    /// Destroys an event handle (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `event` must be a valid HIP event handle or null.
+    pub unsafe fn event_destroy(&self, event: HipEventT) -> Result<()> {
+        if event.is_null() {
+            return Ok(());
+        }
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_event_destroy,
+            &self.lib,
+            "hipEventDestroy",
+        )?;
+        // SAFETY: hipEventDestroy signature is `extern "C" fn(HipEventT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipEventT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees event is a valid handle or null.
+        self.check("hipEventDestroy", func(event))
+    }
+
+    /// Captures the execution state of `stream` into `event` (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `event` and `stream` must be valid handles.
+    pub unsafe fn event_record(&self, event: HipEventT, stream: HipStreamT) -> Result<()> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_event_record, &self.lib, "hipEventRecord")?;
+        // SAFETY: hipEventRecord signature is `extern "C" fn(HipEventT, HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipEventT, HipStreamT) -> HipErrorT =
+            std::mem::transmute(sym);
+        // SAFETY: Caller guarantees valid handles.
+        self.check("hipEventRecord", func(event, stream))
+    }
+
+    /// Blocks host thread until `event` has completed (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `event` must be a valid event handle.
+    pub unsafe fn event_synchronize(&self, event: HipEventT) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_event_synchronize,
+            &self.lib,
+            "hipEventSynchronize",
+        )?;
+        // SAFETY: hipEventSynchronize signature is `extern "C" fn(HipEventT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipEventT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees event is a valid handle.
+        self.check("hipEventSynchronize", func(event))
+    }
+
+    /// Computes elapsed time in milliseconds between two recorded events (Spec 11 §7, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `start` and `stop` must be valid recorded events.
+    pub unsafe fn event_elapsed_time(&self, start: HipEventT, stop: HipEventT) -> Result<f32> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_event_elapsed_time,
+            &self.lib,
+            "hipEventElapsedTime",
+        )?;
+        // SAFETY: hipEventElapsedTime signature is `extern "C" fn(*mut f32, HipEventT, HipEventT) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut f32, HipEventT, HipEventT) -> HipErrorT =
+            std::mem::transmute(sym);
+        let mut ms: f32 = 0.0;
+        // SAFETY: ms is a valid local stack float.
+        self.check("hipEventElapsedTime", func(&mut ms, start, stop))?;
+        Ok(ms)
+    }
+
+    /// Queries completion status of an event without blocking (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `event` must be a valid event handle.
+    pub unsafe fn event_query(&self, event: HipEventT) -> Result<bool> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_event_query, &self.lib, "hipEventQuery")?;
+        // SAFETY: hipEventQuery signature is `extern "C" fn(HipEventT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipEventT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees event is a valid handle.
+        let code = func(event);
+        if code == HIP_SUCCESS {
+            Ok(true)
+        } else if code == HIP_ERROR_NOT_READY {
+            Ok(false)
+        } else {
+            self.check("hipEventQuery", code)?;
+            Ok(true)
+        }
+    }
+
+    // --- Module & Kernel Launch Operations ---
+
+    /// Loads a compiled code object file (`.co`) as a HIP module (Spec 4 §10, Spec 14 §3).
+    pub fn module_load(&self, fname: &Path) -> Result<HipModuleT> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_module_load, &self.lib, "hipModuleLoad")?;
+        // SAFETY: hipModuleLoad signature is `extern "C" fn(*mut HipModuleT, *const c_char) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipModuleT, *const c_char) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let c_fname = CString::new(fname.as_os_str().as_encoded_bytes()).map_err(|e| {
+            HipError::InvalidNulByte {
+                context: "module file path",
+                nul_position: e.nul_position(),
+            }
+        })?;
+        let mut module: HipModuleT = std::ptr::null_mut();
+        // SAFETY: module is a valid local pointer and c_fname is a valid NUL-terminated C string.
+        self.check("hipModuleLoad", unsafe {
+            func(&mut module, c_fname.as_ptr())
+        })?;
+        Ok(module)
+    }
+
+    /// Loads an in-memory compiled code object image as a HIP module (Spec 4 §10, Spec 14 §3).
+    pub fn module_load_data(&self, image: &[u8]) -> Result<HipModuleT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_module_load_data,
+            &self.lib,
+            "hipModuleLoadData",
+        )?;
+        // SAFETY: hipModuleLoadData signature is `extern "C" fn(*mut HipModuleT, *const c_void) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipModuleT, *const c_void) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut module: HipModuleT = std::ptr::null_mut();
+        // SAFETY: image slice points to contiguous in-memory code object bytes.
+        self.check("hipModuleLoadData", unsafe {
+            func(&mut module, image.as_ptr() as *const c_void)
+        })?;
+        Ok(module)
+    }
+
+    /// Unloads a loaded HIP module (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `module` must be a valid HIP module handle or null.
+    pub unsafe fn module_unload(&self, module: HipModuleT) -> Result<()> {
+        if module.is_null() {
+            return Ok(());
+        }
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_module_unload,
+            &self.lib,
+            "hipModuleUnload",
+        )?;
+        // SAFETY: hipModuleUnload signature is `extern "C" fn(HipModuleT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipModuleT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees module is a valid handle or null.
+        self.check("hipModuleUnload", func(module))
+    }
+
+    /// Resolves an exported kernel function symbol from a module (Spec 4 §10, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `module` must be a valid loaded HIP module handle.
+    pub unsafe fn module_get_function(
+        &self,
+        module: HipModuleT,
+        name: &str,
+    ) -> Result<HipFunctionT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_module_get_function,
+            &self.lib,
+            "hipModuleGetFunction",
+        )?;
+        // SAFETY: hipModuleGetFunction signature is `extern "C" fn(*mut HipFunctionT, HipModuleT, *const c_char) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut HipFunctionT, HipModuleT, *const c_char) -> HipErrorT =
+            std::mem::transmute(sym);
+        let c_name = CString::new(name).map_err(|e| HipError::InvalidNulByte {
+            context: "kernel function name",
+            nul_position: e.nul_position(),
+        })?;
+        let mut function: HipFunctionT = std::ptr::null_mut();
+        // SAFETY: Caller guarantees module is valid and c_name is NUL-terminated.
+        self.check(
+            "hipModuleGetFunction",
+            func(&mut function, module, c_name.as_ptr()),
+        )?;
+        Ok(function)
+    }
+
+    /// Enqueues a device kernel launch on a stream with grid/block dimensions (Spec 4 §10, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `func` and `stream` must be valid handles, and `kernel_params` must match the kernel ABI.
+    pub unsafe fn module_launch_kernel(
+        &self,
+        func: HipFunctionT,
+        grid: (u32, u32, u32),
+        block: (u32, u32, u32),
+        shared_mem: u32,
+        stream: HipStreamT,
+        kernel_params: &mut [*mut c_void],
+    ) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_module_launch_kernel,
+            &self.lib,
+            "hipModuleLaunchKernel",
+        )?;
+        // SAFETY: hipModuleLaunchKernel signature matches ROCm kernel launch ABI.
+        let launch_fn: unsafe extern "C" fn(
+            HipFunctionT,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            HipStreamT,
+            *mut *mut c_void,
+            *mut *mut c_void,
+        ) -> HipErrorT = std::mem::transmute(sym);
+
+        let params_ptr = if kernel_params.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            kernel_params.as_mut_ptr()
+        };
+
+        // SAFETY: Caller guarantees func, stream, and parameter types are valid.
+        self.check(
+            "hipModuleLaunchKernel",
+            launch_fn(
+                func,
+                grid.0,
+                grid.1,
+                grid.2,
+                block.0,
+                block.1,
+                block.2,
+                shared_mem,
+                stream,
+                params_ptr,
+                std::ptr::null_mut(),
+            ),
+        )
+    }
+
+    // --- Graph Operations ---
+
+    /// Begins stream capture for graph replay (Spec 1 §3.1, Spec 6 §2, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `stream` must be a valid HIP stream handle.
+    pub unsafe fn stream_begin_capture(
+        &self,
+        stream: HipStreamT,
+        mode: StreamCaptureMode,
+    ) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_begin_capture,
+            &self.lib,
+            "hipStreamBeginCapture",
+        )?;
+        // SAFETY: hipStreamBeginCapture signature is `extern "C" fn(HipStreamT, c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipStreamT, c_int) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees stream is valid.
+        self.check("hipStreamBeginCapture", func(stream, mode.as_raw()))
+    }
+
+    /// Ends stream capture and returns the constructed graph handle (Spec 1 §3.1, Spec 6 §2, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `stream` must be actively capturing.
+    pub unsafe fn stream_end_capture(&self, stream: HipStreamT) -> Result<HipGraphT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_stream_end_capture,
+            &self.lib,
+            "hipStreamEndCapture",
+        )?;
+        // SAFETY: hipStreamEndCapture signature is `extern "C" fn(HipStreamT, *mut HipGraphT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipStreamT, *mut HipGraphT) -> HipErrorT =
+            std::mem::transmute(sym);
+        let mut graph: HipGraphT = std::ptr::null_mut();
+        // SAFETY: graph is a valid local pointer.
+        self.check("hipStreamEndCapture", func(stream, &mut graph))?;
+        Ok(graph)
+    }
+
+    /// Instantiates an executable graph from a captured graph topology (Spec 6 §2, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `graph` must be a valid captured graph handle.
+    pub unsafe fn graph_instantiate(&self, graph: HipGraphT) -> Result<HipGraphExecT> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_graph_instantiate,
+            &self.lib,
+            "hipGraphInstantiate",
+        )?;
+        let mut exec: HipGraphExecT = std::ptr::null_mut();
+
+        // SAFETY: hipGraphInstantiate 5-argument signature in ROCm 6.x/7.x ABI.
+        let func: unsafe extern "C" fn(
+            *mut HipGraphExecT,
+            HipGraphT,
+            *mut HipGraphNodeT,
+            *mut c_char,
+            usize,
+        ) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: exec is a valid local pointer.
+        self.check(
+            "hipGraphInstantiate",
+            func(
+                &mut exec,
+                graph,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+            ),
+        )?;
+
+        Ok(exec)
+    }
+
+    /// Launches an instantiated executable graph on a stream (Spec 6 §2, Spec 14 §3).
+    ///
+    /// # Safety
+    /// `graph_exec` and `stream` must be valid handles.
+    pub unsafe fn graph_launch(&self, graph_exec: HipGraphExecT, stream: HipStreamT) -> Result<()> {
+        let sym =
+            self.symbols
+                .resolve(&self.symbols.hip_graph_launch, &self.lib, "hipGraphLaunch")?;
+        // SAFETY: hipGraphLaunch signature is `extern "C" fn(HipGraphExecT, HipStreamT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipGraphExecT, HipStreamT) -> HipErrorT =
+            std::mem::transmute(sym);
+        // SAFETY: Caller guarantees graph_exec and stream are valid handles.
+        self.check("hipGraphLaunch", func(graph_exec, stream))
+    }
+
+    /// Destroys a captured graph definition (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `graph` must be a valid graph handle or null.
+    pub unsafe fn graph_destroy(&self, graph: HipGraphT) -> Result<()> {
+        if graph.is_null() {
+            return Ok(());
+        }
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_graph_destroy,
+            &self.lib,
+            "hipGraphDestroy",
+        )?;
+        // SAFETY: hipGraphDestroy signature is `extern "C" fn(HipGraphT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipGraphT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees graph is valid or null.
+        self.check("hipGraphDestroy", func(graph))
+    }
+
+    /// Destroys an instantiated executable graph (Spec 14 §3).
+    ///
+    /// # Safety
+    /// `graph_exec` must be a valid handle or null.
+    pub unsafe fn graph_exec_destroy(&self, graph_exec: HipGraphExecT) -> Result<()> {
+        if graph_exec.is_null() {
+            return Ok(());
+        }
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_graph_exec_destroy,
+            &self.lib,
+            "hipGraphExecDestroy",
+        )?;
+        // SAFETY: hipGraphExecDestroy signature is `extern "C" fn(HipGraphExecT) -> hipError_t`.
+        let func: unsafe extern "C" fn(HipGraphExecT) -> HipErrorT = std::mem::transmute(sym);
+        // SAFETY: Caller guarantees graph_exec is valid or null.
+        self.check("hipGraphExecDestroy", func(graph_exec))
+    }
+
+    // --- Peer Access Operations ---
+
+    /// Queries whether peer memory access is supported from `device` to `peer_device` (Spec 5 §7, Spec 14 §3).
+    pub fn device_can_access_peer(&self, device: i32, peer_device: i32) -> Result<bool> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_device_can_access_peer,
+            &self.lib,
+            "hipDeviceCanAccessPeer",
+        )?;
+        // SAFETY: hipDeviceCanAccessPeer signature is `extern "C" fn(*mut c_int, c_int, c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(*mut c_int, c_int, c_int) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let mut can_access: c_int = 0;
+        // SAFETY: can_access is a valid local stack allocation.
+        self.check("hipDeviceCanAccessPeer", unsafe {
+            func(&mut can_access, device, peer_device)
+        })?;
+        Ok(can_access != 0)
+    }
+
+    /// Enables peer direct memory access from current device to `peer_device` (Spec 5 §7, Spec 14 §3).
+    pub fn device_enable_peer_access(&self, peer_device: i32, flags: u32) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_device_enable_peer_access,
+            &self.lib,
+            "hipDeviceEnablePeerAccess",
+        )?;
+        // SAFETY: hipDeviceEnablePeerAccess signature is `extern "C" fn(c_int, c_uint) -> hipError_t`.
+        let func: unsafe extern "C" fn(c_int, c_uint) -> HipErrorT =
+            unsafe { std::mem::transmute(sym) };
+        let code = unsafe { func(peer_device, flags) };
+        if code == HIP_SUCCESS || code == HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED {
+            Ok(())
+        } else {
+            self.check("hipDeviceEnablePeerAccess", code)
+        }
+    }
+
+    /// Disables peer direct memory access to `peer_device` (Spec 5 §7, Spec 14 §3).
+    pub fn device_disable_peer_access(&self, peer_device: i32) -> Result<()> {
+        let sym = self.symbols.resolve(
+            &self.symbols.hip_device_disable_peer_access,
+            &self.lib,
+            "hipDeviceDisablePeerAccess",
+        )?;
+        // SAFETY: hipDeviceDisablePeerAccess signature is `extern "C" fn(c_int) -> hipError_t`.
+        let func: unsafe extern "C" fn(c_int) -> HipErrorT = unsafe { std::mem::transmute(sym) };
+        let code = unsafe { func(peer_device) };
+        if code == HIP_SUCCESS || code == HIP_ERROR_PEER_ACCESS_NOT_ENABLED {
+            Ok(())
+        } else {
+            self.check("hipDeviceDisablePeerAccess", code)
+        }
+    }
+}

--- a/crates/r9v-hip/src/raw.rs
+++ b/crates/r9v-hip/src/raw.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Raw C types, function signatures, and ABI definitions for AMD HIP (Spec 14 §2, §3).
+
+use std::ffi::{c_char, c_int, c_uint, c_void};
+
+pub(crate) type HipErrorT = i32;
+pub(crate) const HIP_SUCCESS: HipErrorT = 0;
+
+pub(crate) const HIP_ERROR_NOT_READY: HipErrorT = 600;
+pub(crate) const HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED: HipErrorT = 704;
+pub(crate) const HIP_ERROR_PEER_ACCESS_NOT_ENABLED: HipErrorT = 705;
+
+pub(crate) type HipStreamT = *mut c_void;
+pub(crate) type HipEventT = *mut c_void;
+pub(crate) type HipModuleT = *mut c_void;
+pub(crate) type HipFunctionT = *mut c_void;
+pub(crate) type HipGraphT = *mut c_void;
+pub(crate) type HipGraphExecT = *mut c_void;
+pub(crate) type HipGraphNodeT = *mut c_void;
+
+/// Raw C representation of `hipDeviceProp_t` (ROCm 6.0+ `hipDeviceProp_tR0600`, Spec 14 §3).
+///
+/// Pinned to exactly 1472 bytes matching ROCm 6.x and 7.x ABI.
+#[repr(C)]
+#[derive(Clone)]
+pub(crate) struct RawDeviceProp {
+    pub name: [c_char; 256],                // 0..256
+    pub uuid: [u8; 16],                     // 256..272
+    pub luid: [c_char; 8],                  // 272..280
+    pub luid_device_node_mask: c_uint,      // 280..284
+    pub _pad0: [u8; 4],                     // 284..288
+    pub total_global_mem: usize,            // 288..296
+    pub shared_mem_per_block: usize,        // 296..304
+    pub regs_per_block: c_int,              // 304..308
+    pub warp_size: c_int,                   // 308..312
+    pub mem_pitch: usize,                   // 312..320
+    pub max_threads_per_block: c_int,       // 320..324
+    pub max_threads_dim: [c_int; 3],        // 324..336
+    pub max_grid_size: [c_int; 3],          // 336..348
+    pub clock_rate: c_int,                  // 348..352
+    pub total_const_mem: usize,             // 352..360
+    pub major: c_int,                       // 360..364
+    pub minor: c_int,                       // 364..368
+    pub texture_alignment: usize,           // 368..376
+    pub texture_pitch_alignment: usize,     // 376..384
+    pub device_overlap: c_int,              // 384..388
+    pub multi_processor_count: c_int,       // 388..392
+    pub kernel_exec_timeout_enabled: c_int, // 392..396
+    pub integrated: c_int,                  // 396..400
+    pub can_map_host_memory: c_int,         // 400..404
+    pub compute_mode: c_int,                // 404..408
+    pub _gap_to_concurrent: [u8; 168],      // 408..576
+    pub concurrent_kernels: c_int,          // 576..580
+    pub ecc_enabled: c_int,                 // 580..584
+    pub pci_bus_id: c_int,                  // 584..588
+    pub pci_device_id: c_int,               // 588..592
+    pub pci_domain_id: c_int,               // 592..596
+    pub _gap_to_multi_gpu: [u8; 60],        // 596..656
+    pub is_multi_gpu_board: c_int,          // 656..660
+    pub _gap_to_cooperative: [u8; 28],      // 660..688
+    pub cooperative_launch: c_int,          // 688..692
+    pub _gap_to_arch: [u8; 468],            // 692..1160
+    pub gcn_arch_name: [c_char; 256],       // 1160..1416
+    pub _gap_end: [u8; 56],                 // 1416..1472
+}
+
+const _: () = assert!(std::mem::size_of::<RawDeviceProp>() == 1472);
+
+impl Default for RawDeviceProp {
+    fn default() -> Self {
+        // SAFETY: RawDeviceProp contains only primitive types (arrays of c_char/u8, usize, c_int, c_uint),
+        // all of which are valid when bitwise zero-initialized.
+        unsafe { std::mem::zeroed() }
+    }
+}

--- a/crates/r9v-hip/src/symbol.rs
+++ b/crates/r9v-hip/src/symbol.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Dynamic symbol resolution and caching for libamdhip64 (Spec 14 §2, §3).
+
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use crate::error::{HipError, Result};
+
+unsafe extern "C" {
+    fn dlopen(filename: *const c_char, flags: c_int) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    fn dlclose(handle: *mut c_void) -> c_int;
+    fn dlerror() -> *mut c_char;
+}
+
+const RTLD_NOW: c_int = 2;
+const RTLD_LOCAL: c_int = 0;
+
+/// Low-level dynamic library handle wrapping `dlopen` / `dlclose`.
+pub(crate) struct DynamicLibrary {
+    handle: *mut c_void,
+    path: PathBuf,
+}
+
+// SAFETY: DynamicLibrary wraps a POSIX dlopen handle (*mut c_void). In Linux/glibc, dlopen handles
+// are thread-safe and can be transferred safely across threads.
+unsafe impl Send for DynamicLibrary {}
+// SAFETY: DynamicLibrary operations via dlsym are thread-safe under POSIX and glibc dynamic linkers.
+unsafe impl Sync for DynamicLibrary {}
+
+impl DynamicLibrary {
+    /// Attempts to open a shared library at `path`.
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        let c_path = CString::new(path.as_os_str().as_encoded_bytes()).map_err(|e| {
+            HipError::InvalidNulByte {
+                context: "library path",
+                nul_position: e.nul_position(),
+            }
+        })?;
+
+        // Clear existing dlerror
+        unsafe { dlerror() };
+
+        let handle = unsafe { dlopen(c_path.as_ptr(), RTLD_NOW | RTLD_LOCAL) };
+        if handle.is_null() {
+            let err_msg = unsafe {
+                let err_ptr = dlerror();
+                if err_ptr.is_null() {
+                    "unknown dlopen error".to_owned()
+                } else {
+                    CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
+                }
+            };
+            return Err(HipError::LibraryNotFound {
+                searched: vec![format!("{}: {err_msg}", path.display())],
+            });
+        }
+
+        Ok(Self {
+            handle,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Resolves a raw symbol address using `dlsym`.
+    pub(crate) fn dlsym(&self, name: &'static str) -> Result<*mut c_void> {
+        let c_name = CString::new(name).map_err(|e| HipError::InvalidNulByte {
+            context: "symbol name",
+            nul_position: e.nul_position(),
+        })?;
+
+        unsafe { dlerror() };
+        let sym = unsafe { dlsym(self.handle, c_name.as_ptr()) };
+        if sym.is_null() {
+            let err_msg = unsafe {
+                let err_ptr = dlerror();
+                if err_ptr.is_null() {
+                    "symbol not found".to_owned()
+                } else {
+                    CStr::from_ptr(err_ptr).to_string_lossy().into_owned()
+                }
+            };
+            return Err(HipError::SymbolNotFound {
+                symbol: name,
+                details: format!("{err_msg} in {}", self.path.display()),
+            });
+        }
+
+        Ok(sym)
+    }
+
+    /// Returns the resolved path of the loaded shared library.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for DynamicLibrary {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { dlclose(self.handle) };
+            self.handle = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Table of lazily resolved and cached function pointers for HIP runtime entry points.
+#[derive(Default)]
+pub(crate) struct SymbolCache {
+    pub(crate) hip_get_device_count: AtomicPtr<c_void>,
+    pub(crate) hip_set_device: AtomicPtr<c_void>,
+    pub(crate) hip_get_device: AtomicPtr<c_void>,
+    pub(crate) hip_get_device_properties_r0600: AtomicPtr<c_void>,
+    pub(crate) hip_get_error_string: AtomicPtr<c_void>,
+
+    pub(crate) hip_malloc: AtomicPtr<c_void>,
+    pub(crate) hip_free: AtomicPtr<c_void>,
+    pub(crate) hip_host_malloc: AtomicPtr<c_void>,
+    pub(crate) hip_host_free: AtomicPtr<c_void>,
+    pub(crate) hip_memcpy: AtomicPtr<c_void>,
+    pub(crate) hip_memcpy_async: AtomicPtr<c_void>,
+    pub(crate) hip_memcpy_peer_async: AtomicPtr<c_void>,
+
+    pub(crate) hip_stream_create: AtomicPtr<c_void>,
+    pub(crate) hip_stream_create_with_flags: AtomicPtr<c_void>,
+    pub(crate) hip_stream_destroy: AtomicPtr<c_void>,
+    pub(crate) hip_stream_synchronize: AtomicPtr<c_void>,
+    pub(crate) hip_stream_query: AtomicPtr<c_void>,
+    pub(crate) hip_stream_wait_event: AtomicPtr<c_void>,
+
+    pub(crate) hip_event_create: AtomicPtr<c_void>,
+    pub(crate) hip_event_create_with_flags: AtomicPtr<c_void>,
+    pub(crate) hip_event_destroy: AtomicPtr<c_void>,
+    pub(crate) hip_event_record: AtomicPtr<c_void>,
+    pub(crate) hip_event_synchronize: AtomicPtr<c_void>,
+    pub(crate) hip_event_elapsed_time: AtomicPtr<c_void>,
+    pub(crate) hip_event_query: AtomicPtr<c_void>,
+
+    pub(crate) hip_module_load: AtomicPtr<c_void>,
+    pub(crate) hip_module_load_data: AtomicPtr<c_void>,
+    pub(crate) hip_module_unload: AtomicPtr<c_void>,
+    pub(crate) hip_module_get_function: AtomicPtr<c_void>,
+    pub(crate) hip_module_launch_kernel: AtomicPtr<c_void>,
+
+    pub(crate) hip_stream_begin_capture: AtomicPtr<c_void>,
+    pub(crate) hip_stream_end_capture: AtomicPtr<c_void>,
+    pub(crate) hip_graph_instantiate: AtomicPtr<c_void>,
+    pub(crate) hip_graph_launch: AtomicPtr<c_void>,
+    pub(crate) hip_graph_destroy: AtomicPtr<c_void>,
+    pub(crate) hip_graph_exec_destroy: AtomicPtr<c_void>,
+
+    pub(crate) hip_device_can_access_peer: AtomicPtr<c_void>,
+    pub(crate) hip_device_enable_peer_access: AtomicPtr<c_void>,
+    pub(crate) hip_device_disable_peer_access: AtomicPtr<c_void>,
+}
+
+impl SymbolCache {
+    /// Loads a symbol pointer from `cell` or lazily resolves it from `lib` and caches it.
+    pub(crate) fn resolve(
+        &self,
+        cell: &AtomicPtr<c_void>,
+        lib: &DynamicLibrary,
+        name: &'static str,
+    ) -> Result<*mut c_void> {
+        let ptr = cell.load(Ordering::Acquire);
+        if !ptr.is_null() {
+            return Ok(ptr);
+        }
+
+        let sym = lib.dlsym(name)?;
+        cell.store(sym, Ordering::Release);
+        Ok(sym)
+    }
+
+    /// Resolves `hipGetDevicePropertiesR0600` strictly without legacy fallbacks.
+    pub(crate) fn resolve_device_properties(&self, lib: &DynamicLibrary) -> Result<*mut c_void> {
+        self.resolve(
+            &self.hip_get_device_properties_r0600,
+            lib,
+            "hipGetDevicePropertiesR0600",
+        )
+    }
+
+    /// Resolves `hipHostMalloc` or falls back to `hipMallocHost`.
+    pub(crate) fn resolve_host_malloc(&self, lib: &DynamicLibrary) -> Result<*mut c_void> {
+        let ptr = self.hip_host_malloc.load(Ordering::Acquire);
+        if !ptr.is_null() {
+            return Ok(ptr);
+        }
+
+        let sym = lib
+            .dlsym("hipHostMalloc")
+            .or_else(|_| lib.dlsym("hipMallocHost"))?;
+
+        self.hip_host_malloc.store(sym, Ordering::Release);
+        Ok(sym)
+    }
+
+    /// Resolves `hipHostFree` or falls back to `hipFreeHost`.
+    pub(crate) fn resolve_host_free(&self, lib: &DynamicLibrary) -> Result<*mut c_void> {
+        let ptr = self.hip_host_free.load(Ordering::Acquire);
+        if !ptr.is_null() {
+            return Ok(ptr);
+        }
+
+        let sym = lib
+            .dlsym("hipHostFree")
+            .or_else(|_| lib.dlsym("hipFreeHost"))?;
+
+        self.hip_host_free.store(sym, Ordering::Release);
+        Ok(sym)
+    }
+}

--- a/crates/r9v-hip/tests/api_shape.rs
+++ b/crates/r9v-hip/tests/api_shape.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+//! API shape tests verifying public exports, trait implementations, and visibility (Spec 14 §2, §3, CONVENTIONS.md §4.1).
+
+use r9v_hip::{
+    default_library, device_count, is_available, Device, DeviceBuffer, DeviceProperties, Event,
+    EventFlags, Function, Graph, GraphExec, HipError, HipLibrary, HostBuffer, MemcpyKind, Module,
+    Result, Stream, StreamCaptureMode, StreamFlags,
+};
+use std::fmt::Display;
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+fn assert_display<T: Display>() {}
+fn assert_clone<T: Clone>() {}
+fn assert_copy<T: Copy>() {}
+
+#[test]
+fn test_api_shape_invariants() {
+    // Top-level discovery helpers
+    let _: fn() -> Result<std::sync::Arc<HipLibrary>> = default_library;
+    let _: fn() -> bool = is_available;
+    let _: fn() -> Result<u32> = device_count;
+
+    // Device enum traits
+    assert_copy::<Device>();
+    assert_clone::<Device>();
+    assert_send::<Device>();
+    assert_sync::<Device>();
+    assert_display::<Device>();
+
+    // Typed parameter enums
+    assert_copy::<MemcpyKind>();
+    assert_clone::<MemcpyKind>();
+    assert_send::<MemcpyKind>();
+    assert_sync::<MemcpyKind>();
+
+    assert_copy::<StreamCaptureMode>();
+    assert_clone::<StreamCaptureMode>();
+    assert_send::<StreamCaptureMode>();
+    assert_sync::<StreamCaptureMode>();
+
+    assert_copy::<StreamFlags>();
+    assert_clone::<StreamFlags>();
+    assert_send::<StreamFlags>();
+    assert_sync::<StreamFlags>();
+
+    assert_copy::<EventFlags>();
+    assert_clone::<EventFlags>();
+    assert_send::<EventFlags>();
+    assert_sync::<EventFlags>();
+
+    // DeviceProperties
+    assert_clone::<DeviceProperties>();
+    assert_send::<DeviceProperties>();
+    assert_sync::<DeviceProperties>();
+
+    // RAII handles
+    assert_send::<Stream>();
+    assert_sync::<Stream>();
+
+    assert_send::<Event>();
+    assert_sync::<Event>();
+
+    assert_clone::<Module>();
+    assert_send::<Module>();
+    assert_sync::<Module>();
+
+    assert_clone::<Function>();
+    assert_send::<Function>();
+    assert_sync::<Function>();
+
+    assert_send::<Graph>();
+    assert_sync::<Graph>();
+
+    assert_send::<GraphExec>();
+    assert_sync::<GraphExec>();
+
+    assert_send::<DeviceBuffer>();
+    assert_sync::<DeviceBuffer>();
+
+    assert_send::<HostBuffer>();
+    assert_sync::<HostBuffer>();
+
+    assert_send::<HipLibrary>();
+    assert_sync::<HipLibrary>();
+
+    // HipError: Must implement Clone
+    assert_clone::<HipError>();
+    assert_send::<HipError>();
+    assert_sync::<HipError>();
+    assert_display::<HipError>();
+}

--- a/crates/r9v-hip/tests/common/mod.rs
+++ b/crates/r9v-hip/tests/common/mod.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Test fixtures and stub compilation helpers for r9v-hip (Spec 14 §2, §3).
+
+use std::fs;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+unsafe extern "C" {
+    fn flock(fd: std::os::raw::c_int, operation: std::os::raw::c_int) -> std::os::raw::c_int;
+}
+
+const LOCK_EX: std::os::raw::c_int = 2;
+const LOCK_UN: std::os::raw::c_int = 8;
+
+static STUB_COUNTER: AtomicUsize = AtomicUsize::new(1);
+
+/// Returns paths to (complete_stub_so, missing_symbols_stub_so).
+///
+/// Uses an advisory file lock and atomic rename to avoid cross-test-binary races.
+pub fn get_or_compile_stubs() -> (PathBuf, PathBuf) {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let stub_src = manifest_dir.join("tests/fixtures/stub_hip.c");
+    let target_dir = manifest_dir
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("target/test-fixtures");
+    fs::create_dir_all(&target_dir).expect("failed to create target/test-fixtures dir");
+
+    let lock_file_path = target_dir.join(".stub_build.lock");
+    let lock_file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_file_path)
+        .expect("failed to open stub build lock file");
+
+    unsafe {
+        flock(lock_file.as_raw_fd(), LOCK_EX);
+    }
+
+    let complete_so = target_dir.join("libamdhip64_complete.so");
+    let missing_so = target_dir.join("libamdhip64_missing.so");
+
+    if !complete_so.is_file() {
+        compile_so(&stub_src, &complete_so, &target_dir, &[]);
+    }
+
+    if !missing_so.is_file() {
+        compile_so(
+            &stub_src,
+            &missing_so,
+            &target_dir,
+            &["-DOMIT_HIP_GRAPH_LAUNCH"],
+        );
+    }
+
+    unsafe {
+        flock(lock_file.as_raw_fd(), LOCK_UN);
+    }
+
+    (complete_so, missing_so)
+}
+
+fn compile_so(src: &Path, dst: &Path, temp_dir: &Path, extra_flags: &[&str]) {
+    let count = STUB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let tmp_dst = temp_dir.join(format!(
+        "{}.tmp.{}.{}",
+        dst.file_name().unwrap().to_string_lossy(),
+        pid,
+        count
+    ));
+
+    let mut cmd = Command::new("gcc");
+    cmd.args([
+        "-shared",
+        "-fPIC",
+        "-O2",
+        "-o",
+        tmp_dst.to_str().unwrap(),
+        src.to_str().unwrap(),
+    ]);
+    for flag in extra_flags {
+        cmd.arg(flag);
+    }
+
+    let output = cmd
+        .output()
+        .expect("failed to invoke gcc to build stub libamdhip64");
+    if !output.status.success() {
+        panic!(
+            "gcc failed to compile stub shared library: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fs::rename(&tmp_dst, dst).expect("failed to atomically rename stub shared library");
+}

--- a/crates/r9v-hip/tests/fixtures/stub_hip.c
+++ b/crates/r9v-hip/tests/fixtures/stub_hip.c
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// Stub libamdhip64 for deterministic hosted testing of r9v-hip (Spec 14 §2, §3).
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef int hipError_t;
+#define HIP_SUCCESS 0
+#define HIP_ERROR_INVALID_DEVICE 101
+#define HIP_ERROR_OUT_OF_MEMORY 2
+#define HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED 704
+#define HIP_ERROR_PEER_ACCESS_NOT_ENABLED 705
+
+// Mock device properties struct (1472 bytes)
+typedef struct {
+    char name[256];
+    uint8_t uuid[16];
+    char luid[8];
+    uint32_t luid_device_node_mask;
+    uint8_t _pad0[4];
+    size_t totalGlobalMem;
+    size_t sharedMemPerBlock;
+    int regsPerBlock;
+    int warpSize;
+    size_t memPitch;
+    int maxThreadsPerBlock;
+    int maxThreadsDim[3];
+    int maxGridSize[3];
+    int clockRate;
+    size_t totalConstMem;
+    int major;
+    int minor;
+    size_t textureAlignment;
+    size_t texturePitchAlignment;
+    int deviceOverlap;
+    int multiProcessorCount;
+    int kernelExecTimeoutEnabled;
+    int integrated;
+    int canMapHostMemory;
+    int computeMode;
+    uint8_t _gap_to_concurrent[168];
+    int concurrentKernels;
+    int ECCEnabled;
+    int pciBusID;
+    int pciDeviceID;
+    int pciDomainID;
+    uint8_t _gap_to_multi_gpu[60];
+    int isMultiGpuBoard;
+    uint8_t _gap_to_cooperative[28];
+    int cooperativeLaunch;
+    uint8_t _gap_to_arch[468];
+    char gcnArchName[256];
+    uint8_t _gap_end[56];
+} MockDeviceProp;
+
+hipError_t hipGetDeviceCount(int *count) {
+    if (!count) return 1;
+    *count = 2;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipSetDevice(int device) {
+    if (device < 0 || device >= 2) {
+        return HIP_ERROR_INVALID_DEVICE;
+    }
+    return HIP_SUCCESS;
+}
+
+hipError_t hipGetDevice(int *device) {
+    if (!device) return 1;
+    *device = 0;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipGetDevicePropertiesR0600(void *prop_ptr, int device) {
+    if (!prop_ptr) return 1;
+    if (device < 0 || device >= 2) return HIP_ERROR_INVALID_DEVICE;
+
+    MockDeviceProp *prop = (MockDeviceProp *)prop_ptr;
+    memset(prop, 0, sizeof(MockDeviceProp));
+    strncpy(prop->name, "Stub AMD Radeon AI PRO R9700", sizeof(prop->name) - 1);
+    strncpy(prop->gcnArchName, "amdgcn-amd-amdhsa--gfx1201", sizeof(prop->gcnArchName) - 1);
+    prop->totalGlobalMem = 34359738368ULL; // 32 GiB
+    prop->sharedMemPerBlock = 65536;
+    prop->regsPerBlock = 512;
+    prop->warpSize = 32;
+    prop->maxThreadsPerBlock = 1024;
+    prop->maxThreadsDim[0] = 1024;
+    prop->maxThreadsDim[1] = 1024;
+    prop->maxThreadsDim[2] = 1024;
+    prop->maxGridSize[0] = 2147483647;
+    prop->maxGridSize[1] = 65535;
+    prop->maxGridSize[2] = 65535;
+    prop->clockRate = 2400000;
+    prop->major = 12;
+    prop->minor = 0;
+    prop->multiProcessorCount = 64;
+    prop->pciBusID = 3;
+    prop->pciDeviceID = 0;
+    prop->pciDomainID = 0;
+    prop->isMultiGpuBoard = 0;
+    prop->canMapHostMemory = 1;
+    prop->concurrentKernels = 1;
+    prop->ECCEnabled = 1;
+    prop->cooperativeLaunch = 1;
+
+    return HIP_SUCCESS;
+}
+
+const char *hipGetErrorString(hipError_t error) {
+    if (error == HIP_SUCCESS) return "hipSuccess";
+    if (error == HIP_ERROR_INVALID_DEVICE) return "hipErrorInvalidDevice";
+    if (error == HIP_ERROR_OUT_OF_MEMORY) return "hipErrorOutOfMemory";
+    if (error == HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED) return "hipErrorPeerAccessAlreadyEnabled";
+    if (error == HIP_ERROR_PEER_ACCESS_NOT_ENABLED) return "hipErrorPeerAccessNotEnabled";
+    return "hipErrorUnknown";
+}
+
+hipError_t hipMalloc(void **ptr, size_t size) {
+    if (!ptr) return 1;
+    if (size == 0xDEADBEEF) {
+        return HIP_ERROR_OUT_OF_MEMORY;
+    }
+    *ptr = calloc(1, size ? size : 1);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipFree(void *ptr) {
+    if (ptr) free(ptr);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipHostMalloc(void **ptr, size_t size, unsigned int flags) {
+    (void)flags;
+    if (!ptr) return 1;
+    *ptr = calloc(1, size ? size : 1);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipHostFree(void *ptr) {
+    if (ptr) free(ptr);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipMemcpy(void *dst, const void *src, size_t count, int kind) {
+    (void)kind;
+    if (!dst || !src) return 1;
+    memmove(dst, src, count);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipMemcpyAsync(void *dst, const void *src, size_t count, int kind, void *stream) {
+    (void)stream;
+    return hipMemcpy(dst, src, count, kind);
+}
+
+hipError_t hipMemcpyPeerAsync(void *dst, int dst_dev, const void *src, int src_dev, size_t count, void *stream) {
+    (void)dst_dev;
+    (void)src_dev;
+    (void)stream;
+    return hipMemcpy(dst, src, count, 3);
+}
+
+hipError_t hipStreamCreate(void **stream) {
+    if (!stream) return 1;
+    *stream = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+hipError_t hipStreamCreateWithFlags(void **stream, unsigned int flags) {
+    (void)flags;
+    return hipStreamCreate(stream);
+}
+
+hipError_t hipStreamDestroy(void *stream) {
+    if (stream) free(stream);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipStreamSynchronize(void *stream) {
+    (void)stream;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipStreamQuery(void *stream) {
+    (void)stream;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipStreamWaitEvent(void *stream, void *event, unsigned int flags) {
+    (void)stream;
+    (void)event;
+    (void)flags;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipEventCreate(void **event) {
+    if (!event) return 1;
+    *event = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+hipError_t hipEventCreateWithFlags(void **event, unsigned int flags) {
+    (void)flags;
+    return hipEventCreate(event);
+}
+
+hipError_t hipEventDestroy(void *event) {
+    if (event) free(event);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipEventRecord(void *event, void *stream) {
+    (void)event;
+    (void)stream;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipEventSynchronize(void *event) {
+    (void)event;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipEventElapsedTime(float *ms, void *start, void *stop) {
+    (void)start;
+    (void)stop;
+    if (!ms) return 1;
+    *ms = 1.25f;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipEventQuery(void *event) {
+    (void)event;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipModuleLoad(void **module, const char *fname) {
+    (void)fname;
+    if (!module) return 1;
+    *module = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+hipError_t hipModuleLoadData(void **module, const void *image) {
+    (void)image;
+    if (!module) return 1;
+    *module = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+hipError_t hipModuleUnload(void *module) {
+    if (module) free(module);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipModuleGetFunction(void **func, void *module, const char *name) {
+    (void)module;
+    (void)name;
+    if (!func) return 1;
+    *func = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+hipError_t hipModuleLaunchKernel(void *func, unsigned int gx, unsigned int gy, unsigned int gz,
+                                unsigned int bx, unsigned int by, unsigned int bz,
+                                unsigned int sm, void *stream, void **params, void **extra) {
+    (void)func; (void)gx; (void)gy; (void)gz; (void)bx; (void)by; (void)bz;
+    (void)sm; (void)stream; (void)params; (void)extra;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipStreamBeginCapture(void *stream, int mode) {
+    (void)stream; (void)mode;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipStreamEndCapture(void *stream, void **graph) {
+    (void)stream;
+    if (!graph) return 1;
+    *graph = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+hipError_t hipGraphInstantiate(void **exec, void *graph, void **err_node, char *log_buf, size_t buf_size) {
+    (void)graph; (void)err_node; (void)log_buf; (void)buf_size;
+    if (!exec) return 1;
+    *exec = malloc(sizeof(int));
+    return HIP_SUCCESS;
+}
+
+#ifndef OMIT_HIP_GRAPH_LAUNCH
+hipError_t hipGraphLaunch(void *exec, void *stream) {
+    (void)exec; (void)stream;
+    return HIP_SUCCESS;
+}
+#endif
+
+hipError_t hipGraphDestroy(void *graph) {
+    if (graph) free(graph);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipGraphExecDestroy(void *exec) {
+    if (exec) free(exec);
+    return HIP_SUCCESS;
+}
+
+hipError_t hipDeviceCanAccessPeer(int *can_access, int device, int peer_device) {
+    (void)device; (void)peer_device;
+    if (!can_access) return 1;
+    *can_access = 1;
+    return HIP_SUCCESS;
+}
+
+static int g_peer_access_enabled[2] = {0, 0};
+
+hipError_t hipDeviceEnablePeerAccess(int peer_device, unsigned int flags) {
+    (void)flags;
+    if (peer_device < 0 || peer_device >= 2) return HIP_ERROR_INVALID_DEVICE;
+    if (g_peer_access_enabled[peer_device]) {
+        return HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED;
+    }
+    g_peer_access_enabled[peer_device] = 1;
+    return HIP_SUCCESS;
+}
+
+hipError_t hipDeviceDisablePeerAccess(int peer_device) {
+    if (peer_device < 0 || peer_device >= 2) return HIP_ERROR_INVALID_DEVICE;
+    if (!g_peer_access_enabled[peer_device]) {
+        return HIP_ERROR_PEER_ACCESS_NOT_ENABLED;
+    }
+    g_peer_access_enabled[peer_device] = 0;
+    return HIP_SUCCESS;
+}

--- a/crates/r9v-hip/tests/gpu/empty_kernel.hip
+++ b/crates/r9v-hip/tests/gpu/empty_kernel.hip
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Empty kernel fixture for real GPU smoke verification (Spec 4 §10, Spec 14 §3).
+
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ void empty_kernel() {
+    // Intentionally empty kernel for runtime launch verification
+}

--- a/crates/r9v-hip/tests/gpu/mod.rs
+++ b/crates/r9v-hip/tests/gpu/mod.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Real GPU smoke test implementation (Spec 4 §10, Spec 5 §7, Spec 14 §2, §3).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use r9v_hip::{
+    DeviceBuffer, Event, Graph, HipError, HipLibrary, Module, Stream, StreamCaptureMode,
+};
+
+/// Finds the ROCm LLVM bin directory containing `clang++` and `clang-offload-bundler`.
+///
+/// Searches only explicit `ROCM_PATH` or `/opt/rocm` (Spec 14 §3).
+fn find_rocm_llvm_bin() -> Option<PathBuf> {
+    if let Ok(rocm_path) = std::env::var("ROCM_PATH") {
+        let base = PathBuf::from(&rocm_path);
+        let p = base.join("lib/llvm/bin");
+        if p.is_dir() {
+            return Some(p);
+        }
+        let p_bin = base.join("bin");
+        if p_bin.is_dir() {
+            return Some(p_bin);
+        }
+    }
+    let opt_p = PathBuf::from("/opt/rocm/lib/llvm/bin");
+    if opt_p.is_dir() {
+        return Some(opt_p);
+    }
+    let opt_bin = PathBuf::from("/opt/rocm/bin");
+    if opt_bin.is_dir() {
+        return Some(opt_bin);
+    }
+    None
+}
+
+/// Finds the ROCm device bitcode directory if present under `ROCM_PATH` or `/opt/rocm` (Spec 14 §3).
+fn find_rocm_device_lib() -> Option<PathBuf> {
+    if let Ok(rocm_path) = std::env::var("ROCM_PATH") {
+        let base = PathBuf::from(&rocm_path);
+        for sub in [
+            "lib/llvm/amdgcn/bitcode",
+            "amdgcn/bitcode",
+            "lib/amdgcn/bitcode",
+        ] {
+            let p = base.join(sub);
+            if p.is_dir() {
+                return Some(p);
+            }
+        }
+    }
+    for cand in [
+        "/opt/rocm/lib/llvm/amdgcn/bitcode",
+        "/opt/rocm/amdgcn/bitcode",
+        "/opt/rocm/lib/amdgcn/bitcode",
+    ] {
+        let p = PathBuf::from(cand);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Runs the complete real GPU smoke test sequence on hardware runners (Spec 14 §3).
+///
+/// When no HIP runtime library or zero GPU devices are present, reports an explicit skip.
+/// When hardware is present, any failure panics immediately.
+pub fn run_gpu_smoke() {
+    let lib = match HipLibrary::default_or_load() {
+        Ok(l) => l,
+        Err(HipError::LibraryNotFound { searched }) => {
+            println!(
+                "[SKIP] HIP dynamic library not available on this host; searched: {searched:?}"
+            );
+            return;
+        }
+        Err(e) => {
+            panic!("failed to load HIP dynamic library: {e}");
+        }
+    };
+
+    let count = lib
+        .device_count()
+        .expect("device_count query failed after HIP library load");
+    if count == 0 {
+        println!("[SKIP] No HIP GPU devices available on this host (device count == 0)");
+        return;
+    }
+
+    println!("=== Real GPU Smoke Test (Spec 14 §3) ===");
+    println!("Discovered {count} HIP device(s)");
+
+    // 1. Device 0 Properties and Configuration
+    lib.set_device(0).expect("failed to set active device to 0");
+    let current_dev = lib.get_device().expect("failed to get active device");
+    assert_eq!(current_dev, 0);
+
+    let props0 = lib
+        .get_device_properties(0)
+        .expect("failed to get properties for device 0");
+    println!(
+        "Device 0: {} [arch: {}, VRAM: {} GiB, CUs: {}, PCIe: {:02x}:{:02x}.0]",
+        props0.name,
+        props0.gcn_arch_name,
+        props0.total_global_mem / (1024 * 1024 * 1024),
+        props0.multi_processor_count,
+        props0.pci_bus_id,
+        props0.pci_device_id
+    );
+
+    // Derive architecture strictly from device properties without fallback
+    let arch = match props0.gcn_arch_name.find("gfx") {
+        Some(idx) => {
+            let candidate = &props0.gcn_arch_name[idx..];
+            let end = candidate
+                .find(|c: char| !c.is_alphanumeric())
+                .unwrap_or(candidate.len());
+            &candidate[..end]
+        }
+        None => {
+            panic!(
+                "device 0 gcn_arch_name {:?} does not contain an identifiable gfx architecture",
+                props0.gcn_arch_name
+            );
+        }
+    };
+
+    // 2. Linear Memory Allocation on Device 0
+    const BUFFER_SIZE: usize = 4096;
+    let mut dev_buf0_a = DeviceBuffer::allocate(&lib, BUFFER_SIZE)
+        .expect("failed to allocate dev_buf0_a on device 0");
+    let mut dev_buf0_b = DeviceBuffer::allocate(&lib, BUFFER_SIZE)
+        .expect("failed to allocate dev_buf0_b on device 0");
+    assert_eq!(dev_buf0_a.size(), BUFFER_SIZE);
+    assert_eq!(dev_buf0_b.size(), BUFFER_SIZE);
+
+    let stream0 = Stream::new(&lib).expect("failed to create HIP stream on device 0");
+
+    // 3. Host-to-Device Copy on Device 0
+    let mut host_send = vec![0u8; BUFFER_SIZE];
+    for (i, byte) in host_send.iter_mut().enumerate() {
+        *byte = ((i * 31 + 7) & 0xFF) as u8;
+    }
+
+    unsafe {
+        dev_buf0_a
+            .copy_from_host_async(&host_send, &stream0)
+            .expect("copy_from_host_async on device 0 failed");
+    }
+    stream0
+        .synchronize()
+        .expect("stream0 synchronize after H2D failed");
+
+    // 4. Peer Transfer Branch (Device 0 -> Device 1)
+    let can_access_peer = if count >= 2 {
+        lib.device_can_access_peer(0, 1)
+            .expect("failed to query peer-access capability")
+    } else {
+        false
+    };
+
+    if can_access_peer {
+        println!(
+            "Peer access supported between Device 0 and Device 1; exercising isolated peer path"
+        );
+
+        lib.device_enable_peer_access(1, 0)
+            .expect("failed to enable peer access on device 0 to device 1");
+
+        lib.set_device(1).expect("failed to switch to device 1");
+        let mut peer_buf1 = DeviceBuffer::allocate(&lib, BUFFER_SIZE)
+            .expect("failed to allocate peer_buf1 on device 1");
+
+        lib.set_device(0)
+            .expect("failed to switch back to device 0");
+
+        // Peer copy on device-0 stream
+        unsafe {
+            dev_buf0_a
+                .copy_to_peer_async(0, &mut peer_buf1, 1, &stream0)
+                .expect("copy_to_peer_async from device 0 to device 1 failed");
+        }
+        stream0
+            .synchronize()
+            .expect("stream0 synchronize after peer copy failed");
+
+        // Switch to device 1 to read and verify peer buffer using device-1 stream
+        lib.set_device(1)
+            .expect("failed to switch to device 1 for D2H");
+        let stream1 = Stream::new(&lib).expect("failed to create stream1 on device 1");
+        let mut host_recv_peer = vec![0u8; BUFFER_SIZE];
+
+        unsafe {
+            peer_buf1
+                .copy_to_host_async(&mut host_recv_peer, &stream1)
+                .expect("peer copy_to_host_async on device 1 failed");
+        }
+        stream1
+            .synchronize()
+            .expect("stream1 synchronize after D2H failed");
+        assert_eq!(
+            host_send, host_recv_peer,
+            "peer transfer bytes on device 1 do not match original host data"
+        );
+        println!("Peer transfer verification passed ({BUFFER_SIZE} bytes bit-identical)");
+
+        // Drop peer resources while active context is device 1
+        drop(peer_buf1);
+        drop(stream1);
+
+        // Switch back to device 0 for subsequent single-device tests
+        lib.set_device(0)
+            .expect("failed to switch back to device 0");
+    } else {
+        println!("Multi-GPU peer access not available; skipping peer transfer test");
+    }
+
+    // 5. Device-to-Device Copy on Device 0
+    unsafe {
+        dev_buf0_a
+            .copy_to_device_async(&mut dev_buf0_b, &stream0)
+            .expect("copy_to_device_async on device 0 failed");
+    }
+
+    let mut host_recv_d2d = vec![0u8; BUFFER_SIZE];
+    unsafe {
+        dev_buf0_b
+            .copy_to_host_async(&mut host_recv_d2d, &stream0)
+            .expect("copy_to_host_async after D2D failed");
+    }
+    stream0
+        .synchronize()
+        .expect("stream0 synchronize after D2D failed");
+    assert_eq!(
+        host_send, host_recv_d2d,
+        "D2D memory transfer bytes do not match original host data"
+    );
+    println!("D2D copy verification passed ({BUFFER_SIZE} bytes bit-identical on Device 0)");
+
+    // 6. Event Lifecycle & Timing on Device 0
+    let event_start = Event::new(&lib).expect("failed to create start event");
+    let event_stop = Event::new(&lib).expect("failed to create stop event");
+
+    event_start
+        .record(&stream0)
+        .expect("failed to record start event");
+    unsafe {
+        dev_buf0_a
+            .copy_to_device_async(&mut dev_buf0_b, &stream0)
+            .expect("copy_to_device_async during event timing failed");
+    }
+    event_stop
+        .record(&stream0)
+        .expect("failed to record stop event");
+    event_stop
+        .synchronize()
+        .expect("failed to synchronize stop event");
+
+    let elapsed_ms = event_stop
+        .elapsed_since(&event_start)
+        .expect("failed to measure elapsed time between events");
+    assert!(elapsed_ms >= 0.0);
+    println!("Event timing lifecycle passed ({elapsed_ms:.4} ms)");
+
+    // 7. Compile, Load, Get, and Launch empty kernel (Spec 4 §10, Spec 14 §3)
+    let llvm_bin = find_rocm_llvm_bin().unwrap_or_else(|| {
+        panic!("ROCm LLVM compiler toolchain (clang++, clang-offload-bundler) not found in ROCM_PATH or /opt/rocm");
+    });
+    let clang = llvm_bin.join("clang++");
+    let bundler = llvm_bin.join("clang-offload-bundler");
+    assert!(clang.is_file(), "clang++ not found at {}", clang.display());
+    assert!(
+        bundler.is_file(),
+        "clang-offload-bundler not found at {}",
+        bundler.display()
+    );
+    println!(
+        "Found ROCm LLVM compiler toolchain at: {}",
+        llvm_bin.display()
+    );
+
+    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("target/test-fixtures");
+    let _ = std::fs::create_dir_all(&target_dir);
+    let hip_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/gpu/empty_kernel.hip");
+    assert!(
+        hip_src.is_file(),
+        "committed empty_kernel.hip fixture not found at {}",
+        hip_src.display()
+    );
+
+    let bundle_path = target_dir.join(format!("empty_bundle_{arch}.o"));
+    let co_path = target_dir.join(format!("empty_kernel_{arch}.co"));
+
+    let mut compile_cmd = Command::new(&clang);
+    compile_cmd.args([
+        "-x",
+        "hip",
+        &format!("--offload-arch={arch}"),
+        "--offload-device-only",
+        "-O3",
+        "-c",
+        "-o",
+        bundle_path.to_str().unwrap(),
+        hip_src.to_str().unwrap(),
+    ]);
+    if let Ok(rocm_path) = std::env::var("ROCM_PATH") {
+        compile_cmd.arg(format!("--rocm-path={rocm_path}"));
+    }
+    if let Some(dev_lib) = find_rocm_device_lib() {
+        compile_cmd.arg(format!("--rocm-device-lib-path={}", dev_lib.display()));
+    }
+
+    let compile_status = compile_cmd
+        .status()
+        .expect("failed to invoke clang++ to compile empty_kernel.hip");
+    assert!(
+        compile_status.success(),
+        "clang++ failed to compile empty_kernel.hip for architecture {arch}"
+    );
+
+    let unbundle_status = Command::new(&bundler)
+        .args([
+            "--type=o",
+            &format!("--targets=hipv4-amdgcn-amd-amdhsa--{arch}"),
+            &format!("--input={}", bundle_path.display()),
+            &format!("--output={}", co_path.display()),
+            "--unbundle",
+        ])
+        .status()
+        .expect("failed to invoke clang-offload-bundler");
+    assert!(
+        unbundle_status.success(),
+        "clang-offload-bundler failed to unbundle {arch} code object"
+    );
+
+    let module = Module::load_file(&lib, &co_path)
+        .expect("Module::load_file failed for compiled empty kernel");
+    let func = module
+        .get_function("empty_kernel")
+        .expect("Module::get_function failed for 'empty_kernel'");
+
+    // Derive launch dimensions dynamically from device properties
+    let block_threads = props0.warp_size.max(1) as u32;
+    unsafe {
+        func.launch((1, 1, 1), (block_threads, 1, 1), 0, &stream0, &mut [])
+            .expect("func.launch failed");
+    }
+    stream0
+        .synchronize()
+        .expect("stream0 synchronize after kernel launch failed");
+    println!("Empty kernel compiled and launched successfully on {arch} with block size {block_threads}!");
+
+    // 8. Graph capture, instantiate, and launch on Device 0
+    Graph::begin_capture(&stream0, StreamCaptureMode::Global).expect("begin_capture failed");
+    unsafe {
+        dev_buf0_a
+            .copy_to_device_async(&mut dev_buf0_b, &stream0)
+            .expect("copy in graph capture failed");
+    }
+    let graph = Graph::end_capture(&stream0).expect("end_capture failed");
+
+    let graph_exec = graph.instantiate().expect("graph.instantiate failed");
+    unsafe {
+        graph_exec
+            .launch(&stream0)
+            .expect("graph_exec.launch failed");
+    }
+    stream0
+        .synchronize()
+        .expect("stream0 synchronize after graph execution failed");
+    println!("Graph capture, instantiate, and launch passed on Device 0!");
+
+    println!("=== Real GPU Smoke Test Succeeded ===");
+}

--- a/crates/r9v-hip/tests/gpu_smoke.rs
+++ b/crates/r9v-hip/tests/gpu_smoke.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration test entry point for real GPU smoke path (Spec 14 §2, §3).
+
+mod gpu;
+
+#[test]
+fn test_real_gpu_smoke_suite() {
+    gpu::run_gpu_smoke();
+}

--- a/crates/r9v-hip/tests/test_device.rs
+++ b/crates/r9v-hip/tests/test_device.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests proving Device enum behavior and properties (Spec 5 §3.4, Spec 14 §2, §3).
+
+use r9v_hip::Device;
+use std::collections::{BTreeSet, HashSet};
+
+#[test]
+fn test_device_enum_variants_and_accessors() {
+    let cpu = Device::cpu();
+    assert!(cpu.is_cpu());
+    assert!(!cpu.is_hip());
+    assert_eq!(cpu.hip_rank(), None);
+    assert_eq!(format!("{cpu}"), "cpu");
+
+    let hip0 = Device::hip(0);
+    assert!(!hip0.is_cpu());
+    assert!(hip0.is_hip());
+    assert_eq!(hip0.hip_rank(), Some(0));
+    assert_eq!(format!("{hip0}"), "hip:0");
+
+    let hip1 = Device::hip(1);
+    assert!(!hip1.is_cpu());
+    assert!(hip1.is_hip());
+    assert_eq!(hip1.hip_rank(), Some(1));
+    assert_eq!(format!("{hip1}"), "hip:1");
+}
+
+#[test]
+fn test_device_ordering_and_collections() {
+    let cpu = Device::Cpu;
+    let hip0 = Device::Hip(0);
+    let hip1 = Device::Hip(1);
+
+    // Ordering: Cpu < Hip(0) < Hip(1)
+    assert!(cpu < hip0);
+    assert!(hip0 < hip1);
+
+    let mut btree = BTreeSet::new();
+    btree.insert(hip1);
+    btree.insert(cpu);
+    btree.insert(hip0);
+
+    let sorted: Vec<_> = btree.into_iter().collect();
+    assert_eq!(sorted, vec![Device::Cpu, Device::Hip(0), Device::Hip(1)]);
+
+    let mut set = HashSet::new();
+    set.insert(Device::Cpu);
+    set.insert(Device::Hip(0));
+    assert_eq!(set.len(), 2);
+    assert!(set.contains(&Device::Cpu));
+    assert!(set.contains(&Device::Hip(0)));
+}

--- a/crates/r9v-hip/tests/test_error_mapping.rs
+++ b/crates/r9v-hip/tests/test_error_mapping.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests proving nonzero hipError_t maps to typed error with operation and numeric code (Spec 14 §2, §3).
+
+mod common;
+
+use r9v_hip::{HipError, HipLibrary};
+use std::sync::Arc;
+
+#[test]
+fn test_nonzero_hiperror_maps_to_operation_and_numeric_code() {
+    let (complete_so, _) = common::get_or_compile_stubs();
+    let lib =
+        Arc::new(HipLibrary::load_from_path(&complete_so).expect("failed to load complete stub"));
+
+    // 1. Trigger hipErrorInvalidDevice (101) via set_device(999)
+    let err1 = lib.set_device(999).expect_err("set_device(999) must fail");
+    match &err1 {
+        HipError::ApiError { op, code, message } => {
+            assert_eq!(*op, "hipSetDevice");
+            assert_eq!(*code, 101);
+            assert!(
+                message.contains("hipErrorInvalidDevice"),
+                "message must contain driver description: {message}"
+            );
+        }
+        other => panic!("expected ApiError, got: {:?}", other),
+    }
+
+    let display1 = format!("{err1}");
+    assert!(
+        display1.contains("hipSetDevice"),
+        "Display must contain operation name 'hipSetDevice': {display1}"
+    );
+    assert!(
+        display1.contains("101"),
+        "Display must contain numeric status code '101': {display1}"
+    );
+
+    // 2. Trigger hipErrorOutOfMemory (2) via malloc(0xDEADBEEF)
+    let err2 = lib
+        .malloc(0xDEADBEEF)
+        .expect_err("malloc(0xDEADBEEF) must fail");
+    match &err2 {
+        HipError::ApiError { op, code, message } => {
+            assert_eq!(*op, "hipMalloc");
+            assert_eq!(*code, 2);
+            assert!(
+                message.contains("hipErrorOutOfMemory"),
+                "message must contain driver description: {message}"
+            );
+        }
+        other => panic!("expected ApiError, got: {:?}", other),
+    }
+
+    let display2 = format!("{err2}");
+    assert!(
+        display2.contains("hipMalloc"),
+        "Display must contain operation name 'hipMalloc': {display2}"
+    );
+    assert!(
+        display2.contains("2"),
+        "Display must contain numeric status code '2': {display2}"
+    );
+}
+
+#[test]
+fn test_result_type_alias_interop() {
+    fn produces_result() -> r9v_hip::Result<u32> {
+        Ok(42)
+    }
+
+    let val = produces_result().expect("Result type alias must behave normally");
+    assert_eq!(val, 42);
+}

--- a/crates/r9v-hip/tests/test_lazy_symbols.rs
+++ b/crates/r9v-hip/tests/test_lazy_symbols.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests proving lazy symbol resolution and cached dispatch (Spec 14 §2, §3).
+
+mod common;
+
+use r9v_hip::{HipError, HipLibrary};
+use std::sync::Arc;
+
+#[test]
+fn test_symbol_lookup_is_actually_lazy() {
+    let (_, missing_so) = common::get_or_compile_stubs();
+
+    // 1. Loading the library succeeds even though hipGraphLaunch is intentionally omitted
+    let lib = HipLibrary::load_from_path(&missing_so)
+        .expect("library load must succeed even with omitted symbols when lazy");
+    let lib_arc = Arc::new(lib);
+
+    // 2. Symbols that ARE present resolve and execute successfully
+    let count = lib_arc
+        .device_count()
+        .expect("present symbol hipGetDeviceCount must succeed");
+    assert_eq!(count, 2);
+
+    let dev_id = lib_arc
+        .get_device()
+        .expect("present symbol hipGetDevice must succeed");
+    assert_eq!(dev_id, 0);
+
+    let ptr = lib_arc
+        .malloc(128)
+        .expect("present symbol hipMalloc must succeed");
+    assert!(!ptr.is_null());
+    unsafe {
+        lib_arc
+            .free(ptr)
+            .expect("present symbol hipFree must succeed");
+    }
+
+    // 3. Invoking the intentionally omitted symbol (hipGraphLaunch) fails with typed SymbolNotFound
+    let launch_result = unsafe { lib_arc.graph_launch(std::ptr::null_mut(), std::ptr::null_mut()) };
+    match launch_result {
+        Err(HipError::SymbolNotFound { symbol, details }) => {
+            assert_eq!(symbol, "hipGraphLaunch");
+            assert!(
+                details.contains("libamdhip64_missing.so"),
+                "details must mention the library path: {details}"
+            );
+        }
+        Err(other) => {
+            panic!("expected HipError::SymbolNotFound, but got: {:?}", other);
+        }
+        Ok(_) => {
+            panic!("calling missing symbol must fail");
+        }
+    }
+}

--- a/crates/r9v-hip/tests/test_library_absence.rs
+++ b/crates/r9v-hip/tests/test_library_absence.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests proving typed error handling for library absence (Spec 14 §2, §3).
+
+use r9v_hip::{HipError, HipLibrary};
+use std::path::Path;
+
+#[test]
+fn test_library_absence_is_typed() {
+    let fake_path = Path::new("/nonexistent/directory/libamdhip64.so.7");
+    let result = HipLibrary::load_from_path(fake_path);
+
+    match result {
+        Err(HipError::LibraryNotFound { searched }) => {
+            assert!(
+                !searched.is_empty(),
+                "searched paths should record the attempted candidate"
+            );
+            assert!(
+                searched[0].contains("libamdhip64.so.7"),
+                "searched record should cite target library: {:?}",
+                searched
+            );
+        }
+        Err(other) => {
+            panic!("expected HipError::LibraryNotFound, but got: {:?}", other);
+        }
+        Ok(_) => {
+            panic!("loading nonexistent library should not succeed");
+        }
+    }
+}

--- a/crates/r9v-hip/tests/test_stub_coverage.rs
+++ b/crates/r9v-hip/tests/test_stub_coverage.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests proving full symbol coverage and signature dispatch against complete stub (Spec 14 §2, §3).
+
+mod common;
+
+use r9v_hip::{
+    DeviceBuffer, Event, EventFlags, Graph, HipError, HipLibrary, HostBuffer, MemcpyKind, Module,
+    Stream, StreamCaptureMode, StreamFlags,
+};
+use std::ffi::c_void;
+use std::path::Path;
+use std::sync::Arc;
+
+#[test]
+fn test_every_required_symbol_is_forced_against_complete_stub() {
+    let (complete_so, _) = common::get_or_compile_stubs();
+    let lib = Arc::new(
+        HipLibrary::load_from_path(&complete_so).expect("failed to load complete stub libamdhip64"),
+    );
+
+    // 1. Device Count, Device Set/Get, Device Properties
+    let count = lib.device_count().expect("device_count failed");
+    assert_eq!(count, 2);
+
+    lib.set_device(0).expect("set_device(0) failed");
+    let current_dev = lib.get_device().expect("get_device failed");
+    assert_eq!(current_dev, 0);
+
+    let props = lib
+        .get_device_properties(0)
+        .expect("get_device_properties failed");
+    assert_eq!(props.name, "Stub AMD Radeon AI PRO R9700");
+    assert_eq!(props.gcn_arch_name, "amdgcn-amd-amdhsa--gfx1201");
+    assert_eq!(props.total_global_mem, 34359738368);
+    assert_eq!(props.warp_size, 32);
+    assert_eq!(props.major, 12);
+    assert_eq!(props.minor, 0);
+    assert_eq!(props.multi_processor_count, 64);
+    assert_eq!(props.pci_bus_id, 3);
+    assert!(props.can_map_host_memory);
+    assert!(props.ecc_enabled);
+    assert!(props.cooperative_launch);
+
+    // 2. Malloc / Free / HostMalloc / HostFree
+    let dev_ptr = lib.malloc(256).expect("malloc failed");
+    assert!(!dev_ptr.is_null());
+
+    let host_ptr = lib.host_malloc(256, 0).expect("host_malloc failed");
+    assert!(!host_ptr.is_null());
+
+    // 3. Memcpy (sync), MemcpyAsync, MemcpyPeerAsync with MemcpyKind enum
+    let host_data = [0x5Au8; 64];
+    unsafe {
+        lib.memcpy(
+            dev_ptr,
+            host_data.as_ptr() as *const c_void,
+            64,
+            MemcpyKind::Default,
+        )
+        .expect("memcpy failed");
+    }
+
+    // 4. Stream lifecycle & query & wait with StreamFlags enum
+    let raw_stream = lib.stream_create().expect("stream_create failed");
+    let raw_stream_flags = lib
+        .stream_create_with_flags(StreamFlags::NonBlocking)
+        .expect("stream_create_with_flags failed");
+
+    unsafe {
+        lib.memcpy_async(
+            dev_ptr,
+            host_data.as_ptr() as *const c_void,
+            64,
+            MemcpyKind::Default,
+            raw_stream,
+        )
+        .expect("memcpy_async failed");
+
+        lib.memcpy_peer_async(dev_ptr, 0, dev_ptr, 1, 64, raw_stream)
+            .expect("memcpy_peer_async failed");
+
+        lib.stream_synchronize(raw_stream)
+            .expect("stream_synchronize failed");
+        let is_done = lib.stream_query(raw_stream).expect("stream_query failed");
+        assert!(is_done);
+    }
+
+    // 5. Event lifecycle & timing with EventFlags enum
+    let raw_event = lib.event_create().expect("event_create failed");
+    let raw_event_flags = lib
+        .event_create_with_flags(EventFlags::DisableTiming)
+        .expect("event_create_with_flags failed");
+
+    unsafe {
+        lib.event_record(raw_event, raw_stream)
+            .expect("event_record failed");
+        lib.stream_wait_event(raw_stream, raw_event, 0)
+            .expect("stream_wait_event failed");
+        lib.event_synchronize(raw_event)
+            .expect("event_synchronize failed");
+        let event_done = lib.event_query(raw_event).expect("event_query failed");
+        assert!(event_done);
+
+        let raw_event_end = lib.event_create().expect("event_create 2 failed");
+        lib.event_record(raw_event_end, raw_stream)
+            .expect("event_record 2 failed");
+        let elapsed_ms = lib
+            .event_elapsed_time(raw_event, raw_event_end)
+            .expect("event_elapsed_time failed");
+        assert!((elapsed_ms - 1.25).abs() < 1e-4);
+
+        lib.event_destroy(raw_event).expect("event_destroy failed");
+        lib.event_destroy(raw_event_flags)
+            .expect("event_destroy flags failed");
+        lib.event_destroy(raw_event_end)
+            .expect("event_destroy 2 failed");
+
+        lib.stream_destroy(raw_stream)
+            .expect("stream_destroy failed");
+        lib.stream_destroy(raw_stream_flags)
+            .expect("stream_destroy flags failed");
+
+        lib.host_free(host_ptr).expect("host_free failed");
+        lib.free(dev_ptr).expect("free failed");
+    }
+
+    // 6. Module & Function & Launch
+    let raw_mod_file = lib
+        .module_load(Path::new("/dummy/empty.co"))
+        .expect("module_load failed");
+    let dummy_co_bytes = [0x7fu8, b'E', b'L', b'F', 0, 0, 0, 0];
+    let raw_mod_data = lib
+        .module_load_data(&dummy_co_bytes)
+        .expect("module_load_data failed");
+
+    let raw_func = unsafe {
+        lib.module_get_function(raw_mod_data, "test_kernel")
+            .expect("module_get_function failed")
+    };
+
+    let test_stream = lib.stream_create().expect("stream_create failed");
+    let mut args: [*mut c_void; 0] = [];
+    unsafe {
+        lib.module_launch_kernel(raw_func, (1, 1, 1), (32, 1, 1), 0, test_stream, &mut args)
+            .expect("module_launch_kernel failed");
+
+        lib.module_unload(raw_mod_file)
+            .expect("module_unload failed");
+        lib.module_unload(raw_mod_data)
+            .expect("module_unload failed");
+    }
+
+    // 7. Graph Capture, Instantiate, Launch, Destroy with StreamCaptureMode enum
+    unsafe {
+        lib.stream_begin_capture(test_stream, StreamCaptureMode::Global)
+            .expect("stream_begin_capture failed");
+        let raw_graph = lib
+            .stream_end_capture(test_stream)
+            .expect("stream_end_capture failed");
+
+        let raw_graph_exec = lib
+            .graph_instantiate(raw_graph)
+            .expect("graph_instantiate failed");
+
+        lib.graph_launch(raw_graph_exec, test_stream)
+            .expect("graph_launch failed");
+        lib.stream_synchronize(test_stream)
+            .expect("stream_synchronize after graph launch failed");
+
+        lib.graph_exec_destroy(raw_graph_exec)
+            .expect("graph_exec_destroy failed");
+        lib.graph_destroy(raw_graph).expect("graph_destroy failed");
+        lib.stream_destroy(test_stream)
+            .expect("stream_destroy failed");
+    }
+
+    // 8. Peer Access Query / Enable / Disable & Idempotence
+    let can_peer = lib
+        .device_can_access_peer(0, 1)
+        .expect("device_can_access_peer failed");
+    assert!(can_peer);
+
+    // First enable succeeds (HIP_SUCCESS)
+    lib.device_enable_peer_access(1, 0)
+        .expect("first device_enable_peer_access failed");
+
+    // Second enable succeeds idempotently (driver returns 704, library maps to Ok)
+    lib.device_enable_peer_access(1, 0)
+        .expect("idempotent device_enable_peer_access must succeed");
+
+    // First disable succeeds (HIP_SUCCESS)
+    lib.device_disable_peer_access(1)
+        .expect("first device_disable_peer_access failed");
+
+    // Second disable succeeds idempotently (driver returns 705, library maps to Ok)
+    lib.device_disable_peer_access(1)
+        .expect("idempotent device_disable_peer_access must succeed");
+}
+
+#[test]
+fn test_high_level_raii_handles_against_complete_stub() {
+    let (complete_so, _) = common::get_or_compile_stubs();
+    let lib = Arc::new(
+        HipLibrary::load_from_path(&complete_so).expect("failed to load complete stub libamdhip64"),
+    );
+
+    // Stream & Event with typed enums
+    let stream = Stream::with_flags(&lib, StreamFlags::Default).expect("Stream::with_flags failed");
+    let event = Event::with_flags(&lib, EventFlags::Default).expect("Event::with_flags failed");
+    event.record(&stream).expect("event.record failed");
+    stream.wait_event(&event).expect("stream.wait_event failed");
+    event.synchronize().expect("event.synchronize failed");
+    assert!(event.is_complete().expect("is_complete failed"));
+
+    // Buffers & Bounds Verification
+    let mut dev_buf = DeviceBuffer::allocate(&lib, 64).expect("DeviceBuffer::allocate failed");
+    assert_eq!(dev_buf.size(), 64);
+    let host_src = [42u8; 64];
+    dev_buf
+        .copy_from_host(&host_src)
+        .expect("copy_from_host failed");
+
+    let mut host_dst = [0u8; 64];
+    dev_buf
+        .copy_to_host(&mut host_dst)
+        .expect("copy_to_host failed");
+    assert_eq!(host_src, host_dst);
+
+    // Bounds checking: buffer too small must return typed HipError::BufferTooSmall
+    let oversized = [1u8; 128];
+    let err_sync = dev_buf
+        .copy_from_host(&oversized)
+        .expect_err("oversized host copy must fail");
+    match err_sync {
+        HipError::BufferTooSmall {
+            operation,
+            required,
+            available,
+        } => {
+            assert_eq!(operation, "copy_from_host");
+            assert_eq!(required, 128);
+            assert_eq!(available, 64);
+        }
+        other => panic!("expected BufferTooSmall, got: {:?}", other),
+    }
+
+    let mut undersized_host = [0u8; 32];
+    let mut small_dev = DeviceBuffer::allocate(&lib, 32).expect("allocate small_dev failed");
+    unsafe {
+        let err_async = dev_buf
+            .copy_to_device_async(&mut small_dev, &stream)
+            .expect_err("copy_to_device_async into smaller buffer must fail");
+        match err_async {
+            HipError::BufferTooSmall {
+                operation,
+                required,
+                available,
+            } => {
+                assert_eq!(operation, "copy_to_device_async");
+                assert_eq!(required, 64);
+                assert_eq!(available, 32);
+            }
+            other => panic!("expected BufferTooSmall, got: {:?}", other),
+        }
+
+        let err_peer = dev_buf
+            .copy_to_peer_async(0, &mut small_dev, 1, &stream)
+            .expect_err("copy_to_peer_async into smaller buffer must fail");
+        match err_peer {
+            HipError::BufferTooSmall {
+                operation,
+                required,
+                available,
+            } => {
+                assert_eq!(operation, "copy_to_peer_async");
+                assert_eq!(required, 64);
+                assert_eq!(available, 32);
+            }
+            other => panic!("expected BufferTooSmall, got: {:?}", other),
+        }
+
+        let err_host_async = dev_buf
+            .copy_to_host_async(&mut undersized_host, &stream)
+            .expect_err("copy_to_host_async into smaller slice must fail");
+        match err_host_async {
+            HipError::BufferTooSmall {
+                operation,
+                required,
+                available,
+            } => {
+                assert_eq!(operation, "copy_to_host_async");
+                assert_eq!(required, 64);
+                assert_eq!(available, 32);
+            }
+            other => panic!("expected BufferTooSmall, got: {:?}", other),
+        }
+    }
+
+    let mut host_pinned = HostBuffer::allocate(&lib, 64, 0).expect("HostBuffer::allocate failed");
+    host_pinned.as_mut_slice().copy_from_slice(&host_src);
+    assert_eq!(host_pinned.as_slice(), &host_src);
+
+    // Module & Function Lifetime: dropping Module keeps Function alive
+    let func = {
+        let dummy_co = [0x7fu8, b'E', b'L', b'F'];
+        let module = Module::load_data(&lib, &dummy_co).expect("Module::load_data failed");
+        module
+            .get_function("empty_kernel")
+            .expect("get_function failed")
+        // module is dropped here!
+    };
+
+    // Function remains valid and callable because it holds an Arc reference to the module inner allocation
+    let mut args: [*mut c_void; 0] = [];
+    unsafe {
+        func.launch((1, 1, 1), (32, 1, 1), 0, &stream, &mut args)
+            .expect("Function must remain callable after original Module handle is dropped");
+    }
+
+    // Graph & GraphExec with StreamCaptureMode enum
+    Graph::begin_capture(&stream, StreamCaptureMode::Global).expect("begin_capture failed");
+    let graph = Graph::end_capture(&stream).expect("end_capture failed");
+    let graph_exec = graph.instantiate().expect("instantiate failed");
+    unsafe {
+        graph_exec.launch(&stream).expect("launch failed");
+    }
+    stream.synchronize().expect("synchronize failed");
+}

--- a/crates/r9v-hip/tests/test_thread_safety.rs
+++ b/crates/r9v-hip/tests/test_thread_safety.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests proving library lifetime and thread safety traits (Spec 14 §2, §3).
+
+mod common;
+
+use r9v_hip::{
+    DeviceBuffer, Event, Function, Graph, GraphExec, HipLibrary, HostBuffer, Module, Stream,
+};
+use std::sync::Arc;
+use std::thread;
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+
+#[test]
+fn test_thread_traits_statically_enforced() {
+    assert_send::<HipLibrary>();
+    assert_sync::<HipLibrary>();
+
+    assert_send::<Stream>();
+    assert_sync::<Stream>();
+
+    assert_send::<Event>();
+    assert_sync::<Event>();
+
+    assert_send::<Module>();
+    assert_sync::<Module>();
+
+    assert_send::<Function>();
+    assert_sync::<Function>();
+
+    assert_send::<Graph>();
+    assert_sync::<Graph>();
+
+    assert_send::<GraphExec>();
+    assert_sync::<GraphExec>();
+
+    assert_send::<DeviceBuffer>();
+    assert_sync::<DeviceBuffer>();
+
+    assert_send::<HostBuffer>();
+    assert_sync::<HostBuffer>();
+}
+
+#[test]
+fn test_concurrent_multithreaded_library_dispatch() {
+    let (complete_so, _) = common::get_or_compile_stubs();
+    let lib =
+        Arc::new(HipLibrary::load_from_path(&complete_so).expect("failed to load complete stub"));
+
+    let mut handles = Vec::new();
+    for thread_idx in 0..8 {
+        let lib_clone = Arc::clone(&lib);
+        let handle = thread::spawn(move || {
+            for i in 0..50 {
+                let stream = Stream::new(&lib_clone).expect("Stream::new in thread");
+                let event = Event::new(&lib_clone).expect("Event::new in thread");
+                event.record(&stream).expect("Event::record in thread");
+                event.synchronize().expect("Event::sync in thread");
+
+                let mut buf = DeviceBuffer::allocate(&lib_clone, 64)
+                    .expect("DeviceBuffer::allocate in thread");
+                let host_src = [(thread_idx * 10 + (i % 10)) as u8; 64];
+                buf.copy_from_host(&host_src)
+                    .expect("copy_from_host in thread");
+
+                let mut host_dst = [0u8; 64];
+                buf.copy_to_host(&mut host_dst)
+                    .expect("copy_to_host in thread");
+                assert_eq!(host_src, host_dst);
+            }
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().expect("thread panicked");
+    }
+}


### PR DESCRIPTION
## Card
A0.2 — r9v-hip (kind: API; GPU: yes; size: S)

## Spec sections implemented
- spec 14 §2: keeps the HIP boundary isolated in `r9v-hip` with no upward crate dependencies.
- spec 14 §3: runtime-only `libamdhip64` loading, lazy symbol resolution, typed devices/errors, and HIP resource operations.
- spec 4 §10: exposes module loading, function lookup, and kernel launch for the execution boundary.
- spec 6 §2: exposes stream capture and graph instantiate/launch primitives.

## Deliverables
- [x] Runtime `dlopen` of `libamdhip64` without build-time ROCm linkage.
- [x] Lazy, cached device count/property, allocation, transfer, stream, event, module/kernel, graph, and peer-access symbols.
- [x] `Device::{Cpu, Hip(rank)}` and typed crate-local HIP error mapping through `r9v-common::Result`.
- [x] RAII wrappers for streams, events, modules/functions, graphs/executables, and device/host buffers.
- [x] Hosted stub runtime covering successful calls, missing symbols, API failures, lifetimes, and concurrency.
- [x] Real-GPU allocation/copy/empty-kernel/graph/peer smoke test.
- [x] `r9v` remains runnable without ROCm installed or linked.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| stub symbol resolution and error mapping | `crates/r9v-hip/tests/test_lazy_symbols.rs`, `crates/r9v-hip/tests/test_error_mapping.rs`, `crates/r9v-hip/tests/test_stub_coverage.rs` | cpu-only / stub device | green |
| library absence and no-ROCm behavior | `crates/r9v-hip/tests/test_library_absence.rs` plus `ldd target/debug/r9v` | cpu-only | green |
| API shape, device conversion, and thread safety | `crates/r9v-hip/tests/api_shape.rs`, `crates/r9v-hip/tests/test_device.rs`, `crates/r9v-hip/tests/test_thread_safety.rs` | cpu-only / stub device | green |
| allocate, copy, launch empty kernel, graph lifecycle, and peer path | `crates/r9v-hip/tests/gpu_smoke.rs` | gpu | green |

## Decisions
- `crates/r9v-hip/src/error.rs:4` — keep `HipError` crate-local and compose it upward instead of adding HIP-specific variants to foundational `r9v-common`.

## SPEC-ISSUES filed
- none

## New dependencies
- `thiserror = "2.0"`: derives the typed `HipError` surface required by the workspace error convention; the crate already existed in the workspace lockfile through `r9v-common`.

## Hardware
Tests run here: hosted cpu-only stub plus local GPU runner with two AMD Radeon AI PRO R9700 devices (`gfx1201`) and one additional HIP device.
Tests pending on the runner: none
Measured numbers (if any): fingerprint `gfx1201 / AMD Radeon AI PRO R9700 / 31 GiB / 32 CUs`; command `R9V_HIP_PATH=<ROCm SDK>/lib/libamdhip64.so.7 ROCM_PATH=<ROCm SDK> cargo test -p r9v-hip --test gpu_smoke -- --nocapture`; receipt none (functional smoke only, no performance claim)

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- none

## Size check
Diff size vs card size class: 3,752 lines vs S — larger than the estimate because the complete FFI/RAII safety boundary, deterministic C stub, and real-GPU lifecycle test require explicit surface and coverage; the change remains confined to A0.2 with no downstream engine work.
