### PR TITLE
A0.3: implement generated configuration schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,40 @@
 version = 4
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +59,7 @@ name = "r9v"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
+ "r9v-config",
 ]
 
 [[package]]
@@ -40,6 +75,19 @@ name = "r9v-config"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
+ "r9v-config-macros",
+ "serde_json",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "r9v-config-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -149,6 +197,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +279,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,8 +332,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/r9v-serve",
     "crates/r9v-obs",
     "crates/r9v-config",
+    "crates/r9v-config/macros",
     "crates/r9v-helper",
     "crates/r9v",
     "xtask",

--- a/crates/r9v-config/Cargo.toml
+++ b/crates/r9v-config/Cargo.toml
@@ -8,4 +8,8 @@ repository.workspace = true
 description = "R9V configuration schema, settings generator, and validation (Spec 12, Spec 14 §2)"
 
 [dependencies]
+r9v-config-macros = { path = "macros" }
 r9v-common = { path = "../r9v-common" }
+serde_json = "1"
+thiserror = "2"
+toml = "0.8"

--- a/crates/r9v-config/macros/Cargo.toml
+++ b/crates/r9v-config/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "r9v-config-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Internal proc macros for r9v-config (section/setting)"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "3", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crates/r9v-config/macros/src/lib.rs
+++ b/crates/r9v-config/macros/src/lib.rs
@@ -1,0 +1,416 @@
+//! Internal proc macros for `r9v-config` (Spec 12 §2).
+//!
+//! `#[section]` generates strongly typed section metadata from annotated
+//! structs. `#[setting]` is the field helper consumed by `#[section]`; used
+//! alone it passes its item through unchanged.
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Expr, Lit, Meta, Token};
+
+/// Field helper consumed by `#[section]`.
+///
+/// When expanded on its own (never, in practice) it passes the input through
+/// unchanged so annotation placement stays valid during incremental edits.
+#[proc_macro_attribute]
+pub fn setting(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+struct SettingMeta {
+    kind: Option<String>,
+    doc: String,
+    default: String,
+    range_or_enum: String,
+    unit: String,
+    mutable: syn::Ident,
+    interacts: Vec<String>,
+    since: u32,
+    renamed_from: String,
+}
+
+fn lit_str(expr: &Expr) -> Option<String> {
+    if let Expr::Lit(l) = expr {
+        if let Lit::Str(s) = &l.lit {
+            return Some(s.value());
+        }
+    }
+    None
+}
+
+fn str_array(expr: &Expr) -> Option<Vec<String>> {
+    if let Expr::Array(a) = expr {
+        let mut out = Vec::new();
+        for e in &a.elems {
+            out.push(lit_str(e)?);
+        }
+        return Some(out);
+    }
+    None
+}
+
+fn parse_setting_meta(
+    field_span: Span,
+    metas: Punctuated<Meta, Token![,]>,
+) -> syn::Result<SettingMeta> {
+    let mut doc: Option<String> = None;
+    let mut kind: Option<String> = None;
+    let mut default: Option<String> = None;
+    let mut range: Option<String> = None;
+    let mut values: Option<Vec<String>> = None;
+    let mut unit = String::new();
+    let mut mutable: Option<syn::Ident> = None;
+    let mut interacts: Vec<String> = Vec::new();
+    let mut since: u32 = 1;
+    let mut renamed_from = String::new();
+    for m in metas {
+        match m {
+            Meta::NameValue(nv) => {
+                let key = nv
+                    .path
+                    .get_ident()
+                    .map(|i| i.to_string())
+                    .unwrap_or_default();
+                match key.as_str() {
+                    "kind" => {
+                        kind =
+                            Some(lit_str(&nv.value).ok_or_else(|| {
+                                syn::Error::new(nv.span(), "kind must be a string")
+                            })?)
+                    }
+                    "doc" => {
+                        doc =
+                            Some(lit_str(&nv.value).ok_or_else(|| {
+                                syn::Error::new(nv.span(), "doc must be a string")
+                            })?)
+                    }
+                    "default" => {
+                        default = Some(lit_str(&nv.value).ok_or_else(|| {
+                            syn::Error::new(nv.span(), "default must be a string")
+                        })?)
+                    }
+                    "range" => {
+                        range =
+                            Some(lit_str(&nv.value).ok_or_else(|| {
+                                syn::Error::new(nv.span(), "range must be a string")
+                            })?)
+                    }
+                    "values" | "enum_values" | "enm" => {
+                        values = Some(str_array(&nv.value).ok_or_else(|| {
+                            syn::Error::new(nv.span(), "values must be an array of strings")
+                        })?);
+                    }
+                    "unit" => {
+                        unit = lit_str(&nv.value)
+                            .ok_or_else(|| syn::Error::new(nv.span(), "unit must be a string"))?
+                    }
+                    "mutable" => {
+                        let s = match &nv.value {
+                            Expr::Path(p) => p.path.get_ident().cloned(),
+                            Expr::Lit(l) => {
+                                if let Lit::Str(s) = &l.lit {
+                                    Some(syn::Ident::new(&s.value(), Span::call_site()))
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        };
+                        let id = s.ok_or_else(|| {
+                            syn::Error::new(nv.span(), "mutable must be Runtime, Reload or Load")
+                        })?;
+                        let name = id.to_string();
+                        if !matches!(name.as_str(), "Runtime" | "Reload" | "Load") {
+                            return Err(syn::Error::new(
+                                id.span(),
+                                "mutable must be Runtime, Reload or Load",
+                            ));
+                        }
+                        mutable = Some(id);
+                    }
+                    "interacts" => {
+                        interacts = str_array(&nv.value).ok_or_else(|| {
+                            syn::Error::new(nv.span(), "interacts must be an array of strings")
+                        })?;
+                    }
+                    "since" => {
+                        if let Expr::Lit(l) = &nv.value {
+                            if let Lit::Int(i) = &l.lit {
+                                since = i.base10_parse::<u32>()?;
+                            } else {
+                                return Err(syn::Error::new(nv.span(), "since must be an integer"));
+                            }
+                        } else {
+                            return Err(syn::Error::new(nv.span(), "since must be an integer"));
+                        }
+                    }
+                    "renamed_from" => {
+                        renamed_from = lit_str(&nv.value).ok_or_else(|| {
+                            syn::Error::new(nv.span(), "renamed_from must be a string")
+                        })?;
+                    }
+                    other => {
+                        return Err(syn::Error::new(
+                            field_span,
+                            format!("unknown setting key `{other}`"),
+                        ))
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "setting entries must be key = value",
+                ))
+            }
+        }
+    }
+    let doc = doc.ok_or_else(|| syn::Error::new(field_span, "setting is missing `doc`"))?;
+    let default =
+        default.ok_or_else(|| syn::Error::new(field_span, "setting is missing `default`"))?;
+    let mutable =
+        mutable.ok_or_else(|| syn::Error::new(field_span, "setting is missing `mutable`"))?;
+    if range.is_some() && values.is_some() {
+        return Err(syn::Error::new(
+            field_span,
+            "setting must pass at most one of `range`, `values`",
+        ));
+    }
+    if doc.trim().is_empty() {
+        return Err(syn::Error::new(field_span, "setting doc must not be empty"));
+    }
+    if default.trim().is_empty() {
+        return Err(syn::Error::new(
+            field_span,
+            "setting default must not be empty",
+        ));
+    }
+    if let Some(range) = &range {
+        let Some((low, high)) = range.split_once("..=") else {
+            return Err(syn::Error::new(
+                field_span,
+                "range must use numeric `low..=high` syntax",
+            ));
+        };
+        let (Ok(low), Ok(high)) = (low.parse::<f64>(), high.parse::<f64>()) else {
+            return Err(syn::Error::new(field_span, "range bounds must be numeric"));
+        };
+        if !low.is_finite() || !high.is_finite() || low > high {
+            return Err(syn::Error::new(
+                field_span,
+                "range bounds must be finite and ordered",
+            ));
+        }
+    }
+    if let Some(values) = &values {
+        if values.is_empty() || values.iter().any(|value| value.is_empty()) {
+            return Err(syn::Error::new(
+                field_span,
+                "values must contain non-empty members",
+            ));
+        }
+        if values
+            .iter()
+            .enumerate()
+            .any(|(index, value)| values[..index].contains(value))
+        {
+            return Err(syn::Error::new(
+                field_span,
+                "values must not contain duplicates",
+            ));
+        }
+    }
+    let range_or_enum = range
+        .or_else(|| values.map(|v| v.join("|")))
+        .unwrap_or_default();
+    Ok(SettingMeta {
+        kind,
+        doc,
+        default,
+        range_or_enum,
+        unit,
+        mutable,
+        interacts,
+        since,
+        renamed_from,
+    })
+}
+
+/// Section attribute: `#[section("name")]` or `#[section("name", doc = "...")]`.
+///
+/// Generates `impl` metadata (`SECTION`, `SETTINGS`, `setting(key)`) from the
+/// annotated struct's `#[setting(...)]` fields. The struct itself is emitted
+/// unchanged apart from stripping the consumed `#[setting]` helpers.
+#[proc_macro_attribute]
+pub fn section(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let out = section_impl(attr, item);
+    match out {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn section_impl(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
+    let parsed: Punctuated<Expr, Token![,]> =
+        syn::parse::Parser::parse2(Punctuated::parse_terminated, attr.into())?;
+    let mut section_name: Option<String> = None;
+    let mut section_doc = String::new();
+    for e in parsed {
+        match e {
+            Expr::Lit(l) => {
+                if let Lit::Str(s) = &l.lit {
+                    if section_name.is_some() {
+                        return Err(syn::Error::new(s.span(), "duplicate section name"));
+                    }
+                    section_name = Some(s.value());
+                } else {
+                    return Err(syn::Error::new(
+                        Span::call_site(),
+                        "section name must be a string literal",
+                    ));
+                }
+            }
+            Expr::Assign(a) => {
+                let key = match *a.left {
+                    Expr::Path(ref p) => p
+                        .path
+                        .get_ident()
+                        .map(|i| i.to_string())
+                        .unwrap_or_default(),
+                    _ => {
+                        return Err(syn::Error::new(
+                            a.span(),
+                            "unknown section key (expected `doc`)",
+                        ))
+                    }
+                };
+                let val = match *a.right {
+                    Expr::Lit(ref l) => {
+                        if let Lit::Str(s) = &l.lit {
+                            s.value()
+                        } else {
+                            return Err(syn::Error::new(a.span(), "doc must be a string"));
+                        }
+                    }
+                    _ => return Err(syn::Error::new(a.span(), "doc must be a string")),
+                };
+                if key == "doc" {
+                    section_doc = val;
+                } else if key == "name" {
+                    section_name = Some(val);
+                } else {
+                    return Err(syn::Error::new(
+                        a.span(),
+                        "unknown section key (expected `doc`)",
+                    ));
+                }
+            }
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "section takes a name literal and optional doc = \"...\"",
+                ))
+            }
+        }
+    }
+    let section_name = section_name
+        .ok_or_else(|| syn::Error::new(Span::call_site(), "section is missing its name"))?;
+    if section_name.is_empty()
+        || section_name.split('.').any(|part| {
+            part.is_empty() || !part.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_')
+        })
+    {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            "section name must contain lowercase snake-case segments",
+        ));
+    }
+
+    let mut input: DeriveInput = syn::parse(item)?;
+    let fields = match &mut input.data {
+        Data::Struct(s) => match &mut s.fields {
+            syn::Fields::Named(f) => f,
+            _ => {
+                return Err(syn::Error::new(
+                    input.ident.span(),
+                    "section structs need named fields",
+                ))
+            }
+        },
+        _ => {
+            return Err(syn::Error::new(
+                input.ident.span(),
+                "section applies to structs",
+            ))
+        }
+    };
+
+    let mut specs = Vec::new();
+    for f in fields.named.iter_mut() {
+        let fname = f.ident.clone().expect("named field").to_string();
+        let idx = f.attrs.iter().position(|a| a.path().is_ident("setting"));
+        let Some(i) = idx else {
+            return Err(syn::Error::new(
+                f.ident.span(),
+                format!("field `{fname}` is missing `#[setting(...)]`"),
+            ));
+        };
+        let attr = f.attrs.remove(i);
+        let metas: Punctuated<Meta, Token![,]> =
+            attr.parse_args_with(Punctuated::parse_terminated)?;
+        let sm = parse_setting_meta(f.ident.span(), metas)?;
+        let key = format!("{section_name}.{fname}");
+        let ty = &f.ty;
+        let derived_type = quote!(#ty).to_string().replace(' ', "");
+        let type_name = sm.kind.unwrap_or(derived_type);
+        let mut_id = sm.mutable;
+        let doc = sm.doc;
+        let default = sm.default;
+        let range_or_enum = sm.range_or_enum;
+        let unit = sm.unit;
+        let interacts = sm.interacts;
+        let since = sm.since;
+        let renamed_from = sm.renamed_from;
+        specs.push(quote! {
+            ::r9v_config::SettingSpec {
+                key: #key,
+                type_name: #type_name,
+                doc: #doc,
+                default: #default,
+                range_or_enum: #range_or_enum,
+                unit: #unit,
+                mutability: ::r9v_config::Mutability::#mut_id,
+                interacts: &[#(#interacts),*],
+                since: #since,
+                renamed_from: #renamed_from,
+            }
+        });
+    }
+
+    let ident = &input.ident;
+    let n = specs.len();
+    let expanded = quote! {
+        #input
+
+        impl #ident {
+            /// Section name (Spec 12 §3, e.g. `"load"`).
+            pub const SECTION: &'static str = #section_name;
+            /// Section doc string declared on `#[section]`.
+            pub const SECTION_DOC: &'static str = #section_doc;
+            /// Strongly typed per-setting metadata, in declaration order.
+            pub const SETTINGS: &'static [::r9v_config::SettingSpec] = &[
+                #(#specs),*
+            ];
+
+            /// Look up one setting by full `section.key`.
+            pub fn setting(key: &str) -> Option<&'static ::r9v_config::SettingSpec> {
+                Self::SETTINGS.iter().find(|s| s.key == key)
+            }
+
+            /// Number of settings in this section.
+            pub const fn len() -> usize { #n }
+        }
+    };
+    Ok(expanded.into())
+}

--- a/crates/r9v-config/src/config.rs
+++ b/crates/r9v-config/src/config.rs
@@ -1,0 +1,906 @@
+//! Effective configuration, precedence, sources, and validation (Spec 12 §4–5).
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use thiserror::Error;
+use toml::Value;
+
+use r9v_common::parse_byte_size;
+
+use crate::{all_settings, find_setting, Mutability, SettingSpec};
+
+/// Schema version written at the top of every generated config (Spec 12 §6).
+pub const CONFIG_VERSION: i64 = 1;
+
+/// Errors produced while loading or changing configuration (Spec 12 §5).
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// The TOML document could not be parsed.
+    #[error("cannot parse configuration {input}: {message}")]
+    Parse {
+        /// Input label or path.
+        input: String,
+        /// Parser detail.
+        message: String,
+    },
+    /// `config_version` was absent, malformed, or unsupported.
+    #[error("configuration version must be {required}; got {available}")]
+    Version {
+        /// Required schema version.
+        required: i64,
+        /// Supplied value or `missing`.
+        available: String,
+    },
+    /// A setting was not declared by the schema.
+    #[error("unknown setting `{key}`; did you mean `{nearest}`?")]
+    UnknownKey {
+        /// Rejected key.
+        key: String,
+        /// Nearest declared key by edit distance.
+        nearest: String,
+    },
+    /// A value had the wrong type.
+    #[error("setting `{key}` requires {required}; got {available}")]
+    Type {
+        /// Setting key.
+        key: String,
+        /// Required schema type.
+        required: String,
+        /// Supplied TOML type/value.
+        available: String,
+    },
+    /// A value was outside its declared range.
+    #[error("setting `{key}` requires range {required}; got {available}")]
+    Range {
+        /// Setting key.
+        key: String,
+        /// Declared range.
+        required: String,
+        /// Supplied number.
+        available: String,
+    },
+    /// A string was not a declared enum member.
+    #[error("setting `{key}` requires one of [{required}]; got `{available}`")]
+    Enum {
+        /// Setting key.
+        key: String,
+        /// Allowed values.
+        required: String,
+        /// Supplied value.
+        available: String,
+    },
+    /// A supplied load-time path did not exist.
+    #[error("setting `{key}` requires an existing path; `{path}` does not exist")]
+    MissingPath {
+        /// Setting key.
+        key: String,
+        /// Missing path.
+        path: PathBuf,
+    },
+    /// A runtime request tried to change a non-runtime setting.
+    #[error(
+        "setting `{key}` is {mutability}, not Runtime, and cannot change through the runtime API"
+    )]
+    Mutability {
+        /// Setting key.
+        key: String,
+        /// Declared mutability.
+        mutability: Mutability,
+    },
+    /// One or more cross-field rules failed. All failures are reported.
+    #[error("cross-field validation failed: {messages:?}")]
+    CrossField {
+        /// Complete deterministic failure list.
+        messages: Vec<String>,
+    },
+    /// Multiple independent values in one layer failed validation.
+    #[error("configuration validation failed: {summary}")]
+    Multiple {
+        /// User-facing concatenation of every problem.
+        summary: String,
+        /// Every validation problem, in deterministic input order.
+        problems: Vec<ConfigError>,
+    },
+    /// A requested auto resolution targeted a concrete value.
+    #[error("setting `{key}` is not currently `auto`")]
+    NotAuto {
+        /// Setting key.
+        key: String,
+    },
+    /// Generated artifacts could not be written.
+    #[error("configuration artifact I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Origin of one effective value (Spec 12 §4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Source {
+    /// Schema default.
+    Default,
+    /// Config file and one-based source line.
+    File {
+        /// File label/path.
+        path: String,
+        /// One-based line number.
+        line: usize,
+    },
+    /// Environment variable.
+    Env {
+        /// Exact variable name.
+        variable: String,
+    },
+    /// Generated command-line flag.
+    Cli {
+        /// Exact flag spelling.
+        flag: String,
+    },
+    /// Approved runtime update.
+    Runtime {
+        /// Requester identity supplied by the API boundary.
+        requester: String,
+        /// Timestamp supplied by the API boundary.
+        time: String,
+    },
+}
+
+impl Source {
+    fn precedence(&self) -> u8 {
+        match self {
+            Source::Default => 0,
+            Source::File { .. } => 1,
+            Source::Env { .. } => 2,
+            Source::Cli { .. } => 3,
+            Source::Runtime { .. } => 4,
+        }
+    }
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Source::Default => write!(f, "default"),
+            Source::File { path, line } => write!(f, "file:{path}:{line}"),
+            Source::Env { .. } => write!(f, "env"),
+            Source::Cli { .. } => write!(f, "cli"),
+            Source::Runtime { requester, time } => {
+                write!(f, "runtime:{requester}:{time}")
+            }
+        }
+    }
+}
+
+/// Effective raw value, source, and optional resolution of `auto` (Spec 12 §4).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourcedValue {
+    /// Configured value. The string `"auto"` remains visible after resolution.
+    pub value: Value,
+    /// Winning precedence source.
+    pub source: Source,
+    /// Concrete value selected by the documented auto rule, when resolved.
+    pub resolved: Option<Value>,
+    /// Rule text copied verbatim from the setting's schema doc.
+    pub auto_rule: Option<&'static str>,
+}
+
+/// Effective phase-A configuration (Spec 12 §4–5).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EffectiveConfig {
+    values: BTreeMap<String, SourcedValue>,
+    extensions: BTreeMap<String, Value>,
+    warnings: Vec<String>,
+}
+
+impl Default for EffectiveConfig {
+    fn default() -> Self {
+        Self::from_defaults()
+    }
+}
+
+impl EffectiveConfig {
+    /// Construct all schema defaults with `Source::Default` (Spec 12 §4).
+    pub fn from_defaults() -> Self {
+        let values = all_settings()
+            .into_iter()
+            .map(|spec| {
+                let value = default_value(spec);
+                (
+                    spec.key.to_string(),
+                    SourcedValue {
+                        auto_rule: is_auto(&value).then(|| auto_rule(spec.doc)),
+                        value,
+                        source: Source::Default,
+                        resolved: None,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            values,
+            extensions: BTreeMap::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Return one effective setting.
+    pub fn get(&self, key: &str) -> Option<&SourcedValue> {
+        self.values.get(key)
+    }
+
+    /// Iterate effective settings in deterministic schema order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &SourcedValue)> {
+        all_settings()
+            .into_iter()
+            .filter_map(|spec| self.values.get(spec.key).map(|value| (spec.key, value)))
+    }
+
+    /// Preserved top-level `[x-*]` extension sections.
+    pub fn extensions(&self) -> &BTreeMap<String, Value> {
+        &self.extensions
+    }
+
+    /// Migration warnings emitted while loading renamed keys.
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
+    }
+
+    /// Apply a complete TOML file atomically (Spec 12 §4–6).
+    pub fn apply_file_str(
+        &mut self,
+        path: impl Into<String>,
+        text: &str,
+    ) -> Result<(), ConfigError> {
+        let path = path.into();
+        let table = text
+            .parse::<toml::Table>()
+            .map_err(|error| ConfigError::Parse {
+                input: path.clone(),
+                message: error.to_string(),
+            })?;
+        let version = table.get("config_version");
+        match version.and_then(Value::as_integer) {
+            Some(CONFIG_VERSION) => {}
+            Some(other) => {
+                return Err(ConfigError::Version {
+                    required: CONFIG_VERSION,
+                    available: other.to_string(),
+                })
+            }
+            None => {
+                return Err(ConfigError::Version {
+                    required: CONFIG_VERSION,
+                    available: version
+                        .map(ToString::to_string)
+                        .unwrap_or_else(|| "missing".to_string()),
+                })
+            }
+        }
+
+        let lines = key_lines(text);
+        let mut flattened = Vec::new();
+        let mut problems = Vec::new();
+        let mut extensions = BTreeMap::new();
+        for (key, value) in &table {
+            if key == "config_version" {
+                continue;
+            }
+            if key.starts_with("x-") {
+                extensions.insert(key.clone(), value.clone());
+                continue;
+            }
+            flatten_value(key, value, &mut flattened, &mut problems);
+        }
+
+        let mut candidate = self.clone();
+        candidate.extensions = extensions;
+        for (input_key, value) in flattened {
+            let (key, warning) = match canonical_key(&input_key) {
+                Ok(canonical) => canonical,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Some(warning) = warning {
+                candidate.warnings.push(warning);
+            }
+            let spec = find_setting(key).expect("canonical key is declared");
+            if let Err(error) = validate_value(spec, &value, true) {
+                problems.push(error);
+                continue;
+            }
+            let source = Source::File {
+                path: path.clone(),
+                line: lines.get(&input_key).copied().unwrap_or(1),
+            };
+            candidate.assign(spec, value, source);
+        }
+        finish_problems(problems)?;
+        candidate.validate_cross_fields()?;
+        *self = candidate;
+        Ok(())
+    }
+
+    /// Apply `R9V__SECTION__KEY=value` variables atomically (Spec 12 §4).
+    pub fn apply_env<I, K, V>(&mut self, entries: I) -> Result<(), ConfigError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut candidate = self.clone();
+        let mut problems = Vec::new();
+        for (name, raw) in entries {
+            let name = name.into();
+            if !name.starts_with("R9V__") {
+                continue;
+            }
+            let key = name[5..]
+                .split("__")
+                .map(str::to_ascii_lowercase)
+                .collect::<Vec<_>>()
+                .join(".");
+            let (key, warning) = match canonical_key(&key) {
+                Ok(canonical) => canonical,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Some(warning) = warning {
+                candidate.warnings.push(warning);
+            }
+            let spec = find_setting(key).expect("canonical key is declared");
+            let value = match parse_text_value(spec, &raw.into()) {
+                Ok(value) => value,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Err(error) = validate_value(spec, &value, true) {
+                problems.push(error);
+                continue;
+            }
+            candidate.assign(spec, value, Source::Env { variable: name });
+        }
+        finish_problems(problems)?;
+        candidate.validate_cross_fields()?;
+        *self = candidate;
+        Ok(())
+    }
+
+    /// Apply generated CLI flags (`--section.key value`) atomically (Spec 12 §4).
+    pub fn apply_cli<I, K, V>(&mut self, entries: I) -> Result<(), ConfigError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut candidate = self.clone();
+        let mut problems = Vec::new();
+        for (flag, raw) in entries {
+            let flag = flag.into();
+            let input_key = flag.strip_prefix("--").unwrap_or(&flag);
+            let (key, warning) = match canonical_key(input_key) {
+                Ok(canonical) => canonical,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Some(warning) = warning {
+                candidate.warnings.push(warning);
+            }
+            let spec = find_setting(key).expect("canonical key is declared");
+            let value = match parse_text_value(spec, &raw.into()) {
+                Ok(value) => value,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Err(error) = validate_value(spec, &value, true) {
+                problems.push(error);
+                continue;
+            }
+            candidate.assign(spec, value, Source::Cli { flag });
+        }
+        finish_problems(problems)?;
+        candidate.validate_cross_fields()?;
+        *self = candidate;
+        Ok(())
+    }
+
+    /// Apply approved runtime values atomically; non-runtime keys are refused (Spec 12 §4–5).
+    pub fn apply_runtime<I, K, V>(
+        &mut self,
+        entries: I,
+        requester: impl Into<String>,
+        time: impl Into<String>,
+    ) -> Result<(), ConfigError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let requester = requester.into();
+        let time = time.into();
+        let mut candidate = self.clone();
+        let mut problems = Vec::new();
+        for (input_key, raw) in entries {
+            let input_key = input_key.into();
+            let (key, warning) = match canonical_key(&input_key) {
+                Ok(canonical) => canonical,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Some(warning) = warning {
+                candidate.warnings.push(warning);
+            }
+            let spec = find_setting(key).expect("canonical key is declared");
+            if spec.mutability != Mutability::Runtime {
+                problems.push(ConfigError::Mutability {
+                    key: key.to_string(),
+                    mutability: spec.mutability,
+                });
+                continue;
+            }
+            let value = match parse_text_value(spec, &raw.into()) {
+                Ok(value) => value,
+                Err(error) => {
+                    problems.push(error);
+                    continue;
+                }
+            };
+            if let Err(error) = validate_value(spec, &value, false) {
+                problems.push(error);
+                continue;
+            }
+            candidate.assign(
+                spec,
+                value,
+                Source::Runtime {
+                    requester: requester.clone(),
+                    time: time.clone(),
+                },
+            );
+        }
+        finish_problems(problems)?;
+        candidate.validate_cross_fields()?;
+        *self = candidate;
+        Ok(())
+    }
+
+    /// Attach the concrete result of a documented `auto` rule (Spec 12 §1, §4).
+    pub fn resolve_auto(&mut self, key: &str, resolved: Value) -> Result<(), ConfigError> {
+        let spec = find_setting(key).ok_or_else(|| unknown_key(key))?;
+        if is_auto(&resolved) {
+            return Err(type_error(spec, resolved));
+        }
+        validate_value(spec, &resolved, false)?;
+        let current = self
+            .values
+            .get_mut(key)
+            .expect("all declared settings have defaults");
+        if !is_auto(&current.value) {
+            return Err(ConfigError::NotAuto {
+                key: key.to_string(),
+            });
+        }
+        current.resolved = Some(resolved);
+        Ok(())
+    }
+
+    /// Run every applicable phase-A cross-field rule and report all failures (Spec 12 §5).
+    pub fn validate_cross_fields(&self) -> Result<(), ConfigError> {
+        let mut messages = Vec::new();
+        let prefill_min = self.integer("scheduler.prefill_min_chunk");
+        let prefill_max = self.integer("scheduler.prefill_max_chunk");
+        let max_bucket = self
+            .get("warmup.buckets")
+            .and_then(|v| max_t_pre_bucket(&v.value))
+            .unwrap_or(2048);
+        if !(prefill_min <= prefill_max && prefill_max <= max_bucket) {
+            messages.push(rule_message(
+                &["scheduler.prefill_min_chunk", "scheduler.prefill_max_chunk", "warmup.buckets"],
+                format!("required min <= max <= max T_pre bucket; got {prefill_min} <= {prefill_max} <= {max_bucket}"),
+            ));
+        }
+
+        let k_max = self.integer("spec.k_max");
+        let tree_max = self.integer("spec.tree_max");
+        if k_max > 15 {
+            messages.push(rule_message(
+                &["spec.k_max"],
+                format!("required k_max <= 15; got {k_max}"),
+            ));
+        }
+        if tree_max > 16 {
+            messages.push(rule_message(
+                &["spec.tree_max"],
+                format!("required tree_max <= 16; got {tree_max}"),
+            ));
+        }
+        if k_max > tree_max {
+            messages.push(rule_message(
+                &["spec.k_max", "spec.tree_max"],
+                format!("required k_max <= tree_max; got {k_max} > {tree_max}"),
+            ));
+        }
+
+        let max_ctx = self.integer("state.max_ctx");
+        if max_ctx % 32 != 0 {
+            messages.push(rule_message(
+                &["state.max_ctx"],
+                format!("required max_ctx % 32 == 0; got {max_ctx}"),
+            ));
+        }
+        if messages.is_empty() {
+            Ok(())
+        } else {
+            Err(ConfigError::CrossField { messages })
+        }
+    }
+
+    fn integer(&self, key: &str) -> i64 {
+        self.values
+            .get(key)
+            .and_then(|v| v.value.as_integer())
+            .expect("integer schema default validated")
+    }
+
+    fn assign(&mut self, spec: &'static SettingSpec, value: Value, source: Source) {
+        let replace = self
+            .values
+            .get(spec.key)
+            .map(|current| source.precedence() >= current.source.precedence())
+            .unwrap_or(true);
+        if replace {
+            self.values.insert(
+                spec.key.to_string(),
+                SourcedValue {
+                    auto_rule: is_auto(&value).then(|| auto_rule(spec.doc)),
+                    value,
+                    source,
+                    resolved: None,
+                },
+            );
+        }
+    }
+}
+
+fn canonical_key(input: &str) -> Result<(&'static str, Option<String>), ConfigError> {
+    if let Some(spec) = find_setting(input) {
+        return Ok((spec.key, None));
+    }
+    if let Some(spec) = all_settings()
+        .into_iter()
+        .find(|spec| !spec.renamed_from.is_empty() && spec.renamed_from == input)
+    {
+        return Ok((
+            spec.key,
+            Some(format!(
+                "setting `{input}` was renamed to `{}`; use the new key",
+                spec.key
+            )),
+        ));
+    }
+    Err(unknown_key(input))
+}
+
+fn unknown_key(input: &str) -> ConfigError {
+    let nearest = all_settings()
+        .into_iter()
+        .min_by_key(|spec| (levenshtein(input, spec.key), spec.key))
+        .map(|spec| spec.key)
+        .unwrap_or("")
+        .to_string();
+    ConfigError::UnknownKey {
+        key: input.to_string(),
+        nearest,
+    }
+}
+
+fn flatten_value(
+    prefix: &str,
+    value: &Value,
+    out: &mut Vec<(String, Value)>,
+    problems: &mut Vec<ConfigError>,
+) {
+    if find_setting(prefix).is_some()
+        || all_settings()
+            .into_iter()
+            .any(|spec| !spec.renamed_from.is_empty() && spec.renamed_from == prefix)
+    {
+        out.push((prefix.to_string(), value.clone()));
+        return;
+    }
+    if let Some(table) = value.as_table() {
+        let has_descendants = all_settings()
+            .into_iter()
+            .any(|spec| spec.key.starts_with(&format!("{prefix}.")));
+        if has_descendants {
+            for (key, child) in table {
+                flatten_value(&format!("{prefix}.{key}"), child, out, problems);
+            }
+            return;
+        }
+    }
+    problems.push(unknown_key(prefix));
+}
+
+fn finish_problems(mut problems: Vec<ConfigError>) -> Result<(), ConfigError> {
+    match problems.len() {
+        0 => Ok(()),
+        1 => Err(problems.pop().expect("length checked as one")),
+        _ => {
+            let summary = problems
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("; ");
+            Err(ConfigError::Multiple { summary, problems })
+        }
+    }
+}
+
+fn key_lines(text: &str) -> BTreeMap<String, usize> {
+    let mut section = String::new();
+    let mut lines = BTreeMap::new();
+    for (index, line) in text.lines().enumerate() {
+        let content = line.split('#').next().unwrap_or("").trim();
+        if content.starts_with('[') && content.ends_with(']') {
+            section = content
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .trim()
+                .to_string();
+            continue;
+        }
+        if let Some((key, _)) = content.split_once('=') {
+            let key = key.trim().trim_matches('"');
+            let full = if section.is_empty() {
+                key.to_string()
+            } else {
+                format!("{section}.{key}")
+            };
+            lines.insert(full, index + 1);
+        }
+    }
+    lines
+}
+
+fn parse_text_value(spec: &SettingSpec, raw: &str) -> Result<Value, ConfigError> {
+    let raw = raw.trim();
+    if spec.type_name.starts_with("Auto<") && raw.eq_ignore_ascii_case("auto") {
+        return Ok(Value::String("auto".to_string()));
+    }
+    let value = match spec.type_name {
+        "bool" => bool::from_str(raw)
+            .map(Value::Boolean)
+            .map_err(|_| type_error(spec, raw))?,
+        "u32" | "u64" => i64::from_str(raw)
+            .map(Value::Integer)
+            .map_err(|_| type_error(spec, raw))?,
+        "f32" => f64::from_str(raw)
+            .map(Value::Float)
+            .map_err(|_| type_error(spec, raw))?,
+        "Vec<String>" | "[str]" | "buckets" => {
+            parse_fragment(raw).ok_or_else(|| type_error(spec, raw))?
+        }
+        _ => Value::String(raw.trim_matches('"').to_string()),
+    };
+    Ok(value)
+}
+
+fn parse_fragment(raw: &str) -> Option<Value> {
+    format!("value = {raw}")
+        .parse::<toml::Table>()
+        .ok()?
+        .remove("value")
+}
+
+fn validate_value(spec: &SettingSpec, value: &Value, check_path: bool) -> Result<(), ConfigError> {
+    if spec.type_name.starts_with("Auto<") && is_auto(value) {
+        return Ok(());
+    }
+    validate_concrete_auto(spec, value)?;
+    let concrete_type = spec
+        .type_name
+        .strip_prefix("Auto<")
+        .and_then(|name| name.strip_suffix('>'))
+        .unwrap_or(spec.type_name);
+    if concrete_type == "bytes" {
+        let raw = value.as_str().ok_or_else(|| type_error(spec, value))?;
+        parse_byte_size(raw).map_err(|_| type_error(spec, value))?;
+    }
+    if spec.range_or_enum.contains('|') {
+        let available = value.as_str().ok_or_else(|| type_error(spec, value))?;
+        if !spec.range_or_enum.split('|').any(|item| item == available) {
+            return Err(ConfigError::Enum {
+                key: spec.key.to_string(),
+                required: spec.range_or_enum.replace('|', ", "),
+                available: available.to_string(),
+            });
+        }
+    } else if spec.range_or_enum.contains("..=") {
+        validate_range(spec, value)?;
+    }
+    if check_path && is_load_path(spec.key) {
+        if let Some(path) = value.as_str() {
+            if !matches!(path, "none" | "(none)" | "auto") && !Path::new(path).exists() {
+                return Err(ConfigError::MissingPath {
+                    key: spec.key.to_string(),
+                    path: PathBuf::from(path),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_concrete_auto(spec: &SettingSpec, value: &Value) -> Result<(), ConfigError> {
+    let ty = spec
+        .type_name
+        .strip_prefix("Auto<")
+        .and_then(|s| s.strip_suffix('>'))
+        .unwrap_or(spec.type_name);
+    let valid = match ty {
+        "bool" => value.is_bool(),
+        "u32" | "u64" => value.as_integer().is_some_and(|v| v >= 0),
+        "f32" => value.is_float() || value.is_integer(),
+        "Vec<String>" | "[str]" => value
+            .as_array()
+            .is_some_and(|items| items.iter().all(Value::is_str)),
+        "buckets" => valid_buckets(value),
+        _ => value.is_str(),
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(type_error(spec, value))
+    }
+}
+
+fn validate_range(spec: &SettingSpec, value: &Value) -> Result<(), ConfigError> {
+    let (low, high) = spec
+        .range_or_enum
+        .split_once("..=")
+        .expect("range metadata was validated by the macro");
+    let low = low.parse::<f64>().expect("numeric lower bound");
+    let high = high.parse::<f64>().expect("numeric upper bound");
+    let available = value
+        .as_float()
+        .or_else(|| value.as_integer().map(|v| v as f64))
+        .ok_or_else(|| type_error(spec, value))?;
+    if (low..=high).contains(&available) {
+        Ok(())
+    } else {
+        Err(ConfigError::Range {
+            key: spec.key.to_string(),
+            required: spec.range_or_enum.to_string(),
+            available: available.to_string(),
+        })
+    }
+}
+
+fn type_error(spec: &SettingSpec, available: impl fmt::Display) -> ConfigError {
+    ConfigError::Type {
+        key: spec.key.to_string(),
+        required: spec.type_name.to_string(),
+        available: available.to_string(),
+    }
+}
+
+pub(crate) fn default_value(spec: &SettingSpec) -> Value {
+    let default = spec.default;
+    if default.starts_with("auto") {
+        return Value::String("auto".to_string());
+    }
+    if spec.key == "warmup.buckets" {
+        let mut buckets = toml::Table::new();
+        buckets.insert("S".to_string(), integer_array(&[1, 2, 4]));
+        buckets.insert("T_dec".to_string(), integer_array(&[1, 2, 4, 8, 16, 32]));
+        buckets.insert("T_pre".to_string(), integer_array(&[0, 128, 512, 2048]));
+        return Value::Table(buckets);
+    }
+    match spec.type_name {
+        "bool" => Value::Boolean(default.parse().expect("bool schema default")),
+        "u32" | "u64" => Value::Integer(default.parse().expect("integer schema default")),
+        "f32" => Value::Float(default.parse().expect("float schema default")),
+        "Vec<String>" | "[str]" if spec.key == "bench.suites" => Value::Array(
+            ["decode", "decode-spec", "prefill", "multi"]
+                .into_iter()
+                .map(|s| Value::String(s.to_string()))
+                .collect(),
+        ),
+        _ => Value::String(default.to_string()),
+    }
+}
+
+fn is_auto(value: &Value) -> bool {
+    value.as_str() == Some("auto")
+}
+
+fn auto_rule(doc: &'static str) -> &'static str {
+    doc.split_once("auto = ")
+        .map(|(_, rule)| rule.trim_end_matches('.'))
+        .unwrap_or("resolved by the owning subsystem")
+}
+
+fn is_load_path(key: &str) -> bool {
+    matches!(
+        key,
+        "load.model" | "load.draft_model" | "load.eagle_head" | "load.cache_dir"
+    )
+}
+
+fn integer_array(values: &[i64]) -> Value {
+    Value::Array(values.iter().copied().map(Value::Integer).collect())
+}
+
+fn valid_buckets(value: &Value) -> bool {
+    let Some(table) = value.as_table() else {
+        return false;
+    };
+    if table.len() != 3
+        || !["S", "T_dec", "T_pre"]
+            .iter()
+            .all(|key| table.contains_key(*key))
+    {
+        return false;
+    }
+    valid_bucket_axis(table.get("S"), false)
+        && valid_bucket_axis(table.get("T_dec"), false)
+        && valid_bucket_axis(table.get("T_pre"), true)
+}
+
+fn valid_bucket_axis(value: Option<&Value>, allow_zero: bool) -> bool {
+    let Some(items) = value.and_then(Value::as_array) else {
+        return false;
+    };
+    !items.is_empty()
+        && items.iter().all(|item| {
+            item.as_integer()
+                .is_some_and(|number| number >= if allow_zero { 0 } else { 1 })
+        })
+}
+
+fn max_t_pre_bucket(value: &Value) -> Option<i64> {
+    value
+        .as_table()?
+        .get("T_pre")?
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_integer)
+        .max()
+}
+
+fn rule_message(keys: &[&str], detail: String) -> String {
+    let docs = keys
+        .iter()
+        .filter_map(|key| find_setting(key).map(|spec| format!("{key}: {:?}", spec.doc)))
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!("{detail}; schema docs: {docs}")
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let mut previous: Vec<usize> = (0..=b.chars().count()).collect();
+    for (i, ca) in a.chars().enumerate() {
+        let mut current = vec![i + 1];
+        for (j, cb) in b.chars().enumerate() {
+            let insert = current[j] + 1;
+            let delete = previous[j + 1] + 1;
+            let replace = previous[j] + usize::from(ca != cb);
+            current.push(insert.min(delete).min(replace));
+        }
+        previous = current;
+    }
+    previous[b.chars().count()]
+}

--- a/crates/r9v-config/src/generate.rs
+++ b/crates/r9v-config/src/generate.rs
@@ -1,0 +1,291 @@
+//! Deterministic config, documentation, and JSON-schema generation (Spec 12 §2).
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use serde_json::{json, Map, Value as JsonValue};
+use toml::Value;
+
+use crate::config::{default_value, ConfigError, EffectiveConfig, CONFIG_VERSION};
+use crate::{all_settings, SettingSpec};
+
+/// The three artifacts emitted by `r9v config gen` (Spec 12 §2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedArtifacts {
+    /// Commented config skeleton.
+    pub r9v_toml: String,
+    /// Per-setting Markdown reference.
+    pub config_markdown: String,
+    /// JSON Schema served by `/r9v/schema` later.
+    pub json_schema: String,
+}
+
+/// Generate every config artifact deterministically from schema declarations.
+pub fn generate_artifacts() -> GeneratedArtifacts {
+    let defaults = EffectiveConfig::from_defaults();
+    GeneratedArtifacts {
+        r9v_toml: render_effective_toml(&defaults, false),
+        config_markdown: generate_markdown(),
+        json_schema: generate_json_schema(),
+    }
+}
+
+/// Write `r9v.toml`, `docs/config.md`, and `r9v.schema.json` beneath `root`.
+pub fn write_generated(root: &Path) -> Result<GeneratedArtifacts, ConfigError> {
+    let generated = generate_artifacts();
+    let docs = root.join("docs");
+    std::fs::create_dir_all(&docs)?;
+    std::fs::write(root.join("r9v.toml"), &generated.r9v_toml)?;
+    std::fs::write(docs.join("config.md"), &generated.config_markdown)?;
+    std::fs::write(root.join("r9v.schema.json"), &generated.json_schema)?;
+    Ok(generated)
+}
+
+/// Render an effective configuration, optionally including source comments.
+/// Preserved `[x-*]` sections are appended unchanged in value semantics.
+pub fn render_effective_toml(config: &EffectiveConfig, include_sources: bool) -> String {
+    let mut out = String::new();
+    writeln!(
+        out,
+        "# Generated from r9v-config schema (Spec 12 §2). Do not maintain a parallel setting list."
+    )
+    .expect("String write");
+    writeln!(out, "config_version = {CONFIG_VERSION}\n").expect("String write");
+
+    let mut emitted = BTreeSet::new();
+    for spec in all_settings() {
+        let (section, leaf) = split_key(spec.key);
+        if emitted.insert(section) {
+            writeln!(out, "[{section}]").expect("String write");
+        }
+        writeln!(out, "# {}", spec.doc).expect("String write");
+        let mut metadata = format!(
+            "type: {}; default: {}; mutability: {}",
+            spec.type_name, spec.default, spec.mutability
+        );
+        if !spec.range_or_enum.is_empty() {
+            write!(metadata, "; constraint: {}", spec.range_or_enum).expect("String write");
+        }
+        if !spec.unit.is_empty() {
+            write!(metadata, "; unit: {}", spec.unit).expect("String write");
+        }
+        writeln!(out, "# {metadata}").expect("String write");
+        let sourced = config
+            .get(spec.key)
+            .expect("all declared settings have effective values");
+        if include_sources {
+            writeln!(out, "# source: {}", sourced.source).expect("String write");
+            if let Some(resolved) = &sourced.resolved {
+                writeln!(out, "# resolved: {}", toml_literal(resolved)).expect("String write");
+            }
+        }
+        writeln!(out, "{leaf} = {}\n", toml_literal(&sourced.value)).expect("String write");
+    }
+
+    if !config.extensions().is_empty() {
+        let extension_table: toml::Table = config
+            .extensions()
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        out.push_str(
+            &toml::to_string(&extension_table)
+                .expect("extension values came from a valid TOML document"),
+        );
+    } else if out.ends_with("\n\n") {
+        out.pop();
+    }
+    out
+}
+
+fn generate_markdown() -> String {
+    let mut out = String::from(
+        "# R9V configuration\n\nGenerated from the `r9v-config` schema (Spec 12 §2).\n\n",
+    );
+    let mut emitted = BTreeSet::new();
+    for spec in all_settings() {
+        let (section, _) = split_key(spec.key);
+        if emitted.insert(section) {
+            writeln!(out, "## `{section}`\n").expect("String write");
+        }
+        writeln!(out, "### `{}`\n", spec.key).expect("String write");
+        writeln!(out, "{}\n", spec.doc).expect("String write");
+        writeln!(out, "- Type: `{}`", spec.type_name).expect("String write");
+        writeln!(out, "- Default: `{}`", spec.default).expect("String write");
+        writeln!(out, "- Mutability: `{}`", spec.mutability).expect("String write");
+        if !spec.range_or_enum.is_empty() {
+            writeln!(out, "- Range/enum: `{}`", spec.range_or_enum).expect("String write");
+        }
+        if !spec.unit.is_empty() {
+            writeln!(out, "- Unit: `{}`", spec.unit).expect("String write");
+        }
+        writeln!(out, "- Since schema: `{}`", spec.since).expect("String write");
+        if !spec.interacts.is_empty() {
+            let keys = spec
+                .interacts
+                .iter()
+                .map(|key| format!("`{key}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(out, "- Interacts with: {keys}").expect("String write");
+        }
+        if !spec.renamed_from.is_empty() {
+            writeln!(out, "- Renamed from: `{}`", spec.renamed_from).expect("String write");
+        }
+        out.push('\n');
+    }
+    if out.ends_with("\n\n") {
+        out.pop();
+    }
+    out
+}
+
+fn generate_json_schema() -> String {
+    let mut root_properties = Map::new();
+    root_properties.insert(
+        "config_version".to_string(),
+        json!({"type": "integer", "const": CONFIG_VERSION}),
+    );
+    for spec in all_settings() {
+        insert_schema(&mut root_properties, spec);
+    }
+    let root = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://r9v.local/schema/config-v1.json",
+        "title": "R9V configuration v1",
+        "type": "object",
+        "required": ["config_version"],
+        "properties": root_properties,
+        "patternProperties": {"^x-": {"type": "object"}},
+        "additionalProperties": false
+    });
+    let mut text = serde_json::to_string_pretty(&root).expect("schema is JSON-serializable");
+    text.push('\n');
+    text
+}
+
+fn insert_schema(root: &mut Map<String, JsonValue>, spec: &SettingSpec) {
+    let parts: Vec<&str> = spec.key.split('.').collect();
+    insert_schema_parts(root, &parts, spec);
+}
+
+fn insert_schema_parts(
+    properties: &mut Map<String, JsonValue>,
+    parts: &[&str],
+    spec: &SettingSpec,
+) {
+    if parts.len() == 1 {
+        properties.insert(parts[0].to_string(), setting_schema(spec));
+        return;
+    }
+    let entry = properties.entry(parts[0].to_string()).or_insert_with(
+        || json!({"type": "object", "properties": {}, "additionalProperties": false}),
+    );
+    let child = entry
+        .as_object_mut()
+        .expect("section schema is an object")
+        .get_mut("properties")
+        .and_then(JsonValue::as_object_mut)
+        .expect("section schema has properties");
+    insert_schema_parts(child, &parts[1..], spec);
+}
+
+fn setting_schema(spec: &SettingSpec) -> JsonValue {
+    let concrete = spec
+        .type_name
+        .strip_prefix("Auto<")
+        .and_then(|ty| ty.strip_suffix('>'))
+        .unwrap_or(spec.type_name);
+    let mut schema = match concrete {
+        "bool" => json!({"type": "boolean"}),
+        "u32" | "u64" => json!({"type": "integer"}),
+        "f32" => json!({"type": "number"}),
+        "Vec<String>" | "[str]" => {
+            json!({"type": "array", "items": {"type": "string"}})
+        }
+        "buckets" => json!({
+            "type": "object",
+            "required": ["S", "T_dec", "T_pre"],
+            "properties": {
+                "S": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}},
+                "T_dec": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}},
+                "T_pre": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 0}}
+            },
+            "additionalProperties": false
+        }),
+        _ => json!({"type": "string"}),
+    };
+    let object = schema.as_object_mut().expect("setting schema is an object");
+    if spec.range_or_enum.contains('|') {
+        object.insert(
+            "enum".to_string(),
+            json!(spec.range_or_enum.split('|').collect::<Vec<_>>()),
+        );
+    } else if let Some((low, high)) = spec.range_or_enum.split_once("..=") {
+        if let (Ok(low), Ok(high)) = (low.parse::<f64>(), high.parse::<f64>()) {
+            object.insert("minimum".to_string(), json!(low));
+            object.insert("maximum".to_string(), json!(high));
+        }
+    }
+    if spec.type_name.starts_with("Auto<") && !spec.range_or_enum.contains("auto") {
+        let concrete_schema = JsonValue::Object(object.clone());
+        schema = json!({
+            "anyOf": [concrete_schema, {"const": "auto"}],
+        });
+    }
+    let object = schema.as_object_mut().expect("setting schema is an object");
+    object.insert("description".to_string(), json!(spec.doc));
+    object.insert(
+        "default".to_string(),
+        serde_json::to_value(default_value(spec)).expect("TOML defaults are JSON-serializable"),
+    );
+    object.insert(
+        "x-r9v-mutability".to_string(),
+        json!(spec.mutability.to_string()),
+    );
+    object.insert("x-r9v-since".to_string(), json!(spec.since));
+    if !spec.unit.is_empty() {
+        object.insert("x-r9v-unit".to_string(), json!(spec.unit));
+    }
+    schema
+}
+
+fn split_key(key: &str) -> (&str, &str) {
+    let split = key.rfind('.').expect("setting keys contain a section");
+    (&key[..split], &key[split + 1..])
+}
+
+fn toml_literal(value: &Value) -> String {
+    match value {
+        Value::Array(items) => {
+            return format!(
+                "[{}]",
+                items
+                    .iter()
+                    .map(toml_literal)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        Value::Table(entries) => {
+            return format!(
+                "{{ {} }}",
+                entries
+                    .iter()
+                    .map(|(key, value)| format!("{key} = {}", toml_literal(value)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        _ => {}
+    }
+    let mut table = toml::Table::new();
+    table.insert("value".to_string(), value.clone());
+    let rendered = toml::to_string(&table).expect("effective value is TOML-serializable");
+    rendered
+        .trim()
+        .strip_prefix("value = ")
+        .expect("single value assignment")
+        .to_string()
+}

--- a/crates/r9v-config/src/index.rs
+++ b/crates/r9v-config/src/index.rs
@@ -1,0 +1,85 @@
+//! Settings-index consistency checking (Spec 12 §3, Spec 14 §5).
+
+use std::collections::BTreeSet;
+
+use thiserror::Error;
+
+use crate::all_settings;
+
+/// Exact difference between phase-A declarations and the Spec 12 §3 index.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("settings index mismatch; missing from code: {missing:?}; extra in code: {extra:?}")]
+pub struct SettingsIndexError {
+    /// Keys in the spec index but not code.
+    pub missing: Vec<String>,
+    /// Keys in code but not the spec index.
+    pub extra: Vec<String>,
+}
+
+/// Verify that the card's phase-A prefixes exactly match Spec 12 §3.
+pub fn check_settings_index(spec_markdown: &str) -> Result<(), SettingsIndexError> {
+    let section = spec_markdown
+        .split_once("## 3. Settings index")
+        .map(|(_, tail)| tail)
+        .unwrap_or("")
+        .split_once("## 4.")
+        .map(|(body, _)| body)
+        .unwrap_or("");
+    let from_spec: BTreeSet<String> = section
+        .lines()
+        .filter_map(|line| line.strip_prefix('|'))
+        .filter_map(|line| line.split('|').next())
+        .flat_map(backticked)
+        .filter(|key| is_phase_a_key(key))
+        .collect();
+    let from_code: BTreeSet<String> = all_settings()
+        .into_iter()
+        .map(|spec| spec.key.to_string())
+        .collect();
+    let missing = from_spec
+        .difference(&from_code)
+        .cloned()
+        .collect::<Vec<_>>();
+    let extra = from_code
+        .difference(&from_spec)
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() && extra.is_empty() {
+        Ok(())
+    } else {
+        Err(SettingsIndexError { missing, extra })
+    }
+}
+
+fn backticked(cell: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = cell;
+    while let Some((_, after_open)) = rest.split_once('`') {
+        let Some((value, after_close)) = after_open.split_once('`') else {
+            break;
+        };
+        out.push(value.to_string());
+        rest = after_close;
+    }
+    out
+}
+
+fn is_phase_a_key(key: &str) -> bool {
+    [
+        "load.",
+        "io.",
+        "host.",
+        "warmup.",
+        "state.",
+        "scheduler.",
+        "graph.",
+        "kernels.",
+        "spec.",
+        "profile.",
+        "log.",
+        "doctor.",
+        "bench.",
+    ]
+    .iter()
+    .any(|prefix| key.starts_with(prefix))
+}

--- a/crates/r9v-config/src/lib.rs
+++ b/crates/r9v-config/src/lib.rs
@@ -1,1 +1,461 @@
 //! R9V configuration schema, settings generator, and validation (Spec 12, Spec 14 §2).
+//!
+//! Spec 12 §2: the schema is code; docs, files, schema, and validation messages
+//! are generated from it. Values retain their winning precedence source and
+//! `auto` resolutions remain auditable.
+
+extern crate self as r9v_config;
+
+use std::path::PathBuf;
+
+use r9v_common::ByteSize;
+
+mod config;
+mod generate;
+mod index;
+
+pub use config::{ConfigError, EffectiveConfig, Source, SourcedValue, CONFIG_VERSION};
+pub use generate::{
+    generate_artifacts, render_effective_toml, write_generated, GeneratedArtifacts,
+};
+pub use index::{check_settings_index, SettingsIndexError};
+pub use r9v_config_macros::{section, setting};
+
+/// `auto` marker: the effective value is resolved by the rule in the setting's
+/// `default` text (Spec 12 §1, principle 2). `Auto::Auto` defers to that rule;
+/// `Auto::Value(v)` pins an explicit value.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum Auto<T> {
+    /// Resolve via the setting's documented rule.
+    #[default]
+    Auto,
+    /// Explicit value overriding the rule.
+    Value(T),
+}
+
+impl<T> Auto<T> {
+    /// True when the value defers to the documented resolution rule.
+    pub fn is_auto(&self) -> bool {
+        matches!(self, Auto::Auto)
+    }
+
+    /// Borrow the explicit value, if any.
+    pub fn as_value(&self) -> Option<&T> {
+        match self {
+            Auto::Auto => None,
+            Auto::Value(v) => Some(v),
+        }
+    }
+
+    /// Resolve with a rule callback for the `Auto` case.
+    pub fn resolve<U>(&self, rule: impl FnOnce() -> U, map: impl FnOnce(&T) -> U) -> U {
+        match self {
+            Auto::Auto => rule(),
+            Auto::Value(v) => map(v),
+        }
+    }
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for Auto<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Auto::Auto => write!(f, "auto"),
+            Auto::Value(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+impl<T: std::str::FromStr> std::str::FromStr for Auto<T> {
+    type Err = T::Err;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.eq_ignore_ascii_case("auto") {
+            Ok(Self::Auto)
+        } else {
+            value.parse().map(Self::Value)
+        }
+    }
+}
+
+macro_rules! closed_setting {
+    (
+        $(#[$enum_meta:meta])*
+        pub enum $name:ident {
+            $($(#[$variant_meta:meta])* $variant:ident => $value:literal),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum $name {
+            $($(#[$variant_meta])* $variant),+
+        }
+
+        impl $name {
+            /// Return the stable config-file spelling from Spec 12 §3.
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $value),+
+                }
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+    };
+}
+
+closed_setting! {
+    /// Spec 12 §3. Concrete weight-read mode when `io.mode` is not `auto`.
+    pub enum IoMode {
+        /// Linux direct I/O.
+        Direct => "direct",
+        /// Memory-mapped reads.
+        Mmap => "mmap",
+    }
+}
+
+closed_setting! {
+    /// Spec 12 §3. Stored KV-cache element representation.
+    pub enum CacheDtype {
+        /// E4M3 FP8 cache values.
+        E4m3 => "e4m3",
+        /// Signed 8-bit integer cache values.
+        I8 => "i8",
+        /// IEEE half-precision cache values.
+        F16 => "f16",
+    }
+}
+
+closed_setting! {
+    /// Spec 12 §3. Concrete graph replay mode when `graph.mode` is not `auto`.
+    pub enum GraphMode {
+        /// Replay an explicit launch list.
+        List => "list",
+        /// Replay a captured HIP graph.
+        HipGraph => "hipgraph",
+    }
+}
+
+closed_setting! {
+    /// Spec 12 §3. Concrete speculative proposer when `spec.proposer` is not `auto`.
+    pub enum ProposerKind {
+        /// Disable speculative proposals.
+        None => "none",
+        /// Host or device n-gram proposals.
+        Ngram => "ngram",
+        /// Multi-token-prediction head.
+        Mtp => "mtp",
+        /// Separate draft model.
+        Draft => "draft",
+        /// Eagle head.
+        Eagle => "eagle",
+    }
+}
+
+closed_setting! {
+    /// Spec 12 §3 and Spec 11 §3. Profiling detail.
+    pub enum ProfileMode {
+        /// One device event per step graph.
+        Step => "step",
+        /// Per-kernel launch profiling.
+        Kernel => "kernel",
+        /// Disable timing instrumentation.
+        Off => "off",
+    }
+}
+
+closed_setting! {
+    /// Spec 12 §3 and Spec 11 §11. Structured-log severity threshold.
+    pub enum LogLevel {
+        /// Most detailed diagnostic records.
+        Trace => "trace",
+        /// Debug records.
+        Debug => "debug",
+        /// Operational records.
+        Info => "info",
+        /// Warning records.
+        Warn => "warn",
+        /// Error records only.
+        Error => "error",
+    }
+}
+
+/// Declared mutability of a setting (Spec 12 §1, principle 4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Mutability {
+    /// Changeable at runtime (`POST /r9v/config`).
+    Runtime,
+    /// Changeable via reload (file/env/CLI, no fresh load).
+    Reload,
+    /// Fixed once a model is loaded.
+    Load,
+}
+
+impl std::fmt::Display for Mutability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Mutability::Runtime => write!(f, "Runtime"),
+            Mutability::Reload => write!(f, "Reload"),
+            Mutability::Load => write!(f, "Load"),
+        }
+    }
+}
+
+/// One setting's metadata: the single source of truth (Spec 12 §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SettingSpec {
+    /// Full `section.key` (e.g. `"scheduler.step_budget_ms"`).
+    pub key: &'static str,
+    /// Rust value type declared by the annotated field.
+    pub type_name: &'static str,
+    /// Doc string; also the generated file/docs/helper explanation.
+    pub doc: &'static str,
+    /// Default: a value or `auto` plus the resolving rule.
+    pub default: &'static str,
+    /// Range (`"1.0..=1000.0"`) or pipe-joined enum (`"direct|mmap|auto"`); `""` when neither applies.
+    pub range_or_enum: &'static str,
+    /// Unit (`"ms"`, `"bytes"`, ...); `""` when unitless.
+    pub unit: &'static str,
+    /// Declared mutability.
+    pub mutability: Mutability,
+    /// Keys whose meaning or resolution this setting affects.
+    pub interacts: &'static [&'static str],
+    /// Schema version introducing the setting.
+    pub since: u32,
+    /// Previous key name after a rename; `""` when never renamed.
+    pub renamed_from: &'static str,
+}
+
+// --- Phase-A sections (Spec 12 §3) -----------------------------------------
+
+/// Spec 12 §3. Model loading inputs.
+#[section("load", doc = "Model and cache inputs for load.")]
+pub struct LoadSection {
+    /// Model file or directory.
+    #[setting(kind = "path", doc = "Primary model artifact path.", default = "(none)", mutable = Load, since = 1)]
+    pub model: PathBuf,
+    /// Draft model for speculative decoding.
+    #[setting(kind = "path", doc = "Draft model artifact path, if any.", default = "none", mutable = Load, since = 1)]
+    pub draft_model: PathBuf,
+    /// Eagle head weights, if any.
+    #[setting(kind = "path", doc = "Eagle head artifact path, if any.", default = "none", mutable = Load, since = 1)]
+    pub eagle_head: PathBuf,
+    /// Repacked-cache directory.
+    #[setting(kind = "Auto<path>", doc = "Cache directory. auto = beside the model.", default = "auto (beside model)", mutable = Load, since = 1)]
+    pub cache_dir: Auto<PathBuf>,
+    /// Refuse to load without the fast path.
+    #[setting(doc = "Require the fast execution path at load.", default = "false", mutable = Load, since = 1)]
+    pub require_fast_path: bool,
+}
+
+/// Spec 12 §3. IO behaviour for load/repack.
+#[section("io", doc = "IO behaviour for load and repack.")]
+pub struct IoSection {
+    /// IO mode.
+    #[setting(doc = "IO mode for weight reads. auto = direct I/O when supported, otherwise mmap.", default = "auto", values = ["direct", "mmap", "auto"], mutable = Load, since = 1)]
+    pub mode: Auto<IoMode>,
+    /// Read chunk size.
+    #[setting(doc = "Read chunk size.", default = "16", range = "1..=1024", unit = "MB", mutable = Load, since = 1)]
+    pub chunk_mb: u32,
+    /// Queue depth.
+    #[setting(doc = "IO queue depth.", default = "8", range = "1..=128", mutable = Load, since = 1)]
+    pub queue_depth: u32,
+    /// Repack threads.
+    #[setting(doc = "Repack worker threads. auto = cores minus 2.", default = "auto (cores-2)", range = "1..=256", mutable = Load, since = 1)]
+    pub repack_threads: Auto<u32>,
+}
+
+/// Spec 12 §3. Host memory budget.
+#[section("host", doc = "Host memory budget.")]
+pub struct HostSection {
+    /// Pinned host-memory budget.
+    #[setting(kind = "Auto<bytes>", doc = "Pinned host-memory budget. auto = min(free minus 4 GB, need).", default = "auto (min(free-4GB, need))", unit = "bytes", mutable = Load, since = 1)]
+    pub pinned_budget: Auto<ByteSize>,
+}
+
+/// Spec 12 §3. Warmup buckets.
+#[section("warmup", doc = "Warmup behaviour and buckets.")]
+pub struct WarmupSection {
+    /// Run warmup at load.
+    #[setting(doc = "Run warmup over the bucket set at load.", default = "true", mutable = Load, since = 1)]
+    pub enabled: bool,
+    /// Warmup bucket set.
+    #[setting(kind = "buckets", doc = "Warmup buckets over S, T_dec and T_pre.", default = "{S:[1,2,4], T_dec:[1,2,4,8,16,32], T_pre:[0,128,512,2048]}", mutable = Load, interacts = ["scheduler.prefill_max_chunk"], since = 1)]
+    pub buckets: WarmupBuckets,
+}
+
+/// Strongly typed shape of `warmup.buckets`; serialized keys follow the spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmupBuckets {
+    /// Concurrent-sequence buckets (`S`).
+    pub sequences: Vec<u32>,
+    /// Decode-token buckets (`T_dec`).
+    pub decode_tokens: Vec<u32>,
+    /// Prefill-token buckets (`T_pre`).
+    pub prefill_tokens: Vec<u32>,
+}
+
+/// Spec 12 §3. Sequence-state limits.
+#[section("state", doc = "Sequence-state limits and cache policy.")]
+pub struct StateSection {
+    /// Maximum context length.
+    #[setting(doc = "Maximum context length; must be a multiple of 32.", default = "32768", range = "32..=1048576", mutable = Reload, since = 1)]
+    pub max_ctx: u32,
+    /// Maximum concurrent sequences.
+    #[setting(doc = "Maximum concurrent sequences.", default = "8", range = "1..=1024", mutable = Reload, since = 1)]
+    pub max_seqs: u32,
+    /// KV cache dtype.
+    #[setting(doc = "KV cache dtype.", default = "e4m3", values = ["e4m3", "i8", "f16"], mutable = Reload, since = 1)]
+    pub cache_dtype: CacheDtype,
+    /// Reserved bytes.
+    #[setting(kind = "bytes", doc = "Bytes reserved outside the state pool.", default = "512 MB", unit = "bytes", mutable = Reload, since = 1)]
+    pub reserve_bytes: ByteSize,
+    /// Host block budget.
+    #[setting(kind = "bytes", doc = "Host block spill budget; 0 disables spilling.", default = "0", unit = "bytes", mutable = Reload, since = 1)]
+    pub host_block_budget: ByteSize,
+    /// Session cache density.
+    #[setting(doc = "Retained sessions per GB of cache.", default = "2", range = "0..=64", mutable = Runtime, since = 1)]
+    pub session_cache: u32,
+}
+
+/// Spec 12 §3. Step scheduling.
+#[section("scheduler", doc = "Step scheduling. Decode step time is the SLO.")]
+pub struct SchedulerSection {
+    /// Target wall time per step.
+    #[setting(doc = "Target wall time per step in milliseconds. Prefill chunks and speculative depth are sized so the step fits. auto = 1.25 x measured single-sequence step time (latency) or 8 x (throughput), resolved at warmup on the loaded plan.", default = "auto", range = "1.0..=1000.0", unit = "ms", mutable = Runtime, interacts = ["scheduler.max_wait_ms", "spec.k_max", "parallel.profile"], since = 1)]
+    pub step_budget_ms: Auto<f32>,
+    /// Minimum prefill chunk.
+    #[setting(doc = "Minimum prefill chunk.", default = "128", range = "1..=16384", unit = "tokens", mutable = Runtime, interacts = ["scheduler.prefill_max_chunk"], since = 1)]
+    pub prefill_min_chunk: u32,
+    /// Maximum prefill chunk.
+    #[setting(doc = "Maximum prefill chunk.", default = "2048", range = "1..=16384", unit = "tokens", mutable = Runtime, interacts = ["scheduler.prefill_min_chunk"], since = 1)]
+    pub prefill_max_chunk: u32,
+    /// Maximum queue wait.
+    #[setting(doc = "Maximum time a request waits before a step starts.", default = "500", range = "0..=60000", unit = "ms", mutable = Runtime, since = 1)]
+    pub max_wait_ms: u32,
+}
+
+/// Spec 12 §3. Graph capture policy.
+#[section("graph", doc = "Graph capture policy.")]
+pub struct GraphSection {
+    /// Capture mode.
+    #[setting(doc = "Graph capture mode. auto = measured at warmup.", default = "auto (measured)", values = ["auto", "list", "hipgraph"], mutable = Reload, since = 1)]
+    pub mode: Auto<GraphMode>,
+}
+
+/// Spec 12 §3. N-gram speculative policy (phase-A subset of `spec.*`).
+#[section("spec", doc = "Speculative decoding policy.")]
+pub struct SpecSection {
+    /// Proposer selection.
+    #[setting(doc = "Speculative proposer. auto = MTP, Eagle, draft, then n-gram according to loaded artifacts.", default = "auto", values = ["auto", "none", "ngram", "mtp", "draft", "eagle"], mutable = Reload, interacts = ["load.draft_model", "load.eagle_head", "spec.k_max"], since = 1)]
+    pub proposer: Auto<ProposerKind>,
+    /// Maximum linear draft depth.
+    #[setting(doc = "Maximum speculative draft depth; k + 1 verified positions must fit the decode-class limit.", default = "8", range = "0..=15", mutable = Runtime, interacts = ["spec.tree_max", "scheduler.step_budget_ms"], since = 1)]
+    pub k_max: u32,
+    /// Maximum tree size.
+    #[setting(doc = "Maximum speculative tree size.", default = "16", range = "1..=16", mutable = Runtime, interacts = ["spec.k_max"], since = 1)]
+    pub tree_max: u32,
+    /// Acceptance threshold.
+    #[setting(doc = "Disable speculation temporarily when the recent acceptance EMA is below this value.", default = "0.3", range = "0.0..=1.0", mutable = Runtime, since = 1)]
+    pub min_accept: f32,
+    /// Permit lossy acceptance.
+    #[setting(doc = "Permit opt-in lossy Typical acceptance.", default = "false", mutable = Runtime, since = 1)]
+    pub lossy: bool,
+}
+
+/// Spec 12 §3. N-gram speculative policy.
+#[section("spec.ngram", doc = "N-gram proposer policy.")]
+pub struct SpecNgramSection {
+    /// N-gram width.
+    #[setting(doc = "N-gram width.", default = "3", range = "1..=16", mutable = Runtime, since = 1)]
+    pub n: u32,
+    /// Minimum match length.
+    #[setting(doc = "Minimum match length to propose.", default = "2", range = "1..=16", mutable = Runtime, since = 1)]
+    pub min_match: u32,
+}
+
+/// Spec 12 §3. Kernel policy.
+#[section("kernels", doc = "Kernel build and determinism policy.")]
+pub struct KernelsSection {
+    /// Allow JIT-built kernels.
+    #[setting(doc = "Allow just-in-time kernel builds.", default = "true", mutable = Load, since = 1)]
+    pub allow_jit: bool,
+    /// Allow nondeterministic kernels.
+    #[setting(doc = "Allow kernels that may be nondeterministic.", default = "false", mutable = Load, since = 1)]
+    pub allow_nondeterministic: bool,
+    /// Autotune budget.
+    #[setting(doc = "Autotune time budget.", default = "2000", range = "0..=600000", unit = "ms", mutable = Load, since = 1)]
+    pub tune_budget_ms: u64,
+}
+
+/// Spec 12 §3. Profiling mode.
+#[section("profile", doc = "Profiling mode.")]
+pub struct ProfileSection {
+    /// Profile mode.
+    #[setting(doc = "Profiling mode.", default = "step", values = ["step", "kernel", "off"], mutable = Runtime, since = 1)]
+    pub mode: ProfileMode,
+}
+
+/// Spec 12 §3. Logging.
+#[section("log", doc = "Logging policy.")]
+pub struct LogSection {
+    /// Log level.
+    #[setting(doc = "Log level.", default = "info", values = ["trace", "debug", "info", "warn", "error"], mutable = Runtime, since = 1)]
+    pub level: LogLevel,
+    /// Log file.
+    #[setting(kind = "path", doc = "Log file path; none disables file logging.", default = "none", mutable = Runtime, since = 1)]
+    pub file: PathBuf,
+}
+
+/// Spec 12 §3. Doctor bundle policy.
+#[section("doctor", doc = "Doctor bundle policy.")]
+pub struct DoctorSection {
+    /// Include token text in bundles.
+    #[setting(doc = "Include token text in the doctor bundle.", default = "false", mutable = Runtime, since = 1)]
+    pub include_tokens: bool,
+    /// Redact secrets in bundles.
+    #[setting(doc = "Redact secrets in the doctor bundle.", default = "true", mutable = Runtime, since = 1)]
+    pub redact: bool,
+}
+
+/// Spec 12 §3. Bench defaults.
+#[section("bench", doc = "Benchmark defaults.")]
+pub struct BenchSection {
+    /// Measured repeats.
+    #[setting(doc = "Measured repeats per benchmark.", default = "5", range = "1..=100", mutable = Runtime, since = 1)]
+    pub repeats: u32,
+    /// Warmup runs.
+    #[setting(doc = "Warmup runs before measurement.", default = "2", range = "0..=100", mutable = Runtime, since = 1)]
+    pub warmup: u32,
+    /// Suites to run.
+    #[setting(kind = "[str]", doc = "Benchmark suites to run.", default = "[decode, decode-spec, prefill, multi]", mutable = Runtime, since = 1)]
+    pub suites: Vec<String>,
+}
+
+/// All phase-A settings in deterministic section order.
+pub fn all_settings() -> Vec<&'static SettingSpec> {
+    let mut out = Vec::new();
+    out.extend(LoadSection::SETTINGS.iter());
+    out.extend(IoSection::SETTINGS.iter());
+    out.extend(HostSection::SETTINGS.iter());
+    out.extend(WarmupSection::SETTINGS.iter());
+    out.extend(StateSection::SETTINGS.iter());
+    out.extend(SchedulerSection::SETTINGS.iter());
+    out.extend(GraphSection::SETTINGS.iter());
+    out.extend(SpecSection::SETTINGS.iter());
+    out.extend(SpecNgramSection::SETTINGS.iter());
+    out.extend(KernelsSection::SETTINGS.iter());
+    out.extend(ProfileSection::SETTINGS.iter());
+    out.extend(LogSection::SETTINGS.iter());
+    out.extend(DoctorSection::SETTINGS.iter());
+    out.extend(BenchSection::SETTINGS.iter());
+    out
+}
+
+/// Look up one setting by full `section.key`.
+pub fn find_setting(key: &str) -> Option<&'static SettingSpec> {
+    all_settings().into_iter().find(|s| s.key == key)
+}

--- a/crates/r9v-config/tests/api_shape.rs
+++ b/crates/r9v-config/tests/api_shape.rs
@@ -1,0 +1,65 @@
+//! Public API-shape checks for card A0.3 (Spec 12 §2, §4–5).
+
+use r9v_config::{
+    section, setting, Auto, CacheDtype, ConfigError, EffectiveConfig, GraphMode, IoMode, LogLevel,
+    Mutability, ProfileMode, ProposerKind, SettingSpec, Source, SourcedValue, WarmupBuckets,
+};
+
+#[setting]
+fn setting_macro_is_reexported() {}
+
+#[section("fixture", doc = "External macro expansion fixture.")]
+struct FixtureSection {
+    #[setting(
+        doc = "Fixture flag.",
+        default = "false",
+        mutable = Runtime,
+        since = 1
+    )]
+    flag: bool,
+}
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn public_schema_surface_is_send_sync() {
+    assert_send_sync::<Auto<u32>>();
+    assert_send_sync::<EffectiveConfig>();
+    assert_send_sync::<Source>();
+    assert_send_sync::<SourcedValue>();
+    assert_send_sync::<SettingSpec>();
+    assert_send_sync::<ConfigError>();
+    assert_send_sync::<WarmupBuckets>();
+    assert_send_sync::<IoMode>();
+    assert_send_sync::<CacheDtype>();
+    assert_send_sync::<GraphMode>();
+    assert_send_sync::<ProposerKind>();
+    assert_send_sync::<ProfileMode>();
+    assert_send_sync::<LogLevel>();
+}
+
+#[test]
+fn section_and_setting_macros_expand_for_external_users() {
+    setting_macro_is_reexported();
+    assert_eq!(FixtureSection::SECTION, "fixture");
+    assert_eq!(
+        FixtureSection::SECTION_DOC,
+        "External macro expansion fixture."
+    );
+    assert_eq!(FixtureSection::len(), 1);
+    let spec = FixtureSection::setting("fixture.flag").expect("fixture field is declared");
+    assert_eq!(spec.key, "fixture.flag");
+    assert_eq!(spec.mutability, Mutability::Runtime);
+    let fixture = FixtureSection { flag: false };
+    assert!(!fixture.flag);
+}
+
+#[test]
+fn closed_setting_values_have_stable_spellings() {
+    assert_eq!(IoMode::Direct.as_str(), "direct");
+    assert_eq!(CacheDtype::E4m3.as_str(), "e4m3");
+    assert_eq!(GraphMode::HipGraph.as_str(), "hipgraph");
+    assert_eq!(ProposerKind::Mtp.as_str(), "mtp");
+    assert_eq!(ProfileMode::Kernel.as_str(), "kernel");
+    assert_eq!(LogLevel::Warn.as_str(), "warn");
+}

--- a/crates/r9v-config/tests/config_behavior.rs
+++ b/crates/r9v-config/tests/config_behavior.rs
@@ -1,0 +1,306 @@
+//! End-to-end configuration machinery tests for card A0.3 (Spec 12 §2, §4–6).
+
+use std::fs;
+use std::path::PathBuf;
+
+use r9v_config::{
+    check_settings_index, generate_artifacts, render_effective_toml, write_generated, Auto,
+    ConfigError, EffectiveConfig, Source,
+};
+use toml::Value;
+
+fn scratch(name: &str) -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/card-tests/r9v-config")
+        .join(name);
+    if path.exists() {
+        fs::remove_dir_all(&path).expect("remove stale test-owned directory");
+    }
+    fs::create_dir_all(&path).expect("create test-owned directory");
+    path
+}
+
+#[test]
+fn auto_parses_displays_and_resolves() {
+    let automatic: Auto<u32> = "auto".parse().unwrap();
+    let concrete: Auto<u32> = "12".parse().unwrap();
+    assert!(automatic.is_auto());
+    assert_eq!(automatic.to_string(), "auto");
+    assert_eq!(concrete.as_value(), Some(&12));
+    assert_eq!(concrete.resolve(|| 99, |value| *value), 12);
+
+    let mut config = EffectiveConfig::from_defaults();
+    config
+        .resolve_auto("scheduler.step_budget_ms", Value::Float(4.5))
+        .unwrap();
+    let setting = config.get("scheduler.step_budget_ms").unwrap();
+    assert_eq!(setting.value.as_str(), Some("auto"));
+    assert_eq!(
+        setting.resolved.as_ref().and_then(Value::as_float),
+        Some(4.5)
+    );
+    assert!(setting
+        .auto_rule
+        .unwrap()
+        .contains("measured single-sequence"));
+}
+
+#[test]
+fn precedence_sources_and_extensions_round_trip() {
+    let dir = scratch("precedence");
+    let model = dir.join("model.gguf");
+    fs::write(&model, b"fixture").unwrap();
+    let input = format!(
+        "config_version = 1\n\n[load]\nmodel = {:?}\n\n[io]\nqueue_depth = 9\n\n[scheduler]\nmax_wait_ms = 400\n\n[x-tool]\nnote = \"preserve me\"\n",
+        model.display().to_string()
+    );
+
+    let mut config = EffectiveConfig::from_defaults();
+    config.apply_file_str("fixture.toml", &input).unwrap();
+    assert!(matches!(
+        &config.get("load.model").unwrap().source,
+        Source::File { path, line: 4 } if path == "fixture.toml"
+    ));
+    config
+        .apply_env([
+            ("R9V__IO__QUEUE_DEPTH", "10"),
+            ("R9V__SCHEDULER__MAX_WAIT_MS", "350"),
+        ])
+        .unwrap();
+    config
+        .apply_cli([
+            ("--io.queue_depth", "11"),
+            ("--scheduler.max_wait_ms", "325"),
+        ])
+        .unwrap();
+    // A late lower-precedence layer cannot overwrite CLI.
+    config.apply_env([("R9V__IO__QUEUE_DEPTH", "12")]).unwrap();
+    config
+        .apply_runtime(
+            [("scheduler.max_wait_ms", "300")],
+            "helper-approved",
+            "2026-09-03T12:00:00Z",
+        )
+        .unwrap();
+
+    assert_eq!(
+        config.get("io.queue_depth").unwrap().value.as_integer(),
+        Some(11)
+    );
+    assert!(matches!(
+        config.get("io.queue_depth").unwrap().source,
+        Source::Cli { .. }
+    ));
+    assert_eq!(
+        config
+            .get("scheduler.max_wait_ms")
+            .unwrap()
+            .source
+            .to_string(),
+        "runtime:helper-approved:2026-09-03T12:00:00Z"
+    );
+    assert_eq!(
+        config.extensions()["x-tool"]
+            .get("note")
+            .and_then(Value::as_str),
+        Some("preserve me")
+    );
+
+    let rendered = render_effective_toml(&config, true);
+    let mut reparsed = EffectiveConfig::from_defaults();
+    reparsed
+        .apply_file_str("roundtrip.toml", &rendered)
+        .unwrap();
+    for (key, value) in config.iter() {
+        assert_eq!(reparsed.get(key).unwrap().value, value.value, "{key}");
+    }
+    assert_eq!(reparsed.extensions(), config.extensions());
+    fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn unknown_key_reports_exact_nearest_key() {
+    let mut config = EffectiveConfig::from_defaults();
+    let error = config
+        .apply_file_str(
+            "typo.toml",
+            "config_version = 1\n[scheduler]\nmax_wiat_ms = 3\n",
+        )
+        .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "unknown setting `scheduler.max_wiat_ms`; did you mean `scheduler.max_wait_ms`?"
+    );
+}
+
+#[test]
+fn type_range_enum_and_path_validation_fail_closed() {
+    let mut config = EffectiveConfig::from_defaults();
+    assert!(matches!(
+        config.apply_cli([("--io.queue_depth", "zero")]),
+        Err(ConfigError::Type { .. })
+    ));
+    assert!(matches!(
+        config.apply_cli([("--io.queue_depth", "0")]),
+        Err(ConfigError::Range { .. })
+    ));
+    assert!(matches!(
+        config.apply_cli([("--graph.mode", "maybe")]),
+        Err(ConfigError::Enum { .. })
+    ));
+    assert!(matches!(
+        config.apply_cli([("--load.model", "/definitely/missing/r9v-model")]),
+        Err(ConfigError::MissingPath { .. })
+    ));
+    assert!(matches!(
+        config.apply_cli([("--state.reserve_bytes", "many")]),
+        Err(ConfigError::Type { .. })
+    ));
+    assert!(matches!(
+        config.apply_cli([("--warmup.buckets", "{ S = [1], T_dec = [], T_pre = [0] }")]),
+        Err(ConfigError::Type { .. })
+    ));
+    assert!(matches!(
+        config.apply_cli([("--warmup.buckets", "{ S = [0], T_dec = [1], T_pre = [0] }")]),
+        Err(ConfigError::Type { .. })
+    ));
+}
+
+#[test]
+fn one_layer_reports_every_independent_validation_problem() {
+    let mut config = EffectiveConfig::from_defaults();
+    let before = config.clone();
+    let error = config
+        .apply_cli([
+            ("--io.queue_depth", "0"),
+            ("--graph.mode", "maybe"),
+            ("--state.reserve_bytes", "many"),
+        ])
+        .unwrap_err();
+    let ConfigError::Multiple { summary, problems } = error else {
+        panic!("expected collected validation problems");
+    };
+    assert!(summary.contains("io.queue_depth"));
+    assert!(summary.contains("graph.mode"));
+    assert!(summary.contains("state.reserve_bytes"));
+    assert_eq!(problems.len(), 3);
+    assert!(matches!(problems[0], ConfigError::Range { .. }));
+    assert!(matches!(problems[1], ConfigError::Enum { .. }));
+    assert!(matches!(problems[2], ConfigError::Type { .. }));
+    assert_eq!(config, before, "a rejected layer must be atomic");
+}
+
+#[test]
+fn runtime_mutability_and_cross_field_rules_are_atomic() {
+    let mut config = EffectiveConfig::from_defaults();
+    assert!(matches!(
+        config.apply_runtime([("state.max_ctx", "65536")], "test", "now"),
+        Err(ConfigError::Mutability { .. })
+    ));
+    let before = config.clone();
+    let error = config
+        .apply_cli([
+            ("--scheduler.prefill_min_chunk", "3000"),
+            ("--scheduler.prefill_max_chunk", "2500"),
+            ("--spec.k_max", "15"),
+            ("--spec.tree_max", "10"),
+            ("--state.max_ctx", "33"),
+        ])
+        .unwrap_err();
+    let ConfigError::CrossField { messages } = error else {
+        panic!("expected all cross-field failures");
+    };
+    assert_eq!(messages.len(), 3, "{messages:?}");
+    assert!(messages
+        .iter()
+        .all(|message| message.contains("schema docs")));
+    assert_eq!(config, before, "a rejected layer must not partially apply");
+}
+
+#[test]
+fn generated_artifacts_are_deterministic_valid_and_writable() {
+    let first = generate_artifacts();
+    let second = generate_artifacts();
+    assert_eq!(first, second);
+    assert!(first
+        .r9v_toml
+        .starts_with("# Generated from r9v-config schema"));
+    let mut parsed = EffectiveConfig::from_defaults();
+    parsed
+        .apply_file_str("generated.toml", &first.r9v_toml)
+        .unwrap();
+    let schema: serde_json::Value = serde_json::from_str(&first.json_schema).unwrap();
+    assert_eq!(schema["properties"]["config_version"]["const"], 1);
+    assert_eq!(
+        schema["properties"]["scheduler"]["properties"]["max_wait_ms"]["type"],
+        "integer"
+    );
+    assert_eq!(
+        schema["properties"]["scheduler"]["properties"]["max_wait_ms"]["default"],
+        500
+    );
+    assert_eq!(
+        schema["properties"]["warmup"]["properties"]["buckets"]["type"],
+        "object"
+    );
+    assert_eq!(
+        schema["properties"]["warmup"]["properties"]["buckets"]["default"]["T_pre"][3],
+        2048
+    );
+    for (key, _) in parsed.iter() {
+        assert!(first.config_markdown.contains(&format!("`{key}`")), "{key}");
+    }
+
+    let dir = scratch("generate");
+    let written = write_generated(&dir).unwrap();
+    assert_eq!(
+        fs::read_to_string(dir.join("r9v.toml")).unwrap(),
+        written.r9v_toml
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("docs/config.md")).unwrap(),
+        written.config_markdown
+    );
+    assert_eq!(
+        fs::read_to_string(dir.join("r9v.schema.json")).unwrap(),
+        written.json_schema
+    );
+    fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
+fn committed_artifacts_match_the_generator() {
+    let generated = generate_artifacts();
+    assert_eq!(generated.r9v_toml, include_str!("../../../r9v.toml"));
+    assert_eq!(
+        generated.config_markdown,
+        include_str!("../../../docs/config.md")
+    );
+    assert_eq!(
+        generated.json_schema,
+        include_str!("../../../r9v.schema.json")
+    );
+}
+
+#[test]
+fn settings_index_is_checked_against_the_actual_spec() {
+    let spec = include_str!("../../../specs/spec-12-config-and-helper.md");
+    check_settings_index(spec).unwrap();
+    let missing = spec.replace("`spec.k_max`, ", "");
+    let error = check_settings_index(&missing).unwrap_err();
+    assert_eq!(error.missing, Vec::<String>::new());
+    assert_eq!(error.extra, vec!["spec.k_max"]);
+}
+
+#[test]
+fn config_version_is_required_and_exact() {
+    let mut config = EffectiveConfig::from_defaults();
+    assert!(matches!(
+        config.apply_file_str("missing.toml", "[io]\nqueue_depth = 8\n"),
+        Err(ConfigError::Version { .. })
+    ));
+    assert!(matches!(
+        config.apply_file_str("future.toml", "config_version = 2\n"),
+        Err(ConfigError::Version { .. })
+    ));
+}

--- a/crates/r9v-config/tests/schema_metadata.rs
+++ b/crates/r9v-config/tests/schema_metadata.rs
@@ -1,0 +1,132 @@
+//! Schema metadata tests: completeness + exact phase-A consistency with
+//! Spec 12 §3 (first half of card A0.3).
+
+use r9v_config::{all_settings, find_setting, Mutability};
+use std::collections::BTreeSet;
+
+fn expected() -> Vec<(&'static str, &'static str, Mutability)> {
+    vec![
+        ("load.model", "(none)", Mutability::Load),
+        ("load.draft_model", "none", Mutability::Load),
+        ("load.eagle_head", "none", Mutability::Load),
+        ("load.cache_dir", "auto (beside model)", Mutability::Load),
+        ("load.require_fast_path", "false", Mutability::Load),
+        ("io.mode", "auto", Mutability::Load),
+        ("io.chunk_mb", "16", Mutability::Load),
+        ("io.queue_depth", "8", Mutability::Load),
+        ("io.repack_threads", "auto (cores-2)", Mutability::Load),
+        (
+            "host.pinned_budget",
+            "auto (min(free-4GB, need))",
+            Mutability::Load,
+        ),
+        ("warmup.enabled", "true", Mutability::Load),
+        ("warmup.buckets", "{S:[1,2,4]", Mutability::Load),
+        ("state.max_ctx", "32768", Mutability::Reload),
+        ("state.max_seqs", "8", Mutability::Reload),
+        ("state.cache_dtype", "e4m3", Mutability::Reload),
+        ("state.reserve_bytes", "512 MB", Mutability::Reload),
+        ("state.host_block_budget", "0", Mutability::Reload),
+        ("state.session_cache", "2", Mutability::Runtime),
+        ("scheduler.step_budget_ms", "auto", Mutability::Runtime),
+        ("scheduler.prefill_min_chunk", "128", Mutability::Runtime),
+        ("scheduler.prefill_max_chunk", "2048", Mutability::Runtime),
+        ("scheduler.max_wait_ms", "500", Mutability::Runtime),
+        ("graph.mode", "auto (measured)", Mutability::Reload),
+        ("spec.proposer", "auto", Mutability::Reload),
+        ("spec.k_max", "8", Mutability::Runtime),
+        ("spec.tree_max", "16", Mutability::Runtime),
+        ("spec.min_accept", "0.3", Mutability::Runtime),
+        ("spec.lossy", "false", Mutability::Runtime),
+        ("spec.ngram.n", "3", Mutability::Runtime),
+        ("spec.ngram.min_match", "2", Mutability::Runtime),
+        ("kernels.allow_jit", "true", Mutability::Load),
+        ("kernels.allow_nondeterministic", "false", Mutability::Load),
+        ("kernels.tune_budget_ms", "2000", Mutability::Load),
+        ("profile.mode", "step", Mutability::Runtime),
+        ("log.level", "info", Mutability::Runtime),
+        ("log.file", "none", Mutability::Runtime),
+        ("doctor.include_tokens", "false", Mutability::Runtime),
+        ("doctor.redact", "true", Mutability::Runtime),
+        ("bench.repeats", "5", Mutability::Runtime),
+        ("bench.warmup", "2", Mutability::Runtime),
+        (
+            "bench.suites",
+            "[decode, decode-spec, prefill, multi]",
+            Mutability::Runtime,
+        ),
+    ]
+}
+
+#[test]
+fn metadata_is_complete_one_source_of_truth() {
+    let all = all_settings();
+    assert!(!all.is_empty());
+    let mut seen = BTreeSet::new();
+    for s in &all {
+        assert!(!s.key.is_empty(), "empty key");
+        assert!(s.key.contains('.'), "key without section: {}", s.key);
+        assert!(!s.doc.is_empty(), "empty doc: {}", s.key);
+        assert!(!s.type_name.is_empty(), "empty type: {}", s.key);
+        assert!(!s.default.is_empty(), "empty default: {}", s.key);
+        assert_eq!(s.since, 1, "since must be 1 in phase A: {}", s.key);
+        assert!(seen.insert(s.key), "duplicate key: {}", s.key);
+        assert_eq!(find_setting(s.key).unwrap().key, s.key);
+        if s.default.starts_with("auto") {
+            assert!(s.doc.contains("auto = "), "auto rule missing: {}", s.key);
+        }
+    }
+    // Enum-typed settings must declare their members.
+    for key in [
+        "io.mode",
+        "state.cache_dtype",
+        "graph.mode",
+        "profile.mode",
+        "log.level",
+    ] {
+        let s = find_setting(key).unwrap();
+        assert!(!s.range_or_enum.is_empty(), "enum missing: {key}");
+    }
+    // Range-typed settings must declare their range.
+    for key in ["scheduler.step_budget_ms", "state.max_ctx", "bench.repeats"] {
+        let s = find_setting(key).unwrap();
+        assert!(!s.range_or_enum.is_empty(), "range missing: {key}");
+    }
+    assert_eq!(
+        find_setting("scheduler.step_budget_ms").unwrap().interacts,
+        ["scheduler.max_wait_ms", "spec.k_max", "parallel.profile"]
+    );
+}
+
+#[test]
+fn phase_a_matches_spec12_section3_exactly() {
+    let all = all_settings();
+    let keys: BTreeSet<&str> = all.iter().map(|s| s.key).collect();
+    let exp = expected();
+    let exp_keys: BTreeSet<&str> = exp.iter().map(|e| e.0).collect();
+    let missing: Vec<&&str> = exp_keys.difference(&keys).collect();
+    let extra: Vec<&&str> = keys.difference(&exp_keys).collect();
+    assert!(missing.is_empty(), "missing settings: {missing:?}");
+    assert!(extra.is_empty(), "extra settings: {extra:?}");
+    for (key, default_part, mutability) in exp {
+        let s = find_setting(key).unwrap();
+        assert!(
+            s.default.contains(default_part),
+            "{} default {:?} missing {default_part:?}",
+            key,
+            s.default
+        );
+        assert_eq!(s.mutability, mutability, "mutability: {key}");
+    }
+}
+
+#[test]
+fn metadata_is_deterministic() {
+    let a: Vec<&str> = all_settings().iter().map(|s| s.key).collect();
+    let b: Vec<&str> = all_settings().iter().map(|s| s.key).collect();
+    assert_eq!(a, b);
+    let mut sorted = a.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(a.len(), sorted.len(), "keys must be unique");
+}

--- a/crates/r9v/Cargo.toml
+++ b/crates/r9v/Cargo.toml
@@ -9,3 +9,4 @@ description = "R9V main CLI binary connecting the engine crates (Spec 14 §2)"
 
 [dependencies]
 r9v-common = { path = "../r9v-common" }
+r9v-config = { path = "../r9v-config" }

--- a/crates/r9v/src/main.rs
+++ b/crates/r9v/src/main.rs
@@ -1,3 +1,72 @@
-//! R9V main CLI binary connecting the engine crates (Spec 14 §2).
+//! R9V main CLI binary connecting the engine crates (Spec 12 §2, Spec 14 §2).
 
-fn main() {}
+use std::path::PathBuf;
+
+// DECISION(A0.3): the card names the public command `r9v config gen`, so its
+// otherwise self-contained r9v-config implementation needs this minimal CLI
+// wiring in the existing r9v binary crate. Parsing stays dependency-free; the
+// schema, generation, and validation remain owned solely by r9v-config.
+fn run(args: impl IntoIterator<Item = String>) -> Result<(), String> {
+    let args = args.into_iter().collect::<Vec<_>>();
+    match args.as_slice() {
+        [command, subcommand] if command == "config" && subcommand == "gen" => {
+            generate(PathBuf::from("."))
+        }
+        [command, subcommand, flag, path]
+            if command == "config" && subcommand == "gen" && flag == "--output" =>
+        {
+            generate(PathBuf::from(path))
+        }
+        [flag] if flag == "--help" || flag == "-h" => {
+            println!("usage: r9v config gen [--output <directory>]");
+            Ok(())
+        }
+        _ => Err("usage: r9v config gen [--output <directory>]".to_string()),
+    }
+}
+
+fn generate(output: PathBuf) -> Result<(), String> {
+    r9v_config::write_generated(&output).map_err(|error| error.to_string())?;
+    println!("generated {}", output.join("r9v.toml").display());
+    println!("generated {}", output.join("docs/config.md").display());
+    println!("generated {}", output.join("r9v.schema.json").display());
+    Ok(())
+}
+
+fn main() {
+    if let Err(error) = run(std::env::args().skip(1)) {
+        eprintln!("r9v: {error}");
+        std::process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::{generate, run};
+
+    #[test]
+    fn help_and_invalid_commands_are_deterministic() {
+        assert!(run(["--help".to_string()]).is_ok());
+        assert_eq!(
+            run(["config".to_string()]).unwrap_err(),
+            "usage: r9v config gen [--output <directory>]"
+        );
+    }
+
+    #[test]
+    fn config_gen_writes_all_three_artifacts() {
+        let output = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../target/card-tests/r9v-cli-config-gen");
+        if output.exists() {
+            fs::remove_dir_all(&output).unwrap();
+        }
+        generate(output.clone()).unwrap();
+        assert!(output.join("r9v.toml").is_file());
+        assert!(output.join("docs/config.md").is_file());
+        assert!(output.join("r9v.schema.json").is_file());
+        fs::remove_dir_all(output).unwrap();
+    }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,440 @@
+# R9V configuration
+
+Generated from the `r9v-config` schema (Spec 12 §2).
+
+## `load`
+
+### `load.model`
+
+Primary model artifact path.
+
+- Type: `path`
+- Default: `(none)`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `load.draft_model`
+
+Draft model artifact path, if any.
+
+- Type: `path`
+- Default: `none`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `load.eagle_head`
+
+Eagle head artifact path, if any.
+
+- Type: `path`
+- Default: `none`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `load.cache_dir`
+
+Cache directory. auto = beside the model.
+
+- Type: `Auto<path>`
+- Default: `auto (beside model)`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `load.require_fast_path`
+
+Require the fast execution path at load.
+
+- Type: `bool`
+- Default: `false`
+- Mutability: `Load`
+- Since schema: `1`
+
+## `io`
+
+### `io.mode`
+
+IO mode for weight reads. auto = direct I/O when supported, otherwise mmap.
+
+- Type: `Auto<IoMode>`
+- Default: `auto`
+- Mutability: `Load`
+- Range/enum: `direct|mmap|auto`
+- Since schema: `1`
+
+### `io.chunk_mb`
+
+Read chunk size.
+
+- Type: `u32`
+- Default: `16`
+- Mutability: `Load`
+- Range/enum: `1..=1024`
+- Unit: `MB`
+- Since schema: `1`
+
+### `io.queue_depth`
+
+IO queue depth.
+
+- Type: `u32`
+- Default: `8`
+- Mutability: `Load`
+- Range/enum: `1..=128`
+- Since schema: `1`
+
+### `io.repack_threads`
+
+Repack worker threads. auto = cores minus 2.
+
+- Type: `Auto<u32>`
+- Default: `auto (cores-2)`
+- Mutability: `Load`
+- Range/enum: `1..=256`
+- Since schema: `1`
+
+## `host`
+
+### `host.pinned_budget`
+
+Pinned host-memory budget. auto = min(free minus 4 GB, need).
+
+- Type: `Auto<bytes>`
+- Default: `auto (min(free-4GB, need))`
+- Mutability: `Load`
+- Unit: `bytes`
+- Since schema: `1`
+
+## `warmup`
+
+### `warmup.enabled`
+
+Run warmup over the bucket set at load.
+
+- Type: `bool`
+- Default: `true`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `warmup.buckets`
+
+Warmup buckets over S, T_dec and T_pre.
+
+- Type: `buckets`
+- Default: `{S:[1,2,4], T_dec:[1,2,4,8,16,32], T_pre:[0,128,512,2048]}`
+- Mutability: `Load`
+- Since schema: `1`
+- Interacts with: `scheduler.prefill_max_chunk`
+
+## `state`
+
+### `state.max_ctx`
+
+Maximum context length; must be a multiple of 32.
+
+- Type: `u32`
+- Default: `32768`
+- Mutability: `Reload`
+- Range/enum: `32..=1048576`
+- Since schema: `1`
+
+### `state.max_seqs`
+
+Maximum concurrent sequences.
+
+- Type: `u32`
+- Default: `8`
+- Mutability: `Reload`
+- Range/enum: `1..=1024`
+- Since schema: `1`
+
+### `state.cache_dtype`
+
+KV cache dtype.
+
+- Type: `CacheDtype`
+- Default: `e4m3`
+- Mutability: `Reload`
+- Range/enum: `e4m3|i8|f16`
+- Since schema: `1`
+
+### `state.reserve_bytes`
+
+Bytes reserved outside the state pool.
+
+- Type: `bytes`
+- Default: `512 MB`
+- Mutability: `Reload`
+- Unit: `bytes`
+- Since schema: `1`
+
+### `state.host_block_budget`
+
+Host block spill budget; 0 disables spilling.
+
+- Type: `bytes`
+- Default: `0`
+- Mutability: `Reload`
+- Unit: `bytes`
+- Since schema: `1`
+
+### `state.session_cache`
+
+Retained sessions per GB of cache.
+
+- Type: `u32`
+- Default: `2`
+- Mutability: `Runtime`
+- Range/enum: `0..=64`
+- Since schema: `1`
+
+## `scheduler`
+
+### `scheduler.step_budget_ms`
+
+Target wall time per step in milliseconds. Prefill chunks and speculative depth are sized so the step fits. auto = 1.25 x measured single-sequence step time (latency) or 8 x (throughput), resolved at warmup on the loaded plan.
+
+- Type: `Auto<f32>`
+- Default: `auto`
+- Mutability: `Runtime`
+- Range/enum: `1.0..=1000.0`
+- Unit: `ms`
+- Since schema: `1`
+- Interacts with: `scheduler.max_wait_ms`, `spec.k_max`, `parallel.profile`
+
+### `scheduler.prefill_min_chunk`
+
+Minimum prefill chunk.
+
+- Type: `u32`
+- Default: `128`
+- Mutability: `Runtime`
+- Range/enum: `1..=16384`
+- Unit: `tokens`
+- Since schema: `1`
+- Interacts with: `scheduler.prefill_max_chunk`
+
+### `scheduler.prefill_max_chunk`
+
+Maximum prefill chunk.
+
+- Type: `u32`
+- Default: `2048`
+- Mutability: `Runtime`
+- Range/enum: `1..=16384`
+- Unit: `tokens`
+- Since schema: `1`
+- Interacts with: `scheduler.prefill_min_chunk`
+
+### `scheduler.max_wait_ms`
+
+Maximum time a request waits before a step starts.
+
+- Type: `u32`
+- Default: `500`
+- Mutability: `Runtime`
+- Range/enum: `0..=60000`
+- Unit: `ms`
+- Since schema: `1`
+
+## `graph`
+
+### `graph.mode`
+
+Graph capture mode. auto = measured at warmup.
+
+- Type: `Auto<GraphMode>`
+- Default: `auto (measured)`
+- Mutability: `Reload`
+- Range/enum: `auto|list|hipgraph`
+- Since schema: `1`
+
+## `spec`
+
+### `spec.proposer`
+
+Speculative proposer. auto = MTP, Eagle, draft, then n-gram according to loaded artifacts.
+
+- Type: `Auto<ProposerKind>`
+- Default: `auto`
+- Mutability: `Reload`
+- Range/enum: `auto|none|ngram|mtp|draft|eagle`
+- Since schema: `1`
+- Interacts with: `load.draft_model`, `load.eagle_head`, `spec.k_max`
+
+### `spec.k_max`
+
+Maximum speculative draft depth; k + 1 verified positions must fit the decode-class limit.
+
+- Type: `u32`
+- Default: `8`
+- Mutability: `Runtime`
+- Range/enum: `0..=15`
+- Since schema: `1`
+- Interacts with: `spec.tree_max`, `scheduler.step_budget_ms`
+
+### `spec.tree_max`
+
+Maximum speculative tree size.
+
+- Type: `u32`
+- Default: `16`
+- Mutability: `Runtime`
+- Range/enum: `1..=16`
+- Since schema: `1`
+- Interacts with: `spec.k_max`
+
+### `spec.min_accept`
+
+Disable speculation temporarily when the recent acceptance EMA is below this value.
+
+- Type: `f32`
+- Default: `0.3`
+- Mutability: `Runtime`
+- Range/enum: `0.0..=1.0`
+- Since schema: `1`
+
+### `spec.lossy`
+
+Permit opt-in lossy Typical acceptance.
+
+- Type: `bool`
+- Default: `false`
+- Mutability: `Runtime`
+- Since schema: `1`
+
+## `spec.ngram`
+
+### `spec.ngram.n`
+
+N-gram width.
+
+- Type: `u32`
+- Default: `3`
+- Mutability: `Runtime`
+- Range/enum: `1..=16`
+- Since schema: `1`
+
+### `spec.ngram.min_match`
+
+Minimum match length to propose.
+
+- Type: `u32`
+- Default: `2`
+- Mutability: `Runtime`
+- Range/enum: `1..=16`
+- Since schema: `1`
+
+## `kernels`
+
+### `kernels.allow_jit`
+
+Allow just-in-time kernel builds.
+
+- Type: `bool`
+- Default: `true`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `kernels.allow_nondeterministic`
+
+Allow kernels that may be nondeterministic.
+
+- Type: `bool`
+- Default: `false`
+- Mutability: `Load`
+- Since schema: `1`
+
+### `kernels.tune_budget_ms`
+
+Autotune time budget.
+
+- Type: `u64`
+- Default: `2000`
+- Mutability: `Load`
+- Range/enum: `0..=600000`
+- Unit: `ms`
+- Since schema: `1`
+
+## `profile`
+
+### `profile.mode`
+
+Profiling mode.
+
+- Type: `ProfileMode`
+- Default: `step`
+- Mutability: `Runtime`
+- Range/enum: `step|kernel|off`
+- Since schema: `1`
+
+## `log`
+
+### `log.level`
+
+Log level.
+
+- Type: `LogLevel`
+- Default: `info`
+- Mutability: `Runtime`
+- Range/enum: `trace|debug|info|warn|error`
+- Since schema: `1`
+
+### `log.file`
+
+Log file path; none disables file logging.
+
+- Type: `path`
+- Default: `none`
+- Mutability: `Runtime`
+- Since schema: `1`
+
+## `doctor`
+
+### `doctor.include_tokens`
+
+Include token text in the doctor bundle.
+
+- Type: `bool`
+- Default: `false`
+- Mutability: `Runtime`
+- Since schema: `1`
+
+### `doctor.redact`
+
+Redact secrets in the doctor bundle.
+
+- Type: `bool`
+- Default: `true`
+- Mutability: `Runtime`
+- Since schema: `1`
+
+## `bench`
+
+### `bench.repeats`
+
+Measured repeats per benchmark.
+
+- Type: `u32`
+- Default: `5`
+- Mutability: `Runtime`
+- Range/enum: `1..=100`
+- Since schema: `1`
+
+### `bench.warmup`
+
+Warmup runs before measurement.
+
+- Type: `u32`
+- Default: `2`
+- Mutability: `Runtime`
+- Range/enum: `0..=100`
+- Since schema: `1`
+
+### `bench.suites`
+
+Benchmark suites to run.
+
+- Type: `[str]`
+- Default: `[decode, decode-spec, prefill, multi]`
+- Mutability: `Runtime`
+- Since schema: `1`

--- a/r9v.schema.json
+++ b/r9v.schema.json
@@ -1,0 +1,560 @@
+{
+  "$id": "https://r9v.local/schema/config-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {
+      "type": "object"
+    }
+  },
+  "properties": {
+    "bench": {
+      "additionalProperties": false,
+      "properties": {
+        "repeats": {
+          "default": 5,
+          "description": "Measured repeats per benchmark.",
+          "maximum": 100.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "suites": {
+          "default": [
+            "decode",
+            "decode-spec",
+            "prefill",
+            "multi"
+          ],
+          "description": "Benchmark suites to run.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "warmup": {
+          "default": 2,
+          "description": "Warmup runs before measurement.",
+          "maximum": 100.0,
+          "minimum": 0.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "config_version": {
+      "const": 1,
+      "type": "integer"
+    },
+    "doctor": {
+      "additionalProperties": false,
+      "properties": {
+        "include_tokens": {
+          "default": false,
+          "description": "Include token text in the doctor bundle.",
+          "type": "boolean",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "redact": {
+          "default": true,
+          "description": "Redact secrets in the doctor bundle.",
+          "type": "boolean",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "graph": {
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "default": "auto",
+          "description": "Graph capture mode. auto = measured at warmup.",
+          "enum": [
+            "auto",
+            "list",
+            "hipgraph"
+          ],
+          "type": "string",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "host": {
+      "additionalProperties": false,
+      "properties": {
+        "pinned_budget": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "const": "auto"
+            }
+          ],
+          "default": "auto",
+          "description": "Pinned host-memory budget. auto = min(free minus 4 GB, need).",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "bytes"
+        }
+      },
+      "type": "object"
+    },
+    "io": {
+      "additionalProperties": false,
+      "properties": {
+        "chunk_mb": {
+          "default": 16,
+          "description": "Read chunk size.",
+          "maximum": 1024.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "MB"
+        },
+        "mode": {
+          "default": "auto",
+          "description": "IO mode for weight reads. auto = direct I/O when supported, otherwise mmap.",
+          "enum": [
+            "direct",
+            "mmap",
+            "auto"
+          ],
+          "type": "string",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "queue_depth": {
+          "default": 8,
+          "description": "IO queue depth.",
+          "maximum": 128.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "repack_threads": {
+          "anyOf": [
+            {
+              "maximum": 256.0,
+              "minimum": 1.0,
+              "type": "integer"
+            },
+            {
+              "const": "auto"
+            }
+          ],
+          "default": "auto",
+          "description": "Repack worker threads. auto = cores minus 2.",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "kernels": {
+      "additionalProperties": false,
+      "properties": {
+        "allow_jit": {
+          "default": true,
+          "description": "Allow just-in-time kernel builds.",
+          "type": "boolean",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "allow_nondeterministic": {
+          "default": false,
+          "description": "Allow kernels that may be nondeterministic.",
+          "type": "boolean",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "tune_budget_ms": {
+          "default": 2000,
+          "description": "Autotune time budget.",
+          "maximum": 600000.0,
+          "minimum": 0.0,
+          "type": "integer",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "ms"
+        }
+      },
+      "type": "object"
+    },
+    "load": {
+      "additionalProperties": false,
+      "properties": {
+        "cache_dir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "const": "auto"
+            }
+          ],
+          "default": "auto",
+          "description": "Cache directory. auto = beside the model.",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "draft_model": {
+          "default": "none",
+          "description": "Draft model artifact path, if any.",
+          "type": "string",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "eagle_head": {
+          "default": "none",
+          "description": "Eagle head artifact path, if any.",
+          "type": "string",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "model": {
+          "default": "(none)",
+          "description": "Primary model artifact path.",
+          "type": "string",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "require_fast_path": {
+          "default": false,
+          "description": "Require the fast execution path at load.",
+          "type": "boolean",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "log": {
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "default": "none",
+          "description": "Log file path; none disables file logging.",
+          "type": "string",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "level": {
+          "default": "info",
+          "description": "Log level.",
+          "enum": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "type": "string",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "profile": {
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "default": "step",
+          "description": "Profiling mode.",
+          "enum": [
+            "step",
+            "kernel",
+            "off"
+          ],
+          "type": "string",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "scheduler": {
+      "additionalProperties": false,
+      "properties": {
+        "max_wait_ms": {
+          "default": 500,
+          "description": "Maximum time a request waits before a step starts.",
+          "maximum": 60000.0,
+          "minimum": 0.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "ms"
+        },
+        "prefill_max_chunk": {
+          "default": 2048,
+          "description": "Maximum prefill chunk.",
+          "maximum": 16384.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "tokens"
+        },
+        "prefill_min_chunk": {
+          "default": 128,
+          "description": "Minimum prefill chunk.",
+          "maximum": 16384.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "tokens"
+        },
+        "step_budget_ms": {
+          "anyOf": [
+            {
+              "maximum": 1000.0,
+              "minimum": 1.0,
+              "type": "number"
+            },
+            {
+              "const": "auto"
+            }
+          ],
+          "default": "auto",
+          "description": "Target wall time per step in milliseconds. Prefill chunks and speculative depth are sized so the step fits. auto = 1.25 x measured single-sequence step time (latency) or 8 x (throughput), resolved at warmup on the loaded plan.",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "ms"
+        }
+      },
+      "type": "object"
+    },
+    "spec": {
+      "additionalProperties": false,
+      "properties": {
+        "k_max": {
+          "default": 8,
+          "description": "Maximum speculative draft depth; k + 1 verified positions must fit the decode-class limit.",
+          "maximum": 15.0,
+          "minimum": 0.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "lossy": {
+          "default": false,
+          "description": "Permit opt-in lossy Typical acceptance.",
+          "type": "boolean",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "min_accept": {
+          "default": 0.3,
+          "description": "Disable speculation temporarily when the recent acceptance EMA is below this value.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        },
+        "ngram": {
+          "additionalProperties": false,
+          "properties": {
+            "min_match": {
+              "default": 2,
+              "description": "Minimum match length to propose.",
+              "maximum": 16.0,
+              "minimum": 1.0,
+              "type": "integer",
+              "x-r9v-mutability": "Runtime",
+              "x-r9v-since": 1
+            },
+            "n": {
+              "default": 3,
+              "description": "N-gram width.",
+              "maximum": 16.0,
+              "minimum": 1.0,
+              "type": "integer",
+              "x-r9v-mutability": "Runtime",
+              "x-r9v-since": 1
+            }
+          },
+          "type": "object"
+        },
+        "proposer": {
+          "default": "auto",
+          "description": "Speculative proposer. auto = MTP, Eagle, draft, then n-gram according to loaded artifacts.",
+          "enum": [
+            "auto",
+            "none",
+            "ngram",
+            "mtp",
+            "draft",
+            "eagle"
+          ],
+          "type": "string",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1
+        },
+        "tree_max": {
+          "default": 16,
+          "description": "Maximum speculative tree size.",
+          "maximum": 16.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "state": {
+      "additionalProperties": false,
+      "properties": {
+        "cache_dtype": {
+          "default": "e4m3",
+          "description": "KV cache dtype.",
+          "enum": [
+            "e4m3",
+            "i8",
+            "f16"
+          ],
+          "type": "string",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1
+        },
+        "host_block_budget": {
+          "default": "0",
+          "description": "Host block spill budget; 0 disables spilling.",
+          "type": "string",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "bytes"
+        },
+        "max_ctx": {
+          "default": 32768,
+          "description": "Maximum context length; must be a multiple of 32.",
+          "maximum": 1048576.0,
+          "minimum": 32.0,
+          "type": "integer",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1
+        },
+        "max_seqs": {
+          "default": 8,
+          "description": "Maximum concurrent sequences.",
+          "maximum": 1024.0,
+          "minimum": 1.0,
+          "type": "integer",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1
+        },
+        "reserve_bytes": {
+          "default": "512 MB",
+          "description": "Bytes reserved outside the state pool.",
+          "type": "string",
+          "x-r9v-mutability": "Reload",
+          "x-r9v-since": 1,
+          "x-r9v-unit": "bytes"
+        },
+        "session_cache": {
+          "default": 2,
+          "description": "Retained sessions per GB of cache.",
+          "maximum": 64.0,
+          "minimum": 0.0,
+          "type": "integer",
+          "x-r9v-mutability": "Runtime",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    },
+    "warmup": {
+      "additionalProperties": false,
+      "properties": {
+        "buckets": {
+          "additionalProperties": false,
+          "default": {
+            "S": [
+              1,
+              2,
+              4
+            ],
+            "T_dec": [
+              1,
+              2,
+              4,
+              8,
+              16,
+              32
+            ],
+            "T_pre": [
+              0,
+              128,
+              512,
+              2048
+            ]
+          },
+          "description": "Warmup buckets over S, T_dec and T_pre.",
+          "properties": {
+            "S": {
+              "items": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "T_dec": {
+              "items": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "T_pre": {
+              "items": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "S",
+            "T_dec",
+            "T_pre"
+          ],
+          "type": "object",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        },
+        "enabled": {
+          "default": true,
+          "description": "Run warmup over the bucket set at load.",
+          "type": "boolean",
+          "x-r9v-mutability": "Load",
+          "x-r9v-since": 1
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "config_version"
+  ],
+  "title": "R9V configuration v1",
+  "type": "object"
+}

--- a/r9v.toml
+++ b/r9v.toml
@@ -1,0 +1,180 @@
+# Generated from r9v-config schema (Spec 12 §2). Do not maintain a parallel setting list.
+config_version = 1
+
+[load]
+# Primary model artifact path.
+# type: path; default: (none); mutability: Load
+model = "(none)"
+
+# Draft model artifact path, if any.
+# type: path; default: none; mutability: Load
+draft_model = "none"
+
+# Eagle head artifact path, if any.
+# type: path; default: none; mutability: Load
+eagle_head = "none"
+
+# Cache directory. auto = beside the model.
+# type: Auto<path>; default: auto (beside model); mutability: Load
+cache_dir = "auto"
+
+# Require the fast execution path at load.
+# type: bool; default: false; mutability: Load
+require_fast_path = false
+
+[io]
+# IO mode for weight reads. auto = direct I/O when supported, otherwise mmap.
+# type: Auto<IoMode>; default: auto; mutability: Load; constraint: direct|mmap|auto
+mode = "auto"
+
+# Read chunk size.
+# type: u32; default: 16; mutability: Load; constraint: 1..=1024; unit: MB
+chunk_mb = 16
+
+# IO queue depth.
+# type: u32; default: 8; mutability: Load; constraint: 1..=128
+queue_depth = 8
+
+# Repack worker threads. auto = cores minus 2.
+# type: Auto<u32>; default: auto (cores-2); mutability: Load; constraint: 1..=256
+repack_threads = "auto"
+
+[host]
+# Pinned host-memory budget. auto = min(free minus 4 GB, need).
+# type: Auto<bytes>; default: auto (min(free-4GB, need)); mutability: Load; unit: bytes
+pinned_budget = "auto"
+
+[warmup]
+# Run warmup over the bucket set at load.
+# type: bool; default: true; mutability: Load
+enabled = true
+
+# Warmup buckets over S, T_dec and T_pre.
+# type: buckets; default: {S:[1,2,4], T_dec:[1,2,4,8,16,32], T_pre:[0,128,512,2048]}; mutability: Load
+buckets = { S = [1, 2, 4], T_dec = [1, 2, 4, 8, 16, 32], T_pre = [0, 128, 512, 2048] }
+
+[state]
+# Maximum context length; must be a multiple of 32.
+# type: u32; default: 32768; mutability: Reload; constraint: 32..=1048576
+max_ctx = 32768
+
+# Maximum concurrent sequences.
+# type: u32; default: 8; mutability: Reload; constraint: 1..=1024
+max_seqs = 8
+
+# KV cache dtype.
+# type: CacheDtype; default: e4m3; mutability: Reload; constraint: e4m3|i8|f16
+cache_dtype = "e4m3"
+
+# Bytes reserved outside the state pool.
+# type: bytes; default: 512 MB; mutability: Reload; unit: bytes
+reserve_bytes = "512 MB"
+
+# Host block spill budget; 0 disables spilling.
+# type: bytes; default: 0; mutability: Reload; unit: bytes
+host_block_budget = "0"
+
+# Retained sessions per GB of cache.
+# type: u32; default: 2; mutability: Runtime; constraint: 0..=64
+session_cache = 2
+
+[scheduler]
+# Target wall time per step in milliseconds. Prefill chunks and speculative depth are sized so the step fits. auto = 1.25 x measured single-sequence step time (latency) or 8 x (throughput), resolved at warmup on the loaded plan.
+# type: Auto<f32>; default: auto; mutability: Runtime; constraint: 1.0..=1000.0; unit: ms
+step_budget_ms = "auto"
+
+# Minimum prefill chunk.
+# type: u32; default: 128; mutability: Runtime; constraint: 1..=16384; unit: tokens
+prefill_min_chunk = 128
+
+# Maximum prefill chunk.
+# type: u32; default: 2048; mutability: Runtime; constraint: 1..=16384; unit: tokens
+prefill_max_chunk = 2048
+
+# Maximum time a request waits before a step starts.
+# type: u32; default: 500; mutability: Runtime; constraint: 0..=60000; unit: ms
+max_wait_ms = 500
+
+[graph]
+# Graph capture mode. auto = measured at warmup.
+# type: Auto<GraphMode>; default: auto (measured); mutability: Reload; constraint: auto|list|hipgraph
+mode = "auto"
+
+[spec]
+# Speculative proposer. auto = MTP, Eagle, draft, then n-gram according to loaded artifacts.
+# type: Auto<ProposerKind>; default: auto; mutability: Reload; constraint: auto|none|ngram|mtp|draft|eagle
+proposer = "auto"
+
+# Maximum speculative draft depth; k + 1 verified positions must fit the decode-class limit.
+# type: u32; default: 8; mutability: Runtime; constraint: 0..=15
+k_max = 8
+
+# Maximum speculative tree size.
+# type: u32; default: 16; mutability: Runtime; constraint: 1..=16
+tree_max = 16
+
+# Disable speculation temporarily when the recent acceptance EMA is below this value.
+# type: f32; default: 0.3; mutability: Runtime; constraint: 0.0..=1.0
+min_accept = 0.3
+
+# Permit opt-in lossy Typical acceptance.
+# type: bool; default: false; mutability: Runtime
+lossy = false
+
+[spec.ngram]
+# N-gram width.
+# type: u32; default: 3; mutability: Runtime; constraint: 1..=16
+n = 3
+
+# Minimum match length to propose.
+# type: u32; default: 2; mutability: Runtime; constraint: 1..=16
+min_match = 2
+
+[kernels]
+# Allow just-in-time kernel builds.
+# type: bool; default: true; mutability: Load
+allow_jit = true
+
+# Allow kernels that may be nondeterministic.
+# type: bool; default: false; mutability: Load
+allow_nondeterministic = false
+
+# Autotune time budget.
+# type: u64; default: 2000; mutability: Load; constraint: 0..=600000; unit: ms
+tune_budget_ms = 2000
+
+[profile]
+# Profiling mode.
+# type: ProfileMode; default: step; mutability: Runtime; constraint: step|kernel|off
+mode = "step"
+
+[log]
+# Log level.
+# type: LogLevel; default: info; mutability: Runtime; constraint: trace|debug|info|warn|error
+level = "info"
+
+# Log file path; none disables file logging.
+# type: path; default: none; mutability: Runtime
+file = "none"
+
+[doctor]
+# Include token text in the doctor bundle.
+# type: bool; default: false; mutability: Runtime
+include_tokens = false
+
+# Redact secrets in the doctor bundle.
+# type: bool; default: true; mutability: Runtime
+redact = true
+
+[bench]
+# Measured repeats per benchmark.
+# type: u32; default: 5; mutability: Runtime; constraint: 1..=100
+repeats = 5
+
+# Warmup runs before measurement.
+# type: u32; default: 2; mutability: Runtime; constraint: 0..=100
+warmup = 2
+
+# Benchmark suites to run.
+# type: [str]; default: [decode, decode-spec, prefill, multi]; mutability: Runtime
+suites = ["decode", "decode-spec", "prefill", "multi"]


### PR DESCRIPTION
## Card
A0.3 — r9v-config   (kind: API; GPU: no; size: M)

## Spec sections implemented
- spec 12 §1–§2: code-owned setting metadata, `Auto<T>`, section/setting attributes, and deterministic config/docs/schema generation.
- spec 12 §3: exact phase-A declarations and executable consistency check against the settings index.
- spec 12 §4: atomic defaults < file < environment < CLI < runtime precedence with per-value source and auto-resolution records.
- spec 12 §5: type, range, enum, byte-size, load-path, unknown-key, mutability, and applicable phase-A cross-field validation.
- spec 12 §6: exact `config_version = 1`, rename-warning support, and extension-section preservation.

## Deliverables
- [x] `#[section]` and `#[setting]` procedural macros with compile-time metadata checks.
- [x] `Auto<T>` and typed phase-A section declarations.
- [x] Atomic precedence and source tracking for defaults, file, environment, CLI, and runtime layers.
- [x] Unknown-key errors with the nearest declared setting.
- [x] `r9v config gen` producing committed `r9v.toml`, `docs/config.md`, and `r9v.schema.json` artifacts.
- [x] Settings-index consistency check against Spec 12 §3.
- [x] Cross-field validation framework with all applicable phase-A rules and collected failures.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| `precedence_sources_and_extensions_round_trip` | `crates/r9v-config/tests/config_behavior.rs` | cpu-only | green |
| `metadata_is_complete_one_source_of_truth` | `crates/r9v-config/tests/schema_metadata.rs` | cpu-only | green |
| `settings_index_is_checked_against_the_actual_spec` | `crates/r9v-config/tests/config_behavior.rs` | cpu-only | green |
| `unknown_key_reports_exact_nearest_key` | `crates/r9v-config/tests/config_behavior.rs` | cpu-only | green |
| `runtime_mutability_and_cross_field_rules_are_atomic` | `crates/r9v-config/tests/config_behavior.rs` | cpu-only | green |
| `committed_artifacts_match_the_generator` | `crates/r9v-config/tests/config_behavior.rs` | cpu-only | green |
| `section_and_setting_macros_expand_for_external_users` | `crates/r9v-config/tests/api_shape.rs` | cpu-only | green |
| `config_gen_writes_all_three_artifacts` | `crates/r9v/src/main.rs` | cpu-only | green |

## Decisions
- `crates/r9v/src/main.rs:5` — `DECISION(A0.3)`: wire the explicitly required public `r9v config gen` command through the existing binary while keeping schema behavior in `r9v-config`; rejected duplicating config logic in the CLI.

## SPEC-ISSUES filed
- none

## New dependencies
- `r9v-config-macros` (workspace-local): Rust attribute macros require a dedicated `proc-macro` package.
- `syn`, `quote`, `proc-macro2`: parse and emit checked Rust syntax for the two attribute macros; these versions already occur in the workspace lock graph.
- `toml`: parse config files and serialize deterministic effective configuration values.
- `serde_json`: emit the required JSON Schema artifact.
- `thiserror`: implement the crate-local typed error enum required by `CONVENTIONS.md`.
- `r9v-config` from `r9v`: connect the explicitly required generator command to its owning crate.

## Hardware
Tests run here: hosted cpu-only
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command none, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- none

## Size check
Diff size vs card size class: 4,089 insertions vs M — acceptable because 1,180 lines are generated owned artifacts, 503 lines are acceptance tests, and the remaining implementation includes the complete proc-macro, precedence, validation, generation, and index machinery assigned to this card.
