### PR TITLE
A0.S4: validate HIP graph replay

### DIFF
--- a/spikes/hipgraph/RESULT.md
+++ b/spikes/hipgraph/RESULT.md
@@ -2,26 +2,73 @@
 
 - **Spike ID**: S4 (`hipgraph`)
 - **Card**: A0.S4
-- **Governing Specs**: Spec 6 §2, Spec 14, Roadmap §A0
-- **Status**: [PENDING_RUNNER | PASS | FAIL]
+- **Governing Specs**: Spec 6 §5.2, Spec 14, Roadmap §A0
+- **Status**: PASS
 
 ## Hardware Fingerprint
-- GPU: [e.g. gfx1201]
-- Driver Version:
-- ROCm Version:
+
+- GPU: AMD Radeon AI PRO R9700, `arch=gfx1201` (HIP device 0; Card Model 0x7551, SKU APM107573, Subsystem ID 0x5413, Device Rev 0xc0, Node ID 1, GUID 23334)
+- Driver Version: kernel driver 7.1.5-ogc5.1.fc44.x86_64; HIP driver/runtime 71460850 (7.14.60850)
+- ROCm Version: pinned SDK `/var/mnt/qwen-storage/projects/r9v/engine-src/.pydeps-native-quant-rocm/_rocm_sdk_core`, HIP 7.14.60850, AMD clang 23.0.0git
+- Engine / Memory Clock (observed, demand-scaled): sclk level 1 at 797 MHz pre-run and 1091 MHz post-run, fclk 2128 MHz, socclk 1371 MHz, dcefclk 243 MHz, PCIe 32.0 GT/s x16
+- Second GPU in system (rocm-smi GPU[1]) was idle and untouched; program pins HIP device 0
 
 ## Execution
-- Command: `hipcc -O3 --offload-arch=gfx1201 spikes/hipgraph/hipgraph.hip -o spikes/hipgraph/hipgraph && ./spikes/hipgraph/hipgraph`
+
+- Build: `/var/mnt/qwen-storage/projects/r9v/engine-src/.pydeps-native-quant-rocm/_rocm_sdk_core/bin/hipcc -O3 --offload-arch=gfx1201 --rocm-device-lib-path=/var/mnt/qwen-storage/projects/r9v/engine-src/.pydeps-native-quant-rocm/_rocm_sdk_core/lib/llvm/amdgcn/bitcode -Wl,-rpath,/var/mnt/qwen-storage/projects/r9v/engine-src/.pydeps-native-quant-rocm/_rocm_sdk_core/lib spikes/hipgraph/hipgraph.hip -o /tmp/hipgraph_s4` (binary kept outside the repo at `/tmp/hipgraph_s4`)
+- Note: `--rocm-device-lib-path` is required because the pinned SDK lays out the amdgcn bitcode outside hipcc's default search path; first attempt without it failed at compile time with "cannot find ROCm device library".
+- Run: `LD_LIBRARY_PATH=<sdk>/lib /tmp/hipgraph_s4` (env `ROCM_PATH`/`HIP_PATH` set to the pinned SDK at build time)
+- Runs: two independent executions, exit 0 both times; run logs at `/tmp/hipgraph_s4_run1.log`, `/tmp/hipgraph_s4_run2.log` (outside repo)
+
+## Method (what the program does)
+
+- Exact 400-kernel launch list: one `step_kernel` launch per chunk over 400 chunks of 2048 uint32 words (3.2 MiB total). Each launch uses 8 blocks x 256 threads so each of the 2048 threads owns exactly one chunk word via a single global index plus one bounds check (no overlapping writes, no out-of-range loop iterations). Each thread does an 8-iteration integer multiply-add chain with a per-launch constant and writes its word (full 8 KiB chunk per launch).
+- Integer arithmetic is bit-exact on host and device, so the host-computed reference buffer is a strict oracle. (An earlier float version showed a 1-ulp host/device mismatch from FMA contraction differences and was replaced — the oracle is not the implementation compared to itself.)
+- Every timed iteration on both paths is verified with a full-buffer `memcmp` against the reference (bit-exact, 100/100 iterations per run), proving launches are real, observable, and semantically equivalent across paths.
+- Graph path: `hipStreamBeginCapture` / 400 launches / `hipStreamEndCapture` / `hipGraphGetNodes` asserted == 400 / `hipGraphInstantiate` — all once, outside replay timing. Replay is `hipGraphLaunch` only.
+- Timing: output buffer reset + stream sync before the start event, so only replay time is measured; `hipEventRecord` start/stop on the same stream, `hipEventSynchronize` before reading. 10 warmups per path, then 50 timed samples per path alternating seq/graph to share thermal conditions.
+- Strict gates, nonzero exit on any violation: any HIP error exits 2; node count != 400, any `memcmp` mismatch, graph max > 2x median, graph CV > 10%, or graph median not strictly below sequential median each print `FAIL:` and exit 1. An earlier failing build (float oracle) exited 1 as designed.
 
 ## Raw Measurements
-| Metric | Value |
-|---|---|
-| Plain launch list total time for 400 launches (µs) | |
-| hipGraph replay total time for 400 launches (µs) | |
-| Dispatch overhead per launch (µs) | |
-| Replay stability across repeated iterations | |
+
+### Run 1 (exit 0)
+
+- Sequential 400-launch total (µs): median 1048.57, min 1045.33, max 1170.49, mean 1057.27, std 24.61
+- Graph replay 400-launch total (µs): median 881.93, min 879.69, max 980.09, mean 890.29, std 23.93
+- Per-launch dispatch-inclusive: seq 2.621 µs, graph 2.205 µs, saved 0.417 µs/launch, speedup 1.189
+- Graph stability: max/median 1.111, CV 0.0271
+- Correctness: 100/100 timed iterations bit-exact on both paths; captured nodes 400/400
+- Seq raw (µs, 50): 1128.3, 1048.8, 1049.5, 1048.6, 1047.4, 1048.1, 1048.9, 1170.5, 1047.5, 1047.7, 1047.9, 1050.6, 1049.5, 1048.6, 1107.0, 1049.6, 1047.8, 1049.7, 1050.7, 1049.0, 1049.1, 1106.7, 1046.1, 1053.4, 1047.0, 1047.8, 1047.5, 1048.1, 1115.9, 1047.5, 1049.8, 1048.8, 1048.1, 1047.6, 1050.1, 1080.2, 1047.5, 1049.0, 1047.1, 1045.3, 1047.7, 1048.5, 1070.0, 1047.6, 1050.0, 1048.2, 1048.3, 1048.6, 1048.5, 1048.0
+- Graph raw (µs, 50): 883.4, 881.7, 880.1, 882.5, 883.4, 881.0, 880.8, 900.7, 880.4, 880.0, 883.0, 882.6, 880.0, 911.4, 884.4, 881.3, 881.9, 884.1, 882.0, 880.8, 959.2, 882.2, 881.5, 880.6, 881.5, 880.2, 879.9, 934.0, 882.2, 879.7, 882.0, 882.4, 879.8, 881.2, 963.3, 882.5, 880.9, 883.8, 882.8, 881.3, 882.1, 958.6, 880.0, 880.2, 882.5, 880.7, 880.2, 882.6, 980.1, 880.3
+
+### Run 2 — independent rerun, same binary (exit 0)
+
+- Sequential 400-launch total (µs): median 1048.29, min 1045.17, max 1091.05, mean 1051.21, std 9.07
+- Graph replay 400-launch total (µs): median 881.47, min 879.13, max 975.81, mean 892.40, std 27.14
+- Per-launch dispatch-inclusive: seq 2.621 µs, graph 2.204 µs, saved 0.417 µs/launch, speedup 1.189
+- Graph stability: max/median 1.107, CV 0.0308
+- Correctness: 100/100 timed iterations bit-exact on both paths; captured nodes 400/400
+- Seq raw (µs, 50): 1050.1, 1048.7, 1049.4, 1048.0, 1091.1, 1048.3, 1047.6, 1047.8, 1048.3, 1047.3, 1048.1, 1085.6, 1046.9, 1046.2, 1047.4, 1047.0, 1048.4, 1049.4, 1066.1, 1047.8, 1047.5, 1048.3, 1048.3, 1051.8, 1047.7, 1066.3, 1047.1, 1046.7, 1047.7, 1048.6, 1047.0, 1047.5, 1049.4, 1048.3, 1049.4, 1048.9, 1051.1, 1050.5, 1049.0, 1063.6, 1045.2, 1046.8, 1050.7, 1045.9, 1047.5, 1049.9, 1067.4, 1046.9, 1048.6, 1047.7
+- Graph raw (µs, 50): 882.6, 881.4, 879.5, 932.1, 883.6, 881.3, 882.2, 883.7, 881.4, 880.7, 973.6, 881.5, 896.4, 881.9, 882.7, 880.6, 880.0, 947.3, 881.7, 879.3, 880.9, 883.3, 880.6, 884.4, 975.8, 880.9, 879.1, 881.6, 882.3, 880.6, 881.3, 961.6, 883.1, 881.4, 882.8, 882.6, 880.2, 881.1, 972.3, 880.7, 879.8, 882.8, 881.2, 879.8, 881.2, 941.1, 880.1, 880.9, 881.9, 881.2
+
+| Metric | Run 1 | Run 2 |
+|---|---|---|
+| Sequential 400-launch median (µs) | 1048.57 | 1048.29 |
+| Graph replay 400-launch median (µs) | 881.93 | 881.47 |
+| Per-launch seq / graph (µs) | 2.621 / 2.205 | 2.621 / 2.204 |
+| Dispatch saved per launch (µs) | 0.417 | 0.417 |
+| Speedup (seq/graph) | 1.189 | 1.189 |
+| Graph max/median, CV | 1.111, 0.0271 | 1.107, 0.0308 |
+| Bit-exact iterations (seq+graph) | 100/100 | 100/100 |
+| Captured nodes | 400/400 | 400/400 |
 
 ## Judgment Against Spec Claim
-- Claim (Roadmap §A0, Spec 6 §2): Capture and replay of 400-launch list on gfx1201 is stable and reduces dispatch overhead compared to sequential kernel launches.
-- Pass/Fail Judgment: [PASS / FAIL]
+
+- Claim (Roadmap §A0, Spec 6 §5.2): capture and replay of a 400-launch list on gfx1201 is stable and reduces dispatch overhead versus sequential kernel launches.
+- Pass/Fail Judgment: **PASS**
 - Notes:
+  - Capture is exact: `hipGraphGetNodes` reports 400 nodes for the 400-launch list, and every replay on both paths reproduces the host reference bit-exactly, so the graph is semantically the same list, not an optimized-away version.
+  - Replay reduces dispatch overhead: graph median is ~167 µs (~0.42 µs/launch, speedup ~1.19) below sequential in both runs, ~6+ stddevs of separation; run-to-run medians agree within ~0.1%.
+  - Replay is stable: graph CV ~0.03, max/median ~1.11 in both runs, far inside the fail gates (2.0x max, 0.10 CV).
+  - Scope limit: kernels here are small integer compute kernels (~3.2 MiB working set), chosen so launch dispatch is a visible fraction of total time. The result supports Spec 6 §5.2's warmup comparison (graph eligible as an accelerator) but does not claim any model-step speedup; per Roadmap §7 risks, the launch list remains primary and hipGraph a non-dependency accelerator.
+  - No SPEC-ISSUES entry: capture was stable and faster, so nothing contradicts the spec. Had it been slower or unstable, the program would have exited 1 with FAIL recorded here.

--- a/spikes/hipgraph/hipgraph.hip
+++ b/spikes/hipgraph/hipgraph.hip
@@ -1,13 +1,262 @@
-// Spike S4: hipgraph
-// Tests capture and replay of a 400-launch list on gfx1201; measures dispatch overhead and stability.
-// (Roadmap §A0, Spec 6 §2, Spec 14).
+// Spike S4: hipgraph (Card A0.S4; Roadmap §A0, Spec 6 §5.2, Spec 14).
+// Captures an exact 400-kernel launch list into a hipGraph on gfx1201,
+// repeatedly replays it, and compares against the same 400 sequential
+// launches for correctness, dispatch overhead, and replay stability.
+//
+// Pass criteria (strict, nonzero exit on any failure):
+//  1. All HIP calls succeed (device 0).
+//  2. Captured graph contains exactly 400 nodes.
+//  3. Every sequential and every graph replay reproduces the host-computed
+//     reference buffer bit-exactly (memcmp), proving launches are real,
+//     observable, and semantically equivalent across paths.
+//  4. Graph replay is stable: max sample <= 2x median and CV <= 10%.
+//  5. Graph replay median total time is strictly less than the sequential
+//     launch-list median (the Spec 6 §5.2 / Roadmap §A0 claim). Otherwise
+//     FAIL is recorded for SPEC-ISSUES; the claim is not weakened.
+//
+// Capture + instantiate happen once, outside all replay timing. Both timed
+// paths reset the output buffer first, are bracketed by hipEvents on the
+// same stream, and are synchronized before the stop event is read.
 
 #include <hip/hip_runtime.h>
-#include <stdio.h>
-#include <stdlib.h>
 
-int main(int argc, char** argv) {
-    printf("Spike S4: hipgraph (Roadmap §A0, Spec 6 §2)\n");
-    printf("Testing 400-launch hipGraph capture, instantiate, and replay stability...\n");
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <numeric>
+#include <vector>
+
+#define HIP_CHECK(call)                                                        \
+    do {                                                                       \
+        hipError_t err = (call);                                               \
+        if (err != hipSuccess) {                                               \
+            std::fprintf(stderr, "HIP error at %s:%d: %s\n", __FILE__,          \
+                         __LINE__, hipGetErrorString(err));                    \
+            std::exit(2);                                                      \
+        }                                                                      \
+    } while (0)
+
+#define FAIL(...)                                                              \
+    do {                                                                       \
+        std::fprintf(stderr, "FAIL: " __VA_ARGS__);                            \
+        std::fprintf(stderr, "\n");                                            \
+        g_fail = true;                                                         \
+    } while (0)
+
+static bool g_fail = false;
+
+static const int kLaunches = 400;      // exact launch-list length (card A0.S4)
+static const int kChunkElem = 2048;    // uint32 words per launch (8 KiB)
+static const int kBlock = 256;         // threads per block
+static const int kWarmups = 10;
+static const int kSamples = 50;        // timed replays per path
+static const uint32_t kMul = 1664525u;
+static const uint32_t kAdd = 1013904223u;
+
+// Deterministic SplitMix64 fill in [-1, 1).
+static uint64_t splitmix64(uint64_t& s) {
+    uint64_t z = (s += 0x9E3779B97F4A7C15ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+// Nontrivial per-launch kernel: 8-iteration integer multiply-add chain with
+// a per-launch term, writing a full 8 KiB chunk. Integer arithmetic is
+// bit-exact on host and device, so the host reference is a strict oracle.
+// Every output word is read back and memcmp'd, so no launch can be eliminated.
+__global__ void step_kernel(const uint32_t* __restrict__ in,
+                            uint32_t* __restrict__ out, int chunk) {
+    int base = chunk * kChunkElem;
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < kChunkElem) {
+        uint32_t c = kAdd + (uint32_t)chunk * 0x9E3779B9u;
+        uint32_t x = in[base + i];
+#pragma unroll
+        for (int r = 0; r < 8; ++r) x = x * kMul + c + (uint32_t)r;
+        out[base + i] = x;
+    }
+}
+
+static void launch_list(hipStream_t s, const uint32_t* d_in, uint32_t* d_out) {
+    for (int c = 0; c < kLaunches; ++c) {
+        hipLaunchKernelGGL(step_kernel, dim3((kChunkElem + kBlock - 1) / kBlock),
+                           dim3(kBlock), 0, s, d_in, d_out, c);
+    }
+}
+
+struct Stats {
+    double median, min, max, mean, stddev;
+};
+
+static Stats summarize(std::vector<float> v) {
+    std::sort(v.begin(), v.end());
+    Stats st;
+    st.min = v.front();
+    st.max = v.back();
+    st.median = (v[v.size() / 2 - (v.size() % 2 == 0 ? 1 : 0)] + v[v.size() / 2]) / 2.0;
+    st.mean = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+    double acc = 0.0;
+    for (float x : v) acc += (x - st.mean) * (x - st.mean);
+    st.stddev = std::sqrt(acc / v.size());
+    return st;
+}
+
+int main() {
+    HIP_CHECK(hipSetDevice(0));
+    hipDeviceProp_t prop;
+    HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+    int driver = 0, runtime = 0;
+    HIP_CHECK(hipDriverGetVersion(&driver));
+    HIP_CHECK(hipRuntimeGetVersion(&runtime));
+    std::printf("device: %s arch=%s\n", prop.name, prop.gcnArchName);
+    std::printf("driver=%d runtime=%d\n", driver, runtime);
+
+    const size_t n = (size_t)kLaunches * kChunkElem;
+    std::vector<uint32_t> h_in(n), h_ref(n);
+    uint64_t seed = 0x243F6A8885A308D3ULL;
+    for (size_t i = 0; i < n; ++i) h_in[i] = (uint32_t)splitmix64(seed);
+    // Host reference: exact same integer arithmetic as the kernel.
+    for (int c = 0; c < kLaunches; ++c) {
+        uint32_t cc = kAdd + (uint32_t)c * 0x9E3779B9u;
+        for (int i = 0; i < kChunkElem; ++i) {
+            uint32_t x = h_in[(size_t)c * kChunkElem + i];
+            for (int r = 0; r < 8; ++r) x = x * kMul + cc + (uint32_t)r;
+            h_ref[(size_t)c * kChunkElem + i] = x;
+        }
+    }
+
+    uint32_t *d_in = nullptr, *d_out = nullptr;
+    HIP_CHECK(hipMalloc(&d_in, n * sizeof(uint32_t)));
+    HIP_CHECK(hipMalloc(&d_out, n * sizeof(uint32_t)));
+    HIP_CHECK(hipMemcpy(d_in, h_in.data(), n * sizeof(uint32_t), hipMemcpyHostToDevice));
+
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+    hipEvent_t ev_start, ev_stop;
+    HIP_CHECK(hipEventCreate(&ev_start));
+    HIP_CHECK(hipEventCreate(&ev_stop));
+
+    std::vector<uint32_t> h_out(n);
+    auto reset_and_sync = [&]() {
+        HIP_CHECK(hipMemsetAsync(d_out, 0, n * sizeof(uint32_t), stream));
+        HIP_CHECK(hipStreamSynchronize(stream));
+    };
+    auto verify = [&](const char* tag, int iter) {
+        HIP_CHECK(hipMemcpy(h_out.data(), d_out, n * sizeof(uint32_t),
+                            hipMemcpyDeviceToHost));
+        if (std::memcmp(h_out.data(), h_ref.data(), n * sizeof(uint32_t)) != 0) {
+            size_t bad = 0;
+            for (size_t i = 0; i < n; ++i)
+                if (h_out[i] != h_ref[i]) { bad = i; break; }
+            FAIL("%s iter %d: output mismatch at word %zu (got 0x%08x expected 0x%08x)",
+                 tag, iter, bad, h_out[bad], h_ref[bad]);
+        }
+    };
+
+    // Sequential warmups (also proves the launch list is correct pre-capture).
+    for (int w = 0; w < kWarmups; ++w) {
+        reset_and_sync();
+        launch_list(stream, d_in, d_out);
+        HIP_CHECK(hipStreamSynchronize(stream));
+    }
+    reset_and_sync();
+    launch_list(stream, d_in, d_out);
+    HIP_CHECK(hipStreamSynchronize(stream));
+    verify("seq-warmup", 0);
+
+    // Capture the exact same 400-launch list. Timing excluded.
+    hipGraph_t graph;
+    HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+    launch_list(stream, d_in, d_out);
+    HIP_CHECK(hipStreamEndCapture(stream, &graph));
+    size_t num_nodes = 0;
+    HIP_CHECK(hipGraphGetNodes(graph, nullptr, &num_nodes));
+    std::printf("captured nodes: %zu (expected %d)\n", num_nodes, kLaunches);
+    if (num_nodes != (size_t)kLaunches)
+        FAIL("graph has %zu nodes, expected exactly %d", num_nodes, kLaunches);
+    hipGraphExec_t exec;
+    HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+    // Graph warmups.
+    for (int w = 0; w < kWarmups; ++w) {
+        reset_and_sync();
+        HIP_CHECK(hipGraphLaunch(exec, stream));
+        HIP_CHECK(hipStreamSynchronize(stream));
+    }
+    reset_and_sync();
+    HIP_CHECK(hipGraphLaunch(exec, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+    verify("graph-warmup", 0);
+
+    // Timed runs, alternating paths to share thermal/drift conditions.
+    // Reset + sync happen before the start event, so only replay time is measured.
+    std::vector<float> t_seq, t_graph;
+    t_seq.reserve(kSamples);
+    t_graph.reserve(kSamples);
+    for (int s = 0; s < kSamples; ++s) {
+        reset_and_sync();
+        HIP_CHECK(hipEventRecord(ev_start, stream));
+        launch_list(stream, d_in, d_out);
+        HIP_CHECK(hipEventRecord(ev_stop, stream));
+        HIP_CHECK(hipEventSynchronize(ev_stop));
+        float ms = 0.0f;
+        HIP_CHECK(hipEventElapsedTime(&ms, ev_start, ev_stop));
+        t_seq.push_back(ms * 1000.0f);
+        verify("seq", s);
+
+        reset_and_sync();
+        HIP_CHECK(hipEventRecord(ev_start, stream));
+        HIP_CHECK(hipGraphLaunch(exec, stream));
+        HIP_CHECK(hipEventRecord(ev_stop, stream));
+        HIP_CHECK(hipEventSynchronize(ev_stop));
+        HIP_CHECK(hipEventElapsedTime(&ms, ev_start, ev_stop));
+        t_graph.push_back(ms * 1000.0f);
+        verify("graph", s);
+    }
+
+    Stats ss = summarize(t_seq), sg = summarize(t_graph);
+    std::printf("seq_us median=%.2f min=%.2f max=%.2f mean=%.2f std=%.2f\n", ss.median,
+                ss.min, ss.max, ss.mean, ss.stddev);
+    std::printf("graph_us median=%.2f min=%.2f max=%.2f mean=%.2f std=%.2f\n", sg.median,
+                sg.min, sg.max, sg.mean, sg.stddev);
+    std::printf("seq raw:");
+    for (float x : t_seq) std::printf(" %.1f", x);
+    std::printf("\ngraph raw:");
+    for (float x : t_graph) std::printf(" %.1f", x);
+    std::printf("\n");
+    double per_seq = ss.median / kLaunches, per_graph = sg.median / kLaunches;
+    double speedup = ss.median / sg.median;
+    double cv = sg.stddev / sg.median;
+    std::printf("per-launch seq=%.3f us graph=%.3f us dispatch-saved=%.3f us speedup=%.3f\n",
+                per_seq, per_graph, per_seq - per_graph, speedup);
+    std::printf("graph stability: max/median=%.3f cv=%.4f\n", sg.max / sg.median, cv);
+
+    // Stability gates (generous: only gross instability fails).
+    if (sg.max > 2.0 * sg.median)
+        FAIL("graph replay unstable: max %.1f us > 2x median %.1f us", sg.max, sg.median);
+    if (cv > 0.10)
+        FAIL("graph replay unstable: CV %.4f > 0.10", cv);
+    // The spec claim, unweakened: replay must reduce dispatch overhead.
+    if (!(sg.median < ss.median))
+        FAIL("graph replay median %.1f us is not below sequential %.1f us", sg.median,
+             ss.median);
+
+    HIP_CHECK(hipGraphExecDestroy(exec));
+    HIP_CHECK(hipGraphDestroy(graph));
+    HIP_CHECK(hipEventDestroy(ev_start));
+    HIP_CHECK(hipEventDestroy(ev_stop));
+    HIP_CHECK(hipStreamDestroy(stream));
+    HIP_CHECK(hipFree(d_in));
+    HIP_CHECK(hipFree(d_out));
+
+    if (g_fail) {
+        std::printf("RESULT: FAIL\n");
+        return 1;
+    }
+    std::printf("RESULT: PASS\n");
     return 0;
 }


### PR DESCRIPTION
## Card
A0.S4 — hipgraph spike (kind: implementation; GPU: yes; size: S)

## Spec sections implemented
- spec 6 §5.2: measures exact 400-launch list capture/replay stability and dispatch reduction.
- spec 14 §3: exercises the HIP stream, event, capture, graph, instantiate, and launch lifecycle on the reference GPU.

## Deliverables
- [x] Single HIP program capturing exactly 400 kernel launches into exactly 400 graph nodes.
- [x] Semantically identical sequential and graph paths with one unique output word per thread.
- [x] Bit-exact host oracle and full-buffer verification after every timed execution.
- [x] Capture and instantiation excluded from replay timing.
- [x] Alternating-path event timing with warmups, 50 raw samples per path, and two executions.
- [x] Strict nonzero failure for graph/HIP/correctness/stability/regression failures.
- [x] Complete hardware, command, raw measurements, and PASS judgment receipt.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| capture exact 400-launch list | `spikes/hipgraph/hipgraph.hip` | gpu | green: 400/400 nodes |
| sequential/graph semantic equivalence | `spikes/hipgraph/hipgraph.hip` | gpu | green: 100/100 timed iterations bit-exact per run |
| graph replay stability | `spikes/hipgraph/RESULT.md` | gpu | green: CV 0.0271 / 0.0308 |
| graph dispatch reduction | `spikes/hipgraph/RESULT.md` | gpu | green: 1.189× in both recorded runs |
| independent orchestrator rerun | `spikes/hipgraph/hipgraph.hip` | gpu | green: 1.189×, exact output, exit 0 |

## Decisions
- none

## SPEC-ISSUES filed
- none

## New dependencies
- none

## Hardware
Tests run here: local GPU runner, device 0, AMD Radeon AI PRO R9700 (`gfx1201`), pinned HIP 7.14 / Clang 23 toolchain.
Tests pending on the runner: none
Measured numbers (if any): fingerprint `gfx1201 / R9700 / HIP 7.14.60850`; command `<ROCm SDK>/bin/hipcc -O3 --offload-arch=gfx1201 --rocm-device-lib-path=<ROCm SDK>/lib/llvm/amdgcn/bitcode -Wl,-rpath,<ROCm SDK>/lib spikes/hipgraph/hipgraph.hip -o <artifact> && <artifact>`; receipt `spikes/hipgraph/RESULT.md`

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- none

## Size check
Diff size vs card size class: 340 changed lines vs S — one self-contained graph experiment includes lifecycle setup, a bit-exact oracle, per-iteration verification, timing/statistics, strict gates, and its receipt; no engine implementation is included.
