### PR TITLE
A0.S6: measure dual-GPU peer transport

### DIFF
--- a/SPEC-ISSUES.md
+++ b/SPEC-ISSUES.md
@@ -17,3 +17,9 @@ What: The pinned compilation command specifies `-ffast-math=off`.
 Why it blocks or misleads: The pinned ROCm Clang 23 rejects that spelling as an unknown argument, so the specified command cannot compile any kernel even though the intended requirement—keeping fast-math disabled—is supported.
 Option taken: Used `-fno-fast-math`, the Clang spelling that enforces the stated intent, for the A0.S3 probe; the FP8 builtin compiled, passed its numerical checks, and lowered to the intended instruction.
 Proposed resolution: Replace `-ffast-math=off` with `-fno-fast-math` in spec 4 §4.3 while retaining `-fno-gpu-approx-transcendentals`.
+
+## SI-2 — A0.S6 — spec 5 §2 / hardware topology
+What: Spec 5 §2 says the current rig has one R9700 on x16 and one on x4, and `hardware/dual-r9700/hardware.json` records rank 1 as `Gen4 x4`.
+Why it blocks or misleads: The A0.S6 reference-rig measurement resolves the two discrete R9700 endpoints as PCI `0000:03:00.0` and `0000:13:00.0`; sysfs reports `32.0 GT/s PCIe`, width `16` for both endpoints, and they occupy separate IOMMU groups 15 and 31. Keeping the stale x4 description would make the topology fingerprint and every calibrated communication-cost estimate disagree with the measured machine.
+Option taken: Recorded the live topology and P2P receipt in `spikes/p2p/RESULT.md`; A0.S6 uses the measured link and selects `Direct`. Work that consumes the seeded x4 topology must use the measured result rather than treating the JSON value as observed fact.
+Proposed resolution: Update spec 5 §2 and `hardware/dual-r9700/hardware.json` to record both discrete endpoints at their measured Gen5 x16 link state on the current reference rig, and populate the 0↔1 transport as `Direct` from the A0.S6 receipt.

--- a/spikes/p2p/RESULT.md
+++ b/spikes/p2p/RESULT.md
@@ -2,28 +2,66 @@
 
 - **Spike ID**: S6 (`p2p`)
 - **Card**: A0.S6
-- **Governing Specs**: Spec 5 §2, Spec 5 §6, Roadmap §A0
-- **Status**: [PENDING_RUNNER | PASS | FAIL]
+- **Governing Specs**: Spec 5 §1, §2, §6; Spec 11 §7; Roadmap §A0
+- **Status**: PASS
 
 ## Hardware Fingerprint
-- Topology: Dual AMD GPUs [e.g. R9700]
-- Host Board / PCIe Topology:
-- IOMMU / Peer Access Support:
+
+- Board: ASRock B850M-C; AMD Ryzen 5 9600X; 12 logical CPUs; one NUMA node.
+- Discrete rank 0: AMD Radeon AI PRO R9700, gfx1201, 32624 MiB, PCI
+  `0000:03:00.0`, current link `32.0 GT/s x16`, IOMMU group 15.
+- Discrete rank 1: AMD Radeon AI PRO R9700, gfx1201, 32624 MiB, PCI
+  `0000:13:00.0`, current link `32.0 GT/s x16`, IOMMU group 31.
+- An integrated gfx1036 device is HIP device 2 and is outside the measured
+  two-rank topology.
+- Kernel: `7.1.5-ogc5.1.fc44.x86_64`; HIP runtime/driver version reported by
+  the container: `71460850`; ROCm runtime from `r9v-ci:test`.
+- The live link state contradicts the seeded x16/x4 description; SI-2 records
+  that topology issue.
 
 ## Execution
-- Command: `hipcc -O3 spikes/p2p/p2p.hip -o spikes/p2p/p2p && ./spikes/p2p/p2p`
 
-## Raw Measurements
-| Metric | Measured |
-|---|---|
-| Peer access supported (`hipDeviceCanAccessPeer`) (yes/no) | |
-| Direct P2P transfer latency at 16 KB (µs) | |
-| Host-staged transfer latency at 16 KB (µs) | |
-| Achieved P2P throughput (GB/s) | |
+- Compile:
+  `docker run --rm -v /var/home/dylan/projects/inference/r9v-engine-spec:/src:ro -v /tmp/r9v-a0s6:/out:rw --entrypoint /opt/rocm/bin/hipcc r9v-ci:test -O3 -std=c++17 -Wall -Wextra -Werror --offload-arch=gfx1201 /src/spikes/p2p/p2p.hip -o /out/p2p`
+- Run:
+  `docker run --rm --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined -e LD_LIBRARY_PATH=/opt/rocm/lib -v /tmp/r9v-a0s6:/work:ro --entrypoint /work/p2p r9v-ci:test`
+- Method: 16 KiB deterministic payload; 10 warmups and 50 timed trials per
+  direction and transport. Each direct trial is a genuine
+  `hipMemcpyPeerAsync` followed by source-stream completion, and runs only
+  after `hipDeviceCanAccessPeer` and peer-enable succeed. Each host-staged
+  trial performs and completes D2H into a pinned bounce buffer, switches to
+  the destination device, then performs and completes H2D on that device's
+  own stream. Latency is end-to-end monotonic wall time; GB/s is decimal
+  payload bytes per second. Destination bytes are exhaustively compared with
+  the deterministic source after each trial set.
 
-## Judgment Against Spec Claim
-- Claim (Spec 5 §2, Roadmap §A0): Determine whether dual GPUs can peer-map directly on the reference rig; record direct vs host-staged 16 KB latency to populate `ArchDescriptor.p2p` link matrix.
-- Peer access available: [yes / no]
-- Direct latency vs host-staged latency: [direct µs vs host-staged µs]
-- Pass/Fail Judgment: [PASS / FAIL]
-- Notes:
+## Measurements
+
+Both independent executions of the final binary returned `A0.S6 PASS`:
+
+| Direction | Peer query / enable | Direct latency, Run A / B | Direct GB/s, A / B | Host-staged latency, A / B | Host-staged GB/s, A / B |
+|---|---|---:|---:|---:|---:|
+| 0 → 1 | yes / yes | 21.8 / 21.5 µs | 0.7513 / 0.7625 | 91.5 / 81.3 µs | 0.1792 / 0.2014 |
+| 1 → 0 | yes / yes | 27.3 / 31.3 µs | 0.6001 / 0.5240 | 79.6 / 79.7 µs | 0.2057 / 0.2057 |
+
+Run B raw latency samples in milliseconds:
+
+- Direct 0→1: `0.0506 0.0219 0.0331 0.0219 0.0222 0.0221 0.0220 0.0220 0.0219 0.0221 0.0222 0.0226 0.0223 0.0218 0.0216 0.0215 0.0213 0.0215 0.0214 0.0222 0.0220 0.0216 0.0214 0.0218 0.0215 0.0214 0.0215 0.0214 0.0214 0.0214 0.0216 0.0214 0.0214 0.0213 0.0211 0.0214 0.0214 0.0213 0.0216 0.0214 0.0213 0.0215 0.0214 0.0214 0.0215 0.0215 0.0214 0.0214 0.0214 0.0214`
+- Host-staged 0→1: `0.0927 0.0841 0.0752 0.0771 0.0760 0.0818 0.0822 0.0823 0.0815 0.0821 0.0802 0.0813 0.0803 0.0755 0.0801 0.0808 0.0799 0.0810 0.0816 0.0812 0.0813 0.0808 0.1500 0.0798 0.0780 0.0860 0.0537 0.0793 0.0773 0.1015 0.0906 0.0830 0.0797 0.0797 0.0792 0.0785 0.0789 0.0839 0.0485 0.0976 0.1785 0.1020 0.0934 0.0936 0.1026 0.1991 0.0987 0.0922 0.0937 0.0753`
+- Direct 1→0: `0.0398 0.0400 0.0356 0.0311 0.0315 0.0314 0.0315 0.0311 0.0312 0.0316 0.0316 0.0312 0.0314 0.0311 0.0312 0.0314 0.0312 0.0314 0.0311 0.0315 0.0311 0.0313 0.0317 0.0314 0.0317 0.0312 0.0313 0.0312 0.0314 0.0316 0.0312 0.0313 0.0312 0.0313 0.0311 0.0313 0.0312 0.0313 0.0317 0.0314 0.0317 0.0312 0.0314 0.0296 0.0271 0.0273 0.0273 0.0273 0.0270 0.0278`
+- Host-staged 1→0: `0.0787 0.0801 0.0707 0.0796 0.0802 0.0799 0.0796 0.0793 0.1479 0.0812 0.0788 0.0794 0.0829 0.0799 0.0712 0.0800 0.0793 0.0793 0.0809 0.0803 0.1528 0.0793 0.0711 0.0585 0.0497 0.0549 0.0797 0.0810 0.0799 0.0800 0.0783 0.0796 0.0800 0.0794 0.0794 0.0727 0.0796 0.0731 0.0800 0.0779 0.0800 0.0800 0.0799 0.0797 0.0802 0.1466 0.0796 0.0797 0.0803 0.0712`
+
+All four content checks passed in both runs. The first timed sample is retained
+in every raw series; medians make the initialization outliers visible without
+letting them determine the topology coefficient.
+
+## Judgment
+
+- The peer map is bidirectionally available and peer enable succeeds in both
+  directions. Direct measurements are therefore genuine rather than HIP
+  fallback copies.
+- Direct is materially lower latency than explicit host staging at 16 KiB in
+  both directions, and every destination byte matches.
+- Selected topology transport for rank 0↔1: **Direct**.
+- **Result: PASS.** The card's diagnostic claim is established. SI-2 is the
+  separate stale-link-width issue; it does not invalidate the live P2P result.

--- a/spikes/p2p/p2p.hip
+++ b/spikes/p2p/p2p.hip
@@ -1,13 +1,297 @@
-// Spike S6: p2p
-// Tests peer-to-peer mapping and transfer latency between dual R9700 GPUs.
-// Measures direct vs host-staged latency at 16 KB (Roadmap §A0, Spec 5 §6).
+// Spike A0.S6: p2p (roadmap §A0, spec 5 §§1-2, 6; spec 11 measurement table).
+// Self-verifying HIP diagnostic: peer-map both R9700s, measure 16 KiB
+// direct (hipMemcpyPeerAsync, only when capability says yes) vs explicit
+// pinned-host-staged latency in both directions, with content checks.
 
 #include <hip/hip_runtime.h>
-#include <stdio.h>
-#include <stdlib.h>
 
-int main(int argc, char** argv) {
-    printf("Spike S6: p2p (Roadmap §A0, Spec 5 §6)\n");
-    printf("Testing dual GPU peer accessibility and 16 KB transfer latency...\n");
-    return 0;
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#define CHECK(expr)                                                        \
+    do {                                                                   \
+        hipError_t _e = (expr);                                            \
+        if (_e != hipSuccess) {                                            \
+            printf("FAIL-CLOSED: %s:%d: %s returned %d (%s)\n", __FILE__,   \
+                   __LINE__, #expr, (int)_e, hipGetErrorString(_e));       \
+            return 1;                                                      \
+        }                                                                  \
+    } while (0)
+
+namespace {
+
+const size_t kBytes = 16 * 1024;  // 16 KiB payload (spec 11 p2p size class)
+const int kWarmups = 10;
+const int kTrials = 50;
+
+void fill_pattern(uint8_t* p, size_t n, uint32_t seed) {
+    // Deterministic content: byte i = (seed + 31*i + (i>>8)) & 0xFF.
+    for (size_t i = 0; i < n; ++i)
+        p[i] = (uint8_t)((seed + 31u * (uint32_t)i + (uint32_t)(i >> 8)) & 0xFFu);
+}
+
+bool verify_pattern(const uint8_t* p, size_t n, uint32_t seed, const char* what) {
+    for (size_t i = 0; i < n; ++i) {
+        uint8_t want = (uint8_t)((seed + 31u * (uint32_t)i + (uint32_t)(i >> 8)) & 0xFFu);
+        if (p[i] != want) {
+            printf("CONTENT-MISMATCH %s at byte %zu: got %u want %u (seed %u)\n", what, i,
+                   (unsigned)p[i], (unsigned)want, seed);
+            return false;
+        }
+    }
+    return true;
+}
+
+double median_ms(std::vector<double> v) {
+    std::sort(v.begin(), v.end());
+    size_t n = v.size();
+    if (n == 0) return -1.0;
+    if (n % 2 == 1) return v[n / 2];
+    return 0.5 * (v[n / 2 - 1] + v[n / 2]);
+}
+
+double gbps(double bytes, double ms) {
+    if (ms <= 0) return -1.0;
+    return (bytes / (ms / 1000.0)) / 1e9;  // decimal GB/s per task
+}
+
+struct DirResult {
+    int src = -1, dst = -1;
+    bool peer_cap = false;   // hipDeviceCanAccessPeer(src -> dst)
+    bool peer_enabled = false;
+    double direct_ms = -1.0;  // median, -1 = N/A
+    double direct_gbps = -1.0;
+    bool direct_ok = false;
+    double staged_ms = -1.0;
+    double staged_gbps = -1.0;
+    bool staged_ok = false;
+};
+
+bool print_props(int dev) {
+    hipDeviceProp_t p;
+    memset(&p, 0, sizeof p);
+    if (hipGetDeviceProperties(&p, dev) != hipSuccess) {
+        printf("device %d: <props query failed>\n", dev);
+        return false;
+    }
+    char busid[64] = "?";
+    if (hipDeviceGetPCIBusId(busid, sizeof busid, dev) != hipSuccess)
+        snprintf(busid, sizeof busid, "?");
+    printf("device %d: name=\"%s\" gcnArch=\"%s\" pciBusId=\"%s\" "
+           "totalGlobalMem=%zuMB multiProcessorCount=%d maxThreadsPerBlock=%d\n",
+           dev, p.name, p.gcnArchName, busid,
+           (size_t)(p.totalGlobalMem >> 20), p.multiProcessorCount,
+           p.maxThreadsPerBlock);
+    return strstr(p.name, "R9700") != nullptr &&
+           strcmp(p.gcnArchName, "gfx1201") == 0;
+}
+
+}  // namespace
+
+int main() {
+    printf("A0.S6 p2p diagnostic (roadmap A0; spec 5 ss1-2,6; spec 11 meas table)\n");
+
+    int ndev = 0;
+    CHECK(hipGetDeviceCount(&ndev));
+    printf("device_count=%d\n", ndev);
+    if (ndev < 2) {
+        printf("FAIL-CLOSED: need >= 2 HIP devices, have %d\n", ndev);
+        return 1;
+    }
+    bool reference_devices = true;
+    for (int d = 0; d < ndev; ++d) {
+        bool is_r9700 = print_props(d);
+        if (d < 2) reference_devices &= is_r9700;
+    }
+    if (!reference_devices) {
+        printf("FAIL-CLOSED: devices 0 and 1 must both be R9700/gfx1201\n");
+        return 1;
+    }
+    // Hardware fingerprint: driver/runtime versions.
+    int rt = 0, drv = 0;
+    if (hipRuntimeGetVersion(&rt) == hipSuccess) printf("hip_runtime_version=%d\n", rt);
+    if (hipDriverGetVersion(&drv) == hipSuccess) printf("hip_driver_version=%d\n", drv);
+
+    // Scope: first two devices (the dual-R9700 reference rig).
+    const int devs[2] = {0, 1};
+
+    // Peer capability map, both directions. Never enable unless cap says yes.
+    DirResult dirs[2];
+    int pairs[2][2] = {{0, 1}, {1, 0}};
+    for (int k = 0; k < 2; ++k) {
+        dirs[k].src = pairs[k][0];
+        dirs[k].dst = pairs[k][1];
+        int can = 0;
+        CHECK(hipDeviceCanAccessPeer(&can, dirs[k].src, dirs[k].dst));
+        dirs[k].peer_cap = (can != 0);
+        printf("peer_capability %d->%d: %s\n", dirs[k].src, dirs[k].dst,
+               dirs[k].peer_cap ? "yes" : "no");
+    }
+    for (int k = 0; k < 2; ++k) {
+        if (!dirs[k].peer_cap) continue;  // fail-open enable is forbidden
+        CHECK(hipSetDevice(dirs[k].src));
+        hipError_t e = hipDeviceEnablePeerAccess(dirs[k].dst, 0);
+        if (e == hipSuccess || e == hipErrorPeerAccessAlreadyEnabled) {
+            dirs[k].peer_enabled = true;
+        } else {
+            printf("FAIL-CLOSED: peer_enable %d->%d failed: %d (%s)\n",
+                   dirs[k].src, dirs[k].dst, (int)e, hipGetErrorString(e));
+            return 1;
+        }
+        printf("peer_enabled %d->%d: %s\n", dirs[k].src, dirs[k].dst,
+               dirs[k].peer_enabled ? "yes" : "no");
+    }
+
+    // Buffers: one device buffer and one device-owned stream per GPU, plus a
+    // pinned host bounce buffer. A HIP stream is device-specific; using the
+    // source stream for D2H and destination stream for H2D keeps the staged
+    // path explicit and prevents the runtime from substituting a peer copy.
+    void* dbuf[2] = {nullptr, nullptr};
+    hipStream_t streams[2] = {nullptr, nullptr};
+    for (int k = 0; k < 2; ++k) {
+        CHECK(hipSetDevice(devs[k]));
+        CHECK(hipMalloc(&dbuf[k], kBytes));
+        CHECK(hipStreamCreate(&streams[k]));
+    }
+    void* stage = nullptr;
+    CHECK(hipHostMalloc(&stage, kBytes, hipHostMallocDefault));
+
+    bool all_content_ok = true;
+    for (int k = 0; k < 2; ++k) {
+        int src = dirs[k].src, dst = dirs[k].dst;
+        uint32_t seed = 0x1000u + (uint32_t)k;
+        std::vector<uint8_t> host_src(kBytes), host_check(kBytes);
+
+        // Init src device buffer with deterministic pattern via staged H2D.
+        fill_pattern(host_src.data(), kBytes, seed);
+        CHECK(hipSetDevice(src));
+        CHECK(hipMemcpy(dbuf[src], host_src.data(), kBytes, hipMemcpyHostToDevice));
+
+        // --- Direct path: genuine hipMemcpyPeerAsync only. ---
+        if (dirs[k].peer_cap && dirs[k].peer_enabled) {
+            // Opposite pattern in dst first so a no-op copy cannot pass verify.
+            std::vector<uint8_t> poison(kBytes, 0xA5);
+            CHECK(hipSetDevice(dst));
+            CHECK(hipMemcpy(dbuf[dst], poison.data(), kBytes, hipMemcpyHostToDevice));
+            CHECK(hipSetDevice(src));
+            for (int w = 0; w < kWarmups; ++w)
+                CHECK(hipMemcpyPeerAsync(dbuf[dst], dst, dbuf[src], src, kBytes,
+                                         streams[src]));
+            CHECK(hipStreamSynchronize(streams[src]));
+            std::vector<double> trials;
+            for (int t = 0; t < kTrials; ++t) {
+                auto t0 = std::chrono::steady_clock::now();
+                CHECK(hipMemcpyPeerAsync(dbuf[dst], dst, dbuf[src], src, kBytes,
+                                         streams[src]));
+                CHECK(hipStreamSynchronize(streams[src]));
+                auto t1 = std::chrono::steady_clock::now();
+                trials.push_back(
+                    std::chrono::duration<double, std::milli>(t1 - t0).count());
+            }
+            dirs[k].direct_ms = median_ms(trials);
+            dirs[k].direct_gbps = gbps((double)kBytes, dirs[k].direct_ms);
+            printf("direct_raw_ms %d->%d:", src, dst);
+            for (double v : trials) printf(" %.4f", v);
+            printf("\n");
+            CHECK(hipSetDevice(dst));
+            CHECK(hipMemcpy(host_check.data(), dbuf[dst], kBytes, hipMemcpyDeviceToHost));
+            dirs[k].direct_ok = verify_pattern(host_check.data(), kBytes, seed, "direct");
+            all_content_ok &= dirs[k].direct_ok;
+            printf("direct %d->%d: median %.4f ms, %.4f GB/s(decimal), content %s\n", src, dst,
+                   dirs[k].direct_ms, dirs[k].direct_gbps,
+                   dirs[k].direct_ok ? "OK" : "MISMATCH");
+            // Restore src content (direct overwrote nothing on src, but re-init
+            // anyway so the staged leg starts from a known state).
+            CHECK(hipSetDevice(src));
+            CHECK(hipMemcpy(dbuf[src], host_src.data(), kBytes, hipMemcpyHostToDevice));
+        } else {
+            printf("direct %d->%d: N/A (peer capability %s)\n", src, dst,
+                   dirs[k].peer_cap ? "yes-but-enable-failed" : "no");
+        }
+
+        // --- Host-staged path (always): D2H completion, then H2D. ---
+        {
+            std::vector<uint8_t> poison(kBytes, 0x5A);
+            CHECK(hipSetDevice(dst));
+            CHECK(hipMemcpy(dbuf[dst], poison.data(), kBytes, hipMemcpyHostToDevice));
+            CHECK(hipSetDevice(src));
+            for (int w = 0; w < kWarmups; ++w) {
+                CHECK(hipMemcpyAsync(stage, dbuf[src], kBytes, hipMemcpyDeviceToHost,
+                                     streams[src]));
+                CHECK(hipStreamSynchronize(streams[src]));  // D2H completion first
+                CHECK(hipSetDevice(dst));
+                CHECK(hipMemcpyAsync(dbuf[dst], stage, kBytes, hipMemcpyHostToDevice,
+                                     streams[dst]));
+                CHECK(hipStreamSynchronize(streams[dst]));
+                CHECK(hipSetDevice(src));
+            }
+            std::vector<double> trials;
+            for (int t = 0; t < kTrials; ++t) {
+                // Source is current before the timed interval. The interval
+                // includes both completed DMA legs and the inter-device handoff.
+                auto t0 = std::chrono::steady_clock::now();
+                CHECK(hipMemcpyAsync(stage, dbuf[src], kBytes, hipMemcpyDeviceToHost,
+                                     streams[src]));
+                CHECK(hipStreamSynchronize(streams[src]));
+                CHECK(hipSetDevice(dst));
+                CHECK(hipMemcpyAsync(dbuf[dst], stage, kBytes, hipMemcpyHostToDevice,
+                                     streams[dst]));
+                CHECK(hipStreamSynchronize(streams[dst]));
+                auto t1 = std::chrono::steady_clock::now();
+                trials.push_back(
+                    std::chrono::duration<double, std::milli>(t1 - t0).count());
+                CHECK(hipSetDevice(src));
+            }
+            dirs[k].staged_ms = median_ms(trials);
+            dirs[k].staged_gbps = gbps((double)kBytes, dirs[k].staged_ms);
+            printf("staged_raw_ms %d->%d:", src, dst);
+            for (double v : trials) printf(" %.4f", v);
+            printf("\n");
+            CHECK(hipSetDevice(dst));
+            CHECK(hipMemcpy(host_check.data(), dbuf[dst], kBytes, hipMemcpyDeviceToHost));
+            dirs[k].staged_ok = verify_pattern(host_check.data(), kBytes, seed, "staged");
+            all_content_ok &= dirs[k].staged_ok;
+            printf("staged %d->%d: median %.4f ms, %.4f GB/s(decimal), content %s\n", src,
+                   dst, dirs[k].staged_ms, dirs[k].staged_gbps,
+                   dirs[k].staged_ok ? "OK" : "MISMATCH");
+        }
+    }
+
+    for (int k = 0; k < 2; ++k) {
+        CHECK(hipSetDevice(devs[k]));
+        CHECK(hipStreamDestroy(streams[k]));
+        CHECK(hipFree(dbuf[k]));
+    }
+    CHECK(hipHostFree(stage));
+
+    // Judgment: diagnostic PASS = peer map established in both directions AND
+    // host-staged baseline measured with exact content in both directions.
+    // Unavailable direct P2P is an expected valid result (roadmap risk text).
+    printf("--- summary ---\n");
+    bool staged_ok = true;
+    for (int k = 0; k < 2; ++k) {
+        printf("leg %d->%d peer_cap=%s direct=%s staged=%.4fms/%.4fGB/s content=%s/%s\n",
+               dirs[k].src, dirs[k].dst, dirs[k].peer_cap ? "yes" : "no",
+               (dirs[k].direct_ms >= 0 ? "measured" : "N/A"), dirs[k].staged_ms,
+               dirs[k].staged_gbps, dirs[k].direct_ms >= 0
+                                            ? (dirs[k].direct_ok ? "OK" : "MISMATCH")
+                                            : "n/a",
+               dirs[k].staged_ok ? "OK" : "MISMATCH");
+        staged_ok &= (dirs[k].staged_ms >= 0 && dirs[k].staged_ok);
+    }
+    const char* transport = "HostStaged";  // direct only if measured available+correct
+    bool direct_usable = true;
+    for (int k = 0; k < 2; ++k)
+        direct_usable &= (dirs[k].direct_ms >= 0 && dirs[k].direct_ok);
+    if (direct_usable) transport = "Direct";
+    printf("selected_transport=%s\n", transport);
+    // Both peer-map queries are already established: CHECK returns before
+    // this judgment on any query failure.
+    bool pass = staged_ok && all_content_ok;
+    printf("A0.S6 %s\n", pass ? "PASS" : "FAIL");
+    return pass ? 0 : 1;
 }


### PR DESCRIPTION
## Card
A0.S6 — p2p spike (kind: implementation; GPU: yes; size: S)

## Spec sections implemented
- spec 5 §1–2: measures rather than assumes the bidirectional topology transport.
- spec 5 §6: compares genuine direct peer copies with explicit pinned-host staging.
- spec 11 §7: records 16 KiB link latency and bandwidth for the topology measurement block.
- roadmap §A0: judges peer mapping on the dual-R9700 reference machine.

## Deliverables
- [x] One self-verifying HIP program that queries and enables peer access in both directions.
- [x] Direct and explicit host-staged 16 KiB latency measurements with raw trials and decimal GB/s.
- [x] Exact destination-content checks and fail-closed HIP/device handling.
- [x] `spikes/p2p/RESULT.md` with commands, hardware fingerprint, raw measurements, and judgment.
- [x] SI-2 records the stale seeded PCIe-width description found by the live topology probe.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| bidirectional `hipDeviceCanAccessPeer` map and peer enable | `spikes/p2p/p2p.hip` | gpu | green |
| genuine direct 16 KiB latency and bandwidth, both directions | `spikes/p2p/p2p.hip` | gpu | green |
| explicit pinned-host-staged 16 KiB latency and bandwidth, both directions | `spikes/p2p/p2p.hip` | gpu | green |
| exhaustive destination-content verification | `spikes/p2p/p2p.hip` | gpu | green |
| warning-free gfx1201 compilation | `spikes/p2p/p2p.hip` | compile-only | green |

## Decisions
- none

## SPEC-ISSUES filed
- SI-2: spec 5 §2 and `hardware/dual-r9700/hardware.json` describe rank 1 as Gen4 x4, while both live R9700 endpoints report Gen5 x16.

## New dependencies
- none

## Hardware
Tests run here: local reference runner — ASRock B850M-C, Ryzen 5 9600X, two AMD Radeon AI PRO R9700 gfx1201 devices at PCI `0000:03:00.0` and `0000:13:00.0`, both currently 32.0 GT/s x16 in separate IOMMU groups; kernel `7.1.5-ogc5.1.fc44.x86_64`; HIP runtime/driver `71460850` from `r9v-ci:test`.
Tests pending on the runner: none.
Measured numbers (if any): exact command, raw samples, and fingerprint are in `spikes/p2p/RESULT.md`; direct medians 21.5–21.8 µs (0→1) and 27.3–31.3 µs (1→0), host-staged medians 81.3–91.5 µs and 79.6–79.7 µs respectively. Peer query, peer enable, and every content gate passed in two independent runs.

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- B3: the seeded implementation was a print-only stub, so absence of the measurement and gates is established by the base revision rather than destructive local reversion.
- F3: the GPU test is already green twice on the named reference runner, so the card is complete rather than pending runner.

## Size check
Diff size vs card size class: approximately 360 changed lines vs S — acceptable for a standalone two-device measurement probe including two directions, two transports, raw-sample reporting, hardware validation, exact correctness gates, and its receipt.
