### PR TITLE
A1.1: define IR core types and descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ name = "r9v-ir"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
+ "thiserror",
 ]
 
 [[package]]

--- a/SPEC-ISSUES.md
+++ b/SPEC-ISSUES.md
@@ -23,3 +23,27 @@ What: Spec 5 §2 says the current rig has one R9700 on x16 and one on x4, and `h
 Why it blocks or misleads: The A0.S6 reference-rig measurement resolves the two discrete R9700 endpoints as PCI `0000:03:00.0` and `0000:13:00.0`; sysfs reports `32.0 GT/s PCIe`, width `16` for both endpoints, and they occupy separate IOMMU groups 15 and 31. Keeping the stale x4 description would make the topology fingerprint and every calibrated communication-cost estimate disagree with the measured machine.
 Option taken: Recorded the live topology and P2P receipt in `spikes/p2p/RESULT.md`; A0.S6 uses the measured link and selects `Direct`. Work that consumes the seeded x4 topology must use the measured result rather than treating the JSON value as observed fact.
 Proposed resolution: Update spec 5 §2 and `hardware/dual-r9700/hardware.json` to record both discrete endpoints at their measured Gen5 x16 link state on the current reference rig, and populate the 0↔1 transport as `Direct` from the A0.S6 receipt.
+
+## SI-3 — A1.1 — spec 1 §2.3, App. A / spec 2 §2 / spec 4 §13
+What: Spec 1 requires `Tensor.layout`, `ArchDescriptor.fragment_layout`, and `ArchDescriptor.attention_layout` to carry `LayoutId`, while spec 2 defines only the names `L0`, `L1`, and `L1S`, card A2.1 assigns their Rust type to downstream crate `r9v-format`, and spec 4 describes a distinct gfx1201 attention order without assigning it an id.
+Why it blocks or misleads: `r9v-format` depends on `r9v-ir` in the mandated downward dependency graph, so the IR cannot name a `LayoutId` owned by `r9v-format` without a cycle. Reusing `L1` for the described K/V cache order would falsely identify a weight permutation as an attention-state layout, while leaving the field unset would violate the non-optional ArchDescriptor surface.
+Option taken: Defined an opaque `LayoutId` code newtype in `r9v-ir` with provisional constants for `Contiguous`, `L0`, `L1`, `L1S`, and the spec 4 §5.3 gfx1201 attention order. Card A2.1 must make `r9v-format` map or re-export these identities instead of declaring a second incompatible type.
+Proposed resolution: Name `r9v-ir` as the canonical owner of layout identity codes, assign stable values (including the gfx1201 attention layout), and amend card A2.1 to define layout semantics and format mappings over that shared identity type.
+
+## SI-4 — A1.1 — spec 1 §2.2
+What: The `QuantScheme` pseudocode writes `PerRow { scale: f16 }`, `PerToken { scale: f32 }`, and `PerBlock32 { scale: f32 }` but does not define whether `scale` is a scalar enum payload, a tensor handle, or a declaration of the associated scale tensor's dtype.
+Why it blocks or misleads: Each scheme requires an array of scales, not one scalar: spec 2 stores PerRow records per output row, `quant_act` emits `scale [T] f32`, and PerBlock32 requires one value per token per K block. Embedding one `f16` or `f32` in the enum cannot represent those shapes, while the actual scale arrays already travel in format records or op tensors.
+Option taken: Represented these as closed marker variants and exposed `scale_dtype()`; actual scale arrays remain separate data owned by the format or op signature. `Scheme(SchemeId)` retains its id payload because that value selects structure rather than storing tensor data.
+Proposed resolution: Clarify that the braces in §2.2 declare associated scale-record element types, or replace each `scale` field with an explicitly shaped tensor/reference type if the IR is intended to carry scale data directly.
+
+## SI-5 — A1.1 — spec 1 §2.3 / spec 2 §5
+What: Spec 1 permits `Host` and `Tiered` only for `Weight` tensors whose semantic role is expert weight, n-gram table, or embedding, but the specified `Tensor` fields contain only the broad five-way `Class` and no weight-role identity.
+Why it blocks or misleads: `Tensor::new` can enforce the `Weight` half of the rule but cannot distinguish an allowed expert/table/embedding weight from a forbidden dense weight without adding a field outside the specified surface. Pretending the broad class check is the whole rule would allow an illegal placement to reach execution.
+Option taken: `Tensor::new` rejects non-Weight host/tiered tensors; card A2.6 loader binding and the placement planner must enforce the semantic-role half where tensor names/model roles are available.
+Proposed resolution: State that role-specific placement legality is a loader/planner validation over model weight bindings, or add a closed weight-role field to the IR Tensor surface.
+
+## SI-6 — A1.1 — spec 1 §2.1–§2.2 / §4.A `ngram_gather`
+What: The core-type notes call `i4`, `PerRow`, and `Scheme` weights-only, while the closed `ngram_gather` signature consumes `gather_staging [T, Np, Dn] (i4|i8, Block)`, which is a `Staging` tensor holding copied quantized table rows.
+Why it blocks or misleads: Enforcing “weights-only” as `Tensor.class == Weight` makes the specified n-gram op impossible to construct, even though its staging bytes remain quantized weight-origin data with their scale records. Treating the staging tensor as unquantized would misdescribe its bytes and break reference dequantization.
+Option taken: Allowed weight-side quant schemes and `i4` on `Class::Staging` as well as `Class::Weight`; `PerToken` and `PerBlock32` remain activation-only. The exception is limited to the class explicitly used by `gather_staging`.
+Proposed resolution: Clarify in §2.1–§2.2 that “weights-only” includes quantized weight-origin rows in `Staging` tensors, or give `gather_staging` a distinct closed scheme/class representation.

--- a/crates/r9v-ir/Cargo.toml
+++ b/crates/r9v-ir/Cargo.toml
@@ -9,3 +9,4 @@ description = "R9V Op IR, graph, types, and sharding tables (Spec 1, Spec 14 §2
 
 [dependencies]
 r9v-common = { path = "../r9v-common" }
+thiserror = "2.0"

--- a/crates/r9v-ir/src/arch.rs
+++ b/crates/r9v-ir/src/arch.rs
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Arch descriptor (Spec 1 App. A).
+//!
+//! One instance per device, consumed by the kernel generator (Spec 4), the
+//! partitioner (Spec 5), the loader (Spec 9) and the scheduler (Spec 6). It is
+//! the only source of hardware facts in the engine: wave size, LDS size,
+//! instruction availability and bandwidth all come from here, never from
+//! literals in kernel-adjacent code (r9v-card-work §2).
+//!
+//! Fields are public: the spec states no cross-field invariants, and validity
+//! is established by measurement (the doctor's pass, Spec 11 §7), not by
+//! construction. The `measured` block starts empty and the doctor fills it.
+
+use crate::{DType, IrError, LayoutId};
+
+/// Device family (Spec 1 App. A).
+///
+/// `Cpu` is the T0/T0v device (Spec 4 §2): the scalar reference and SIMD
+/// paths run there, and hosted CI claims only this tier (Spec 14 §1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArchFamily {
+    /// RDNA4, e.g. gfx1201 (Spec 1 App. A).
+    Rdna4,
+    /// RDNA3 (Spec 1 App. A).
+    Rdna3,
+    /// CDNA3 (Spec 1 App. A).
+    Cdna3,
+    /// Portable reference device (Spec 1 App. A).
+    Reference,
+    /// The T0/T0v CPU device (Spec 1 App. A, Spec 4 §2).
+    Cpu,
+}
+
+/// Relative matrix-throughput rate (Spec 1 App. A `RelRate`).
+///
+/// Multiple of the f16/bf16 baseline: gfx1201 lists f16/bf16 at 1×,
+/// e4m3/e5m2, iu8 and iu4 at 2× nominal (Spec 1 App. A).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RelRate(f32);
+
+impl RelRate {
+    /// Builds a rate; must be finite and positive (Spec 1 App. A).
+    pub fn new(value: f32) -> Result<Self, IrError> {
+        if value.is_finite() && value > 0.0 {
+            Ok(Self(value))
+        } else {
+            Err(IrError::NonPositiveRate { value })
+        }
+    }
+
+    /// Baseline multiple (1.0 = f16/bf16 rate on gfx1201).
+    pub const fn as_f32(self) -> f32 {
+        self.0
+    }
+}
+
+/// One WMMA/MFMA form with its relative throughput
+/// (Spec 1 App. A `matrix_ops`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MatrixOp {
+    /// Tile shape `(m, n, k)`, e.g. `(16, 16, 16)` (Spec 1 App. A).
+    pub shape: [u32; 3],
+    /// First operand dtype (Spec 1 App. A).
+    pub a: DType,
+    /// Second operand dtype; `e5m2` appears here only (Spec 1 §2.1).
+    pub b: DType,
+    /// Accumulator dtype: f32 or i32, never f16/bf16 (Spec 1 §6.1).
+    pub acc: DType,
+    /// Relative throughput (Spec 1 App. A).
+    pub rate: RelRate,
+}
+
+impl MatrixOp {
+    /// Builds a matrix-op entry; tile dims must be nonzero.
+    pub fn new(
+        shape: [u32; 3],
+        a: DType,
+        b: DType,
+        acc: DType,
+        rate: RelRate,
+    ) -> Result<Self, IrError> {
+        let mut problems = Vec::new();
+        for (axis, dim) in shape.iter().enumerate() {
+            if *dim == 0 {
+                problems.push(IrError::ZeroExtent { axis });
+            }
+        }
+        if !matches!(acc, DType::F32 | DType::I32) {
+            problems.push(IrError::InvalidAccumulator { got: acc });
+        }
+        if problems.is_empty() {
+            Ok(Self {
+                shape,
+                a,
+                b,
+                acc,
+                rate,
+            })
+        } else if problems.len() == 1 {
+            Err(problems
+                // Internal invariant: this branch runs only when len == 1.
+                .pop()
+                .expect("problems holds exactly one entry"))
+        } else {
+            Err(IrError::Multiple {
+                problems: problems.into_boxed_slice(),
+            })
+        }
+    }
+}
+
+/// VALU dot-product forms (Spec 1 App. A `valu_dot`).
+///
+/// Closed enum for the named forms. A new form lands via RFC (Spec 1 §7);
+// DECISION(A1.1): gfx1201() lists only dot4_i32_i8, the one form the spec
+// names as present on gfx1201 ("dot4_i32_i8 present", App. A); rejected
+// adding the dot2 forms without a spec statement for this arch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ValuDot {
+    /// `v_dot4`-style i8 dot product with i32 accumulation (Spec 1 App. A).
+    Dot4I32I8,
+    /// f16 dot product with f32 accumulation (Spec 1 App. A).
+    Dot2F32F16,
+    /// bf16 dot product with f32 accumulation (Spec 1 App. A).
+    Dot2F32Bf16,
+}
+
+/// hipGraph capture support (Spec 1 App. A `graph_capture`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GraphCapture {
+    /// Graphs capture and replay reliably (Spec 1 App. A; gfx1201).
+    Supported,
+    /// Captures but unreliably; the scheduler must not depend on it
+    /// (Spec 1 App. A).
+    Unstable,
+    /// No capture support, e.g. the CPU reference device (Spec 1 App. A).
+    None,
+}
+
+/// Peer transport for collectives (Spec 1 App. A `p2p`, Spec 1 §4.G).
+///
+/// The op is the same either way; transport only changes how the runtime
+/// moves the bytes: P2P where the descriptor says the pair supports it,
+/// host-staged otherwise (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum P2pTransport {
+    /// Direct peer access (Spec 1 App. A).
+    Direct,
+    /// Staged through host memory (Spec 1 App. A).
+    HostStaged,
+}
+
+/// One peer link entry, mirrored in `Topology.links` (Spec 5 §2).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct P2pLink {
+    /// Peer rank.
+    pub peer_rank: u32,
+    /// How bytes move to that peer (Spec 1 §4.G).
+    pub transport: P2pTransport,
+    /// Measured throughput, once the doctor measures it; `None` until then.
+    // DECISION(A1.1): Option, None until measured — mirrors the measured
+    // block below. Rejected 0.0, which would read as "measured zero".
+    pub measured_gbps: Option<f32>,
+}
+
+/// Doctor-measured values (Spec 1 App. A `measured`, Spec 11 §7).
+///
+/// Empty until the doctor's measurement pass fills it; spec-sheet values live
+/// on [`ArchDescriptor`] itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Measured {
+    /// Measured memory bandwidth in GB/s (Spec 1 App. A).
+    pub mem_bw_gbps: Option<f32>,
+    /// Kernel dispatch overhead in µs (Spec 1 App. A).
+    pub dispatch_overhead_us: Option<f32>,
+    /// Measured matrix rates, parallel to `matrix_ops` (Spec 1 App. A).
+    pub matrix_rates: Vec<RelRate>,
+    /// Host-to-device bandwidth in GB/s (Spec 1 App. A).
+    pub h2d_gbps: Option<f32>,
+    /// Device-to-host bandwidth in GB/s (Spec 1 App. A).
+    pub d2h_gbps: Option<f32>,
+}
+
+impl Measured {
+    /// Empty measurement block: the pre-doctor state (Spec 1 App. A:
+    /// "empty until then").
+    pub fn empty() -> Self {
+        Self {
+            mem_bw_gbps: None,
+            dispatch_overhead_us: None,
+            matrix_rates: Vec::new(),
+            h2d_gbps: None,
+            d2h_gbps: None,
+        }
+    }
+
+    /// True when no measurement has been recorded yet.
+    pub fn is_empty(&self) -> bool {
+        self.mem_bw_gbps.is_none()
+            && self.dispatch_overhead_us.is_none()
+            && self.matrix_rates.is_empty()
+            && self.h2d_gbps.is_none()
+            && self.d2h_gbps.is_none()
+    }
+}
+
+/// Per-device hardware description (Spec 1 App. A).
+///
+/// The only source of hardware facts: the planner also gets a link matrix
+/// (Spec 5 §2), and per-pair entries here mirror `Topology.links`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArchDescriptor {
+    /// Device name, e.g. `"gfx1201"` (Spec 1 App. A).
+    pub name: String,
+    /// Device family (Spec 1 App. A).
+    pub family: ArchFamily,
+    /// Wavefront size, 32 on gfx1201 (Spec 1 App. A).
+    pub wave_size: u32,
+    /// Compute-unit count, 64 on gfx1201 (Spec 1 App. A).
+    pub cu_count: u32,
+    /// LDS bytes per workgroup, 64 KiB on gfx1201 (Spec 1 App. A).
+    pub lds_bytes_per_wg: u32,
+    /// VGPRs available per lane (Spec 1 App. A).
+    pub vgprs_per_lane: u32,
+    /// L2 cache size in bytes (Spec 1 App. A).
+    pub l2_bytes: u64,
+    /// Infinity-cache size in bytes; 0 if none (Spec 1 App. A).
+    pub l3_bytes: u64,
+    /// VRAM in bytes; 32 GiB on gfx1201 (Spec 1 App. A).
+    pub vram_bytes: u64,
+    /// Spec-sheet bandwidth in GB/s; measured value lives in
+    /// [`Measured::mem_bw_gbps`] (Spec 1 App. A).
+    pub mem_bw_gbps: f32,
+    /// Clock in MHz (Spec 1 App. A).
+    pub clock_mhz: f32,
+    /// Complete list of WMMA/MFMA forms with relative throughput
+    /// (Spec 1 App. A).
+    pub matrix_ops: Vec<MatrixOp>,
+    /// VALU dot forms available (Spec 1 App. A).
+    pub valu_dot: Vec<ValuDot>,
+    /// Hardware conversion to/from e4m3/e5m2 (Spec 1 App. A; present on
+    /// gfx1201).
+    pub fp8_convert: bool,
+    /// SWMMAC / 2:4 structured-sparse support (Spec 1 App. A; present on
+    /// gfx1201).
+    pub sparse_matrix: bool,
+    /// Native B-fragment order the zero-copy loader checks against
+    /// (Spec 1 App. A, Spec 2 §2.4).
+    pub fragment_layout: LayoutId,
+    /// Intra-block K/V element order the attention kernels use
+    /// (Spec 1 App. A, Spec 3 §3.2, Spec 4 §5.3).
+    pub attention_layout: LayoutId,
+    /// Maximum workgroup size (Spec 1 App. A).
+    pub max_wg_size: u32,
+    /// hipGraph capture support (Spec 1 App. A).
+    pub graph_capture: GraphCapture,
+    /// Doctor-measured values; empty until measured (Spec 1 App. A,
+    /// Spec 11 §7).
+    pub measured: Measured,
+    /// Peer links, mirrored in `Topology.links` (Spec 1 App. A, Spec 5 §2).
+    pub p2p: Vec<P2pLink>,
+}
+
+impl ArchDescriptor {
+    /// gfx1201 (R9700) initial values, to be overwritten by measurement
+    /// (Spec 1 App. A).
+    ///
+    /// Spec-stated: wave 32; 64 CUs; 64 KiB LDS/WG; f16/bf16 at 1×,
+    /// e4m3/e5m2, iu8 and iu4 (nominal, verify) at 2×; `dot4_i32_i8` present;
+    /// fp8 convert present; SWMMAC present; 32 GiB VRAM; 640 GB/s spec
+    /// bandwidth; graph capture `Supported`. `fragment_layout` is `L1`: the
+    /// gfx12 native fragment order equals `L1` (Spec 2 §2.2).
+    // DECISION(A1.1): fields omitted from App. A's initial-value sentence use
+    // the reference gfx1201 capabilities recorded by the A0 spike hardware
+    // fingerprints: 256 addressable VGPRs/lane, 8 MiB L2, 64 MiB L3, 2350 MHz,
+    // and 1024 threads/WG. Rejected zero sentinels because Spec 4 §4.2 uses
+    // these fields as hard search-space limits. `measured` remains empty and
+    // p2p remains per-device/topology data; SI-2 owns the current rig's link.
+    // DECISION(A1.1): the e5m2 matrix entry pairs an e4m3 first operand.
+    // Spec 1 §2.1 constrains e5m2 to the second operand only but never names
+    // the first; rejected omitting e5m2 (App. A lists it at 2×) and rejected
+    // an (e5m2, e5m2) entry (contradicts §2.1). Spec 4 owns the correction.
+    pub fn gfx1201() -> Self {
+        let rate =
+            |v: f32| RelRate::new(v).expect("A1.1 gfx1201 rates are positive finite literals");
+        let mat = |shape: [u32; 3], a: DType, b: DType, acc: DType, r: f32| {
+            MatrixOp::new(shape, a, b, acc, rate(r))
+                .expect("A1.1 gfx1201 tile shapes are nonzero literals")
+        };
+        Self {
+            name: "gfx1201".to_owned(),
+            family: ArchFamily::Rdna4,
+            wave_size: 32,
+            cu_count: 64,
+            lds_bytes_per_wg: 64 * 1024,
+            vgprs_per_lane: 256,
+            l2_bytes: 8 * 1024 * 1024,
+            l3_bytes: 64 * 1024 * 1024,
+            vram_bytes: 32 * 1024 * 1024 * 1024,
+            mem_bw_gbps: 640.0,
+            clock_mhz: 2350.0,
+            matrix_ops: vec![
+                mat([16, 16, 16], DType::F16, DType::F16, DType::F32, 1.0),
+                mat([16, 16, 16], DType::Bf16, DType::Bf16, DType::F32, 1.0),
+                mat([16, 16, 16], DType::E4m3, DType::E4m3, DType::F32, 2.0),
+                mat([16, 16, 16], DType::E4m3, DType::E5m2, DType::F32, 2.0),
+                mat([16, 16, 16], DType::I8, DType::I8, DType::I32, 2.0),
+                mat([16, 16, 32], DType::I4, DType::I4, DType::I32, 2.0),
+            ],
+            valu_dot: vec![ValuDot::Dot4I32I8],
+            fp8_convert: true,
+            sparse_matrix: true,
+            fragment_layout: LayoutId::L1,
+            attention_layout: LayoutId::ATTENTION_GFX1201,
+            max_wg_size: 1024,
+            graph_capture: GraphCapture::Supported,
+            measured: Measured::empty(),
+            p2p: Vec::new(),
+        }
+    }
+
+    /// The CPU reference device for T0/T0v (Spec 1 App. A family `CPU`,
+    /// Spec 4 §2).
+    ///
+    /// Reports the scalar-reference identity: one lane, no matrix units, no
+    /// capture. Numeric fields are unset (0/empty): the spec assigns no values
+    /// here and the cost model must not mistake them for hardware facts.
+    // DECISION(A1.1): wave 1 / single CU / Contiguous layouts / capture None
+    // as the scalar-truth identity; rejected fabricating host core counts,
+    // SIMD widths or DRAM bandwidth, which vary per machine and belong to
+    // doctor measurement, not to a checked-in constructor.
+    pub fn cpu() -> Self {
+        Self {
+            name: "cpu".to_owned(),
+            family: ArchFamily::Cpu,
+            wave_size: 1,
+            cu_count: 1,
+            lds_bytes_per_wg: 0,
+            vgprs_per_lane: 0,
+            l2_bytes: 0,
+            l3_bytes: 0,
+            vram_bytes: 0,
+            mem_bw_gbps: 0.0,
+            clock_mhz: 0.0,
+            matrix_ops: Vec::new(),
+            valu_dot: Vec::new(),
+            fp8_convert: false,
+            sparse_matrix: false,
+            fragment_layout: LayoutId::CONTIGUOUS,
+            attention_layout: LayoutId::CONTIGUOUS,
+            max_wg_size: 1,
+            graph_capture: GraphCapture::None,
+            measured: Measured::empty(),
+            p2p: Vec::new(),
+        }
+    }
+}

--- a/crates/r9v-ir/src/batch.rs
+++ b/crates/r9v-ir/src/batch.rs
@@ -1,0 +1,595 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Batch metadata shared by ops (Spec 1 §2.5, §4.D.1).
+//!
+//! One [`BatchMeta`] is an external input shared by ops (Spec 1 §2.5). `G`
+//! (layer groups, one block table per group per Spec 3 §6.1) is fixed per
+//! model, which keeps `BatchMeta` fixed-shape (Spec 3 §3.3). Build with
+//! [`BatchMeta::builder`]; the builder checks every `[G, T]` / `[G, S,
+//! max_blocks]` / `[G, S]` length against the declared dims and reports every
+//! mismatch at once (CONVENTIONS.md §1.4).
+
+use crate::IrError;
+
+/// Sentinel padding value for unused `block_table` entries.
+///
+/// Tables are `[G, S, max_blocks]` with `max_blocks = ceil(max_ctx / 32)`
+/// (Spec 3 §3.3); rows shorter than `max_blocks` are padded with a value that
+/// can never be a real block id.
+// DECISION(A1.1): u32::MAX. Spec 3 §3.3 requires "a sentinel" without naming
+// it; rejected 0 because block 0 is a valid allocation.
+pub const BLOCK_TABLE_SENTINEL: u32 = u32::MAX;
+
+/// Token positions: per-token absolute positions, or triplets under mrope
+/// (`positions [T] u32 | [T,3] u32`, Spec 1 §2.5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Positions {
+    /// One absolute position per token (Spec 1 §2.5).
+    PerToken(Vec<u32>),
+    /// One `(t, h, w)`-style triplet per token under mrope (Spec 1 §2.5).
+    Mrope(Vec<[u32; 3]>),
+}
+
+impl Positions {
+    /// Number of tokens described; must equal batch `T` (Spec 1 §2.5).
+    pub fn len(&self) -> usize {
+        match self {
+            Positions::PerToken(v) => v.len(),
+            Positions::Mrope(v) => v.len(),
+        }
+    }
+
+    /// True when no token is described.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Speculative tree mask (Spec 1 §4.D.1).
+///
+/// `parents [T] i32` (−1 = root of its sequence) plus the derived
+/// `[T, T_max] bool` ancestor mask, built by the scheduler. Kernels may
+/// consume either form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeMask {
+    parents: Vec<i32>,
+    t_max: u32,
+    ancestors: Vec<bool>,
+}
+
+impl TreeMask {
+    /// Builds a tree mask, checking `parents` ids (−1 or `< T`, never self)
+    /// and the `T * t_max` ancestor length (Spec 1 §4.D.1).
+    ///
+    /// `t_max` is the column count per token row; producers (scheduler
+    /// pre-step, Spec 6) size it to cover the longest query in the batch.
+    // DECISION(A1.1): T_max sizing rule. Spec 1 §4.D.1 gives the shape
+    // `[T, T_max]` but no sizing rule; rejected fixing it to a bucket
+    // constant because bucket sizes vary (Spec 1 §3.5). The IR carries the
+    // mask the scheduler built; it does not derive ancestor sets itself.
+    pub fn new(parents: Vec<i32>, t_max: u32, ancestors: Vec<bool>) -> Result<Self, IrError> {
+        let t = parents.len();
+        let mut problems = Vec::new();
+        if t > 0 && t_max == 0 {
+            problems.push(IrError::ZeroTreeMax { t });
+        }
+        match t.checked_mul(t_max as usize) {
+            Some(expected) if ancestors.len() != expected => {
+                problems.push(IrError::AncestorLength {
+                    t,
+                    t_max,
+                    expected,
+                    actual: ancestors.len(),
+                });
+            }
+            Some(_) => {}
+            None => problems.push(IrError::AncestorShapeOverflow { t, t_max }),
+        }
+        for (token, parent) in parents.iter().enumerate() {
+            if *parent < -1 || *parent >= t as i32 {
+                problems.push(IrError::BadParent {
+                    token,
+                    parent: *parent,
+                    t,
+                });
+            } else if *parent == token as i32 {
+                problems.push(IrError::SelfParent { token });
+            }
+        }
+        collect_parent_cycles(&parents, &mut problems);
+        if problems.is_empty() {
+            Ok(Self {
+                parents,
+                t_max,
+                ancestors,
+            })
+        } else if problems.len() == 1 {
+            Err(problems
+                // Internal invariant: this branch runs only when len == 1.
+                .pop()
+                .expect("problems holds exactly one entry"))
+        } else {
+            Err(IrError::Multiple {
+                problems: problems.into_boxed_slice(),
+            })
+        }
+    }
+
+    /// Token count `T` (`parents.len()`).
+    pub fn t(&self) -> usize {
+        self.parents.len()
+    }
+
+    /// Columns per row (`T_max`).
+    pub fn t_max(&self) -> u32 {
+        self.t_max
+    }
+
+    /// Parent ids, −1 for roots (Spec 1 §4.D.1).
+    pub fn parents(&self) -> &[i32] {
+        &self.parents
+    }
+
+    /// Flattened `[T, T_max]` row-major ancestor mask (Spec 1 §4.D.1).
+    pub fn ancestors(&self) -> &[bool] {
+        &self.ancestors
+    }
+
+    /// Ancestor bit for token `tok` at column `pos`.
+    ///
+    /// Panics on out-of-bounds indices: dimensions are fixed at construction,
+    /// so a bad index is a caller bug, not input data.
+    pub fn is_ancestor(&self, tok: usize, pos: usize) -> bool {
+        assert!(
+            tok < self.parents.len(),
+            "TreeMask::is_ancestor token {tok} out of bounds for T={}",
+            self.parents.len(),
+        );
+        assert!(
+            (pos as u32) < self.t_max,
+            "TreeMask::is_ancestor pos {pos} out of bounds for t_max={}",
+            self.t_max,
+        );
+        self.ancestors[tok * self.t_max as usize + pos]
+    }
+}
+
+/// Batch metadata: one external input shared by ops (Spec 1 §2.5).
+///
+/// Explicit shape semantics: `G` layer groups (fixed per model, Spec 3 §3.3),
+/// `S` sequences, `T = T_dec + T_pre` tokens (Spec 1 §3.1), `max_blocks =
+/// ceil(max_ctx / 32)` blocks per sequence per group (Spec 3 §3.3).
+/// `slot_map` is `[G, T]` flattened slots, `block_table` is
+/// `[G, S, max_blocks]`, `window_start` is `[G, S]` (first retained position
+/// for Window groups, 0 otherwise; Spec 1 §2.5, Spec 3 §3.5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchMeta {
+    g: u32,
+    s: u32,
+    t: u32,
+    max_blocks: u32,
+    seq_ids: Vec<u32>,
+    query_len: Vec<u32>,
+    ctx_len: Vec<u32>,
+    positions: Positions,
+    slot_map: Vec<u32>,
+    block_table: Vec<u32>,
+    window_start: Vec<u32>,
+    tree: Option<TreeMask>,
+}
+
+impl BatchMeta {
+    /// Starts a builder for the given dims (Spec 1 §2.5 shapes).
+    pub fn builder(g: u32, s: u32, t: u32, max_blocks: u32) -> BatchMetaBuilder {
+        BatchMetaBuilder {
+            g,
+            s,
+            t,
+            max_blocks,
+            seq_ids: None,
+            query_len: None,
+            ctx_len: None,
+            positions: None,
+            slot_map: None,
+            block_table: None,
+            window_start: None,
+            tree: None,
+        }
+    }
+
+    /// Layer-group count `G`, fixed per model (Spec 3 §3.3).
+    pub fn g(&self) -> u32 {
+        self.g
+    }
+
+    /// Sequence count `S` (Spec 1 §2.5).
+    pub fn s(&self) -> u32 {
+        self.s
+    }
+
+    /// Token count `T = T_dec + T_pre` (Spec 1 §2.5, §3.1).
+    pub fn t(&self) -> u32 {
+        self.t
+    }
+
+    /// Blocks per sequence per group, `ceil(max_ctx / 32)` (Spec 3 §3.3).
+    pub fn max_blocks(&self) -> u32 {
+        self.max_blocks
+    }
+
+    /// Sequence ids `[S]` (Spec 1 §2.5).
+    pub fn seq_ids(&self) -> &[u32] {
+        &self.seq_ids
+    }
+
+    /// Query lengths `[S]`: 1 for plain decode, `k+1` for spec verify, chunk
+    /// size for prefill (Spec 1 §2.5).
+    pub fn query_len(&self) -> &[u32] {
+        &self.query_len
+    }
+
+    /// Tokens already in state before this step, `[S]` (Spec 1 §2.5).
+    pub fn ctx_len(&self) -> &[u32] {
+        &self.ctx_len
+    }
+
+    /// Token positions, `[T]` or `[T,3]` (Spec 1 §2.5).
+    pub fn positions(&self) -> &Positions {
+        &self.positions
+    }
+
+    /// Flattened KV destination slot per new token per group, `[G, T]`
+    /// row-major (Spec 1 §2.5, Spec 3 §3.3).
+    pub fn slot_map(&self) -> &[u32] {
+        &self.slot_map
+    }
+
+    /// Block tables, `[G, S, max_blocks]` row-major, padded with
+    /// [`BLOCK_TABLE_SENTINEL`] (Spec 1 §2.5, Spec 3 §3.3).
+    pub fn block_table(&self) -> &[u32] {
+        &self.block_table
+    }
+
+    /// First retained position per group per sequence, `[G, S]` row-major; 0
+    /// for non-window groups (Spec 1 §2.5, Spec 3 §3.5).
+    pub fn window_start(&self) -> &[u32] {
+        &self.window_start
+    }
+
+    /// Speculative tree mask, if the step verifies drafts (Spec 1 §4.D.1).
+    pub fn tree(&self) -> Option<&TreeMask> {
+        self.tree.as_ref()
+    }
+
+    /// Slot for new token `tok` in group `group` (row-major `[G, T]`).
+    ///
+    /// Panics on out-of-bounds indices: dims are fixed at construction, so a
+    /// bad index is a caller bug, not input data.
+    pub fn slot(&self, group: u32, tok: u32) -> u32 {
+        assert!(
+            group < self.g,
+            "BatchMeta::slot group {group} >= G={}",
+            self.g
+        );
+        assert!(tok < self.t, "BatchMeta::slot tok {tok} >= T={}", self.t);
+        self.slot_map[group as usize * self.t as usize + tok as usize]
+    }
+
+    /// Block id for sequence `seq`, slot-entry `b`, in group `group`
+    /// (row-major `[G, S, max_blocks]`).
+    ///
+    /// Panics on out-of-bounds indices: dims are fixed at construction, so a
+    /// bad index is a caller bug, not input data.
+    pub fn block(&self, group: u32, seq: u32, b: u32) -> u32 {
+        assert!(
+            group < self.g,
+            "BatchMeta::block group {group} >= G={}",
+            self.g
+        );
+        assert!(seq < self.s, "BatchMeta::block seq {seq} >= S={}", self.s);
+        assert!(
+            b < self.max_blocks,
+            "BatchMeta::block b {b} >= max_blocks={}",
+            self.max_blocks,
+        );
+        self.block_table[(group as usize * self.s as usize + seq as usize)
+            * self.max_blocks as usize
+            + b as usize]
+    }
+
+    /// First retained position for sequence `seq` in group `group`
+    /// (row-major `[G, S]`).
+    ///
+    /// Panics on out-of-bounds indices: dims are fixed at construction, so a
+    /// bad index is a caller bug, not input data.
+    pub fn window(&self, group: u32, seq: u32) -> u32 {
+        assert!(
+            group < self.g,
+            "BatchMeta::window group {group} >= G={}",
+            self.g
+        );
+        assert!(seq < self.s, "BatchMeta::window seq {seq} >= S={}", self.s);
+        self.window_start[group as usize * self.s as usize + seq as usize]
+    }
+}
+
+/// Builder for [`BatchMeta`] (Spec 1 §2.5).
+///
+/// `G/S/T/max_blocks` are fixed up front; every field is set by name and
+/// [`BatchMetaBuilder::build`] checks presence plus all lengths at once.
+#[derive(Debug, Clone)]
+pub struct BatchMetaBuilder {
+    g: u32,
+    s: u32,
+    t: u32,
+    max_blocks: u32,
+    seq_ids: Option<Vec<u32>>,
+    query_len: Option<Vec<u32>>,
+    ctx_len: Option<Vec<u32>>,
+    positions: Option<Positions>,
+    slot_map: Option<Vec<u32>>,
+    block_table: Option<Vec<u32>>,
+    window_start: Option<Vec<u32>>,
+    tree: Option<TreeMask>,
+}
+
+impl BatchMetaBuilder {
+    /// Sequence ids `[S]` (Spec 1 §2.5).
+    pub fn seq_ids(mut self, v: Vec<u32>) -> Self {
+        self.seq_ids = Some(v);
+        self
+    }
+
+    /// Query lengths `[S]` (Spec 1 §2.5).
+    pub fn query_len(mut self, v: Vec<u32>) -> Self {
+        self.query_len = Some(v);
+        self
+    }
+
+    /// Context lengths `[S]` (Spec 1 §2.5).
+    pub fn ctx_len(mut self, v: Vec<u32>) -> Self {
+        self.ctx_len = Some(v);
+        self
+    }
+
+    /// Token positions, `[T]` or `[T,3]` (Spec 1 §2.5).
+    pub fn positions(mut self, v: Positions) -> Self {
+        self.positions = Some(v);
+        self
+    }
+
+    /// Flattened slots `[G, T]` row-major (Spec 1 §2.5).
+    pub fn slot_map(mut self, v: Vec<u32>) -> Self {
+        self.slot_map = Some(v);
+        self
+    }
+
+    /// Block tables `[G, S, max_blocks]` row-major (Spec 1 §2.5).
+    pub fn block_table(mut self, v: Vec<u32>) -> Self {
+        self.block_table = Some(v);
+        self
+    }
+
+    /// First retained positions `[G, S]` row-major (Spec 1 §2.5).
+    pub fn window_start(mut self, v: Vec<u32>) -> Self {
+        self.window_start = Some(v);
+        self
+    }
+
+    /// Speculative tree mask (Spec 1 §4.D.1). Optional; `None` when the step
+    /// verifies no drafts.
+    pub fn tree(mut self, v: Option<TreeMask>) -> Self {
+        self.tree = v;
+        self
+    }
+
+    /// Validates presence and every `[G, T]` / `[G, S, max_blocks]` / `[G, S]`
+    /// length, reporting all failures at once (CONVENTIONS.md §1.4).
+    pub fn build(self) -> Result<BatchMeta, IrError> {
+        let mut problems = Vec::new();
+        if self.g == 0 || self.s == 0 || self.t == 0 || self.max_blocks == 0 {
+            problems.push(IrError::ZeroBatchDim {
+                g: self.g,
+                s: self.s,
+                t: self.t,
+                max_blocks: self.max_blocks,
+            });
+        }
+        let s = self.s as usize;
+        let t = self.t as usize;
+
+        let seq_ids = check_len(&mut problems, "seq_ids", self.seq_ids, Some(s));
+        let query_len = check_len(&mut problems, "query_len", self.query_len, Some(s));
+        let ctx_len = check_len(&mut problems, "ctx_len", self.ctx_len, Some(s));
+        let slot_map_expected = checked_product(&mut problems, "slot_map", &[self.g, self.t]);
+        let block_table_expected = checked_product(
+            &mut problems,
+            "block_table",
+            &[self.g, self.s, self.max_blocks],
+        );
+        let window_start_expected =
+            checked_product(&mut problems, "window_start", &[self.g, self.s]);
+        let slot_map = check_len(&mut problems, "slot_map", self.slot_map, slot_map_expected);
+        let block_table = check_len(
+            &mut problems,
+            "block_table",
+            self.block_table,
+            block_table_expected,
+        );
+        let window_start = check_len(
+            &mut problems,
+            "window_start",
+            self.window_start,
+            window_start_expected,
+        );
+
+        let positions = match self.positions {
+            Some(p) if p.len() == t => Some(p),
+            Some(p) => {
+                problems.push(IrError::BatchLength {
+                    field: "positions",
+                    expected: t,
+                    actual: p.len(),
+                });
+                None
+            }
+            None => {
+                problems.push(IrError::MissingField { field: "positions" });
+                None
+            }
+        };
+
+        if let Some(q) = query_len.as_ref() {
+            for (seq, len) in q.iter().enumerate() {
+                if *len == 0 {
+                    problems.push(IrError::EmptyQuery { seq });
+                }
+            }
+            let actual = q.iter().map(|&len| u64::from(len)).sum();
+            if actual != u64::from(self.t) {
+                problems.push(IrError::QueryTokenCount {
+                    expected: self.t,
+                    actual,
+                });
+            }
+        }
+
+        if let Some(tree) = self.tree.as_ref() {
+            if tree.t() != t {
+                problems.push(IrError::TreeBatchMismatch {
+                    tree_t: tree.t(),
+                    batch_t: self.t,
+                });
+            }
+            if let Some(query_len) = query_len.as_ref() {
+                let required = query_len.iter().copied().max().unwrap_or(0);
+                if tree.t_max() < required {
+                    problems.push(IrError::TreeMaxTooSmall {
+                        required,
+                        actual: tree.t_max(),
+                    });
+                }
+                if tree.t() == t {
+                    let mut seq_start = 0usize;
+                    for (seq, &seq_len) in query_len.iter().enumerate() {
+                        let seq_end = seq_start + seq_len as usize;
+                        for token in seq_start..seq_end {
+                            let parent = tree.parents()[token];
+                            if parent >= 0
+                                && ((parent as usize) < seq_start || (parent as usize) >= seq_end)
+                            {
+                                problems.push(IrError::TreeParentCrossesSequence {
+                                    token,
+                                    parent,
+                                    seq,
+                                    seq_start,
+                                    seq_end,
+                                });
+                            }
+                        }
+                        seq_start = seq_end;
+                    }
+                }
+            }
+        }
+
+        if problems.is_empty() {
+            Ok(BatchMeta {
+                g: self.g,
+                s: self.s,
+                t: self.t,
+                max_blocks: self.max_blocks,
+                seq_ids: seq_ids.expect("checked present"),
+                query_len: query_len.expect("checked present"),
+                ctx_len: ctx_len.expect("checked present"),
+                positions: positions.expect("checked present"),
+                slot_map: slot_map.expect("checked present"),
+                block_table: block_table.expect("checked present"),
+                window_start: window_start.expect("checked present"),
+                tree: self.tree,
+            })
+        } else if problems.len() == 1 {
+            Err(problems
+                // Internal invariant: this branch runs only when len == 1.
+                .pop()
+                .expect("problems holds exactly one entry"))
+        } else {
+            Err(IrError::Multiple {
+                problems: problems.into_boxed_slice(),
+            })
+        }
+    }
+}
+
+fn check_len(
+    problems: &mut Vec<IrError>,
+    field: &'static str,
+    value: Option<Vec<u32>>,
+    expected: Option<usize>,
+) -> Option<Vec<u32>> {
+    match value {
+        Some(v) if expected.is_some_and(|expected| v.len() == expected) => Some(v),
+        Some(v) if expected.is_some() => {
+            problems.push(IrError::BatchLength {
+                field,
+                expected: expected.expect("guard proves expected is present"),
+                actual: v.len(),
+            });
+            None
+        }
+        Some(_) => None,
+        None => {
+            problems.push(IrError::MissingField { field });
+            None
+        }
+    }
+}
+
+fn checked_product(
+    problems: &mut Vec<IrError>,
+    field: &'static str,
+    factors: &[u32],
+) -> Option<usize> {
+    let product = factors.iter().try_fold(1usize, |product, &factor| {
+        product.checked_mul(factor as usize)
+    });
+    if product.is_none() {
+        problems.push(IrError::BatchShapeOverflow {
+            field,
+            factors: factors.to_vec().into_boxed_slice(),
+        });
+    }
+    product
+}
+
+fn collect_parent_cycles(parents: &[i32], problems: &mut Vec<IrError>) {
+    let mut state = vec![0u8; parents.len()];
+    for start in 0..parents.len() {
+        if state[start] == 2 {
+            continue;
+        }
+        let mut path = Vec::new();
+        let mut token = start;
+        loop {
+            match state[token] {
+                2 => break,
+                1 => {
+                    let first = path.iter().position(|&seen| seen == token).unwrap_or(0);
+                    let cycle_token = path[first..].iter().copied().min().unwrap_or(token);
+                    problems.push(IrError::TreeCycle { token: cycle_token });
+                    break;
+                }
+                _ => {}
+            }
+            state[token] = 1;
+            path.push(token);
+            let parent = parents[token];
+            if parent < 0 || parent as usize >= parents.len() || parent as usize == token {
+                break;
+            }
+            token = parent as usize;
+        }
+        for token in path {
+            state[token] = 2;
+        }
+    }
+}

--- a/crates/r9v-ir/src/dtype.rs
+++ b/crates/r9v-ir/src/dtype.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Element data types (Spec 1 §2.1).
+//!
+//! Closed set: a new dtype lands via the RFC process (Spec 1 §7), never as a
+//! one-off. Codebook GGUF types have no dtype here: spec 2 §3.3 maps them to
+//! the `i8` matrix path, so the IR never sees a codebook (Spec 1 §2.1).
+
+use std::fmt;
+
+/// Element data type (Spec 1 §2.1).
+///
+/// Closed enum: every `match` on this type is exhaustive with no wildcard arm
+/// so an RFC-added variant fails to compile at each site that must care.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DType {
+    /// IEEE single; accumulators, norm stats, logits (Spec 1 §2.1).
+    F32,
+    /// IEEE half; activations (Spec 1 §2.1).
+    F16,
+    /// bfloat16; activations (Spec 1 §2.1).
+    Bf16,
+    /// fp8 E4M3; activations, KV cache, fp8 weights (Spec 1 §2.1).
+    E4m3,
+    /// fp8 E5M2; second WMMA operand only (Spec 1 §2.1).
+    E5m2,
+    /// Signed int8; weights, quantized activations (Spec 1 §2.1).
+    I8,
+    /// Signed/unsigned int4, packed 2 per byte; weights only (Spec 1 §2.1).
+    I4,
+    /// int32; accumulators, ids, counts (Spec 1 §2.1).
+    I32,
+    /// uint32; token ids, row ids, block ids (Spec 1 §2.1).
+    U32,
+    /// Mask; attention masks, grammar masks (Spec 1 §2.1).
+    Bool,
+}
+
+impl fmt::Display for DType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Stable lowercase snake_case names, never discriminants
+        // (CONVENTIONS.md §3.2).
+        let name = match self {
+            DType::F32 => "f32",
+            DType::F16 => "f16",
+            DType::Bf16 => "bf16",
+            DType::E4m3 => "e4m3",
+            DType::E5m2 => "e5m2",
+            DType::I8 => "i8",
+            DType::I4 => "i4",
+            DType::I32 => "i32",
+            DType::U32 => "u32",
+            DType::Bool => "bool",
+        };
+        write!(f, "{name}")
+    }
+}

--- a/crates/r9v-ir/src/error.rs
+++ b/crates/r9v-ir/src/error.rs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Crate error type for the Op IR (Spec 1 §2–§6, App. A; CONVENTIONS.md §1.1).
+//!
+//! [`IrError`] is the per-crate domain error enum for `r9v-ir`. Every variant
+//! carries the numbers a caller needs to fix the problem (CONVENTIONS.md §1.3),
+//! and constructors that check several fields return every failure at once
+//! (CONVENTIONS.md §1.4) via [`IrError::Multiple`].
+
+use crate::{Class, DType, LayoutId, Placement, QuantScheme};
+
+/// Domain error for Op IR type construction and validation.
+///
+/// Covers Spec 1 §2 (core types), §3.1 (step-graph shape rules that constrain
+/// batch metadata), §4.D.1 (tree masks) and App. A (arch descriptor rates).
+/// Wrapping into the top-level `r9v_common::R9vError` is owned by a later card
+/// once a downstream crate composes this error down the dependency graph
+/// (CONVENTIONS.md §1.1); this crate cannot declare that impl without either
+/// editing `r9v-common` (outside card A1.1's crates) or orphan-rule issues.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum IrError {
+    /// Tensor rank outside `1..=4` (Spec 1 §2.3: `shape: [Dim; ≤4]`, and every
+    /// op signature in §4 has rank ≥ 1).
+    #[error("invalid tensor rank {got}: rank must be 1..=4 (Spec 1 §2.3)")]
+    InvalidRank {
+        /// Rank that was supplied.
+        got: usize,
+    },
+
+    /// A concrete tensor extent is zero (Spec 1 §2.3; every §4 signature
+    /// requires at least one element per axis).
+    #[error("tensor axis {axis} has zero extent (Spec 1 §2.3)")]
+    ZeroExtent {
+        /// Axis index holding the zero extent.
+        axis: usize,
+    },
+
+    /// A `Host` or `Tiered` placement was attached to a non-`Weight` tensor
+    /// class (Spec 1 §2.3: both are legal only for `Weight` class tensors).
+    #[error("placement {placement} requires Weight class, got {class} (Spec 1 §2.3)")]
+    PlacementForClass {
+        /// Requested placement.
+        placement: Placement,
+        /// Tensor class it was attached to.
+        class: Class,
+    },
+
+    /// A quantization scheme was attached to a tensor class on which Spec 1
+    /// §2.2 does not permit it.
+    #[error("quantization {quant:?} is not legal for tensor class {class} (Spec 1 §2.2)")]
+    QuantForClass {
+        /// Requested quantization scheme.
+        quant: QuantScheme,
+        /// Tensor class it was attached to.
+        class: Class,
+    },
+
+    /// A logical layout was attached to a tensor class on which it is not
+    /// defined (Spec 1 §2.3, Spec 2 §2).
+    #[error("layout {layout} is not legal for tensor class {class} (Spec 1 §2.3, Spec 2 §2)")]
+    LayoutForClass {
+        /// Requested logical layout.
+        layout: LayoutId,
+        /// Tensor class it was attached to.
+        class: Class,
+    },
+
+    /// A dtype was attached to a class for which Spec 1 §2.1 forbids it.
+    #[error("dtype {dtype} is not legal for tensor class {class} (Spec 1 §2.1)")]
+    DTypeForClass {
+        /// Requested element dtype.
+        dtype: DType,
+        /// Tensor class it was attached to.
+        class: Class,
+    },
+
+    /// A quantization scheme and stored dtype are incompatible (Spec 1 §2.2,
+    /// §4.A; Spec 2 §3.4).
+    #[error("quantization {quant:?} is not legal with dtype {dtype} (Spec 1 §2.2, §4.A)")]
+    QuantDType {
+        /// Requested quantization scheme.
+        quant: QuantScheme,
+        /// Stored element dtype.
+        dtype: DType,
+    },
+
+    /// One or more batch dims are zero. `G`, `S`, `T` follow the bucket rules
+    /// (Spec 1 §3.5: buckets start at 1; `T_pre` may be 0 but `T ≥ 1` always
+    /// holds) and `max_blocks = ceil(max_ctx / 32) ≥ 1` (Spec 3 §3.3).
+    #[error("batch dims must be nonzero: G={g} S={s} T={t} max_blocks={max_blocks} (Spec 1 §2.5)")]
+    ZeroBatchDim {
+        /// Layer-group count.
+        g: u32,
+        /// Sequence count.
+        s: u32,
+        /// Token count (`T_dec + T_pre`).
+        t: u32,
+        /// Blocks per sequence per group.
+        max_blocks: u32,
+    },
+
+    /// A batch field's length disagrees with the `(G, S, T, max_blocks)` shape
+    /// (Spec 1 §2.5).
+    #[error("batch field `{field}` has length {actual}, expected {expected} (Spec 1 §2.5)")]
+    BatchLength {
+        /// Field name, e.g. `"slot_map"`.
+        field: &'static str,
+        /// Required length from the batch dims.
+        expected: usize,
+        /// Supplied length.
+        actual: usize,
+    },
+
+    /// A declared batch shape cannot be represented as a host allocation
+    /// length (Spec 1 §2.5). The factors are reported in their documented
+    /// order, for example `[G, S, max_blocks]`.
+    #[error(
+        "batch field `{field}` shape product overflows usize: factors={factors:?} (Spec 1 §2.5)"
+    )]
+    BatchShapeOverflow {
+        /// Field whose flattened length overflowed.
+        field: &'static str,
+        /// Shape factors in spec order.
+        factors: Box<[u32]>,
+    },
+
+    /// The builder is missing a required field (Spec 1 §2.5).
+    #[error("batch field `{field}` is missing (Spec 1 §2.5)")]
+    MissingField {
+        /// Missing field name.
+        field: &'static str,
+    },
+
+    /// A sequence declares `query_len == 0`. Decode sequences have
+    /// `1..=k+1`, prefill sequences a chunk size ≥ 1 (Spec 1 §3.1).
+    #[error("sequence {seq} has query_len 0, must be >= 1 (Spec 1 §3.1)")]
+    EmptyQuery {
+        /// Sequence index.
+        seq: usize,
+    },
+
+    /// The per-sequence query lengths do not sum to the declared token count
+    /// `T` (Spec 1 §2.4–§2.5).
+    #[error("query_len sum is {actual}, expected batch T={expected} (Spec 1 §2.4–§2.5)")]
+    QueryTokenCount {
+        /// Declared batch token count.
+        expected: u32,
+        /// Sum of every sequence's query length.
+        actual: u64,
+    },
+
+    /// A tree mask's token count disagrees with the batch `T` it is attached
+    /// to (`parents [T]`, Spec 1 §4.D.1).
+    #[error("tree parents length {tree_t} does not match batch T={batch_t} (Spec 1 §4.D.1)")]
+    TreeBatchMismatch {
+        /// `parents.len()`.
+        tree_t: usize,
+        /// Batch `T`.
+        batch_t: u32,
+    },
+
+    /// A tree parent id is neither −1 (root) nor a valid token index
+    /// (Spec 1 §4.D.1).
+    #[error("tree parent of token {token} is {parent}, must be -1 or < {t} (Spec 1 §4.D.1)")]
+    BadParent {
+        /// Token index.
+        token: usize,
+        /// Offending parent id.
+        parent: i32,
+        /// Token count `T`.
+        t: usize,
+    },
+
+    /// A token names itself as its own parent; never a valid tree
+    /// (Spec 1 §4.D.1).
+    #[error("token {token} is its own parent (Spec 1 §4.D.1)")]
+    SelfParent {
+        /// Token index.
+        token: usize,
+    },
+
+    /// The ancestor mask length disagrees with `T * t_max` (Spec 1 §4.D.1).
+    #[error(
+        "tree ancestors length {actual} != T({t}) * t_max({t_max}) = {expected} (Spec 1 §4.D.1)"
+    )]
+    AncestorLength {
+        /// Token count `T` (`parents.len()`).
+        t: usize,
+        /// Columns per row.
+        t_max: u32,
+        /// Required length.
+        expected: usize,
+        /// Supplied length.
+        actual: usize,
+    },
+
+    /// The ancestor-mask shape cannot be represented as a host allocation
+    /// length (Spec 1 §4.D.1).
+    #[error("tree ancestor shape T={t} by t_max={t_max} overflows usize (Spec 1 §4.D.1)")]
+    AncestorShapeOverflow {
+        /// Token count.
+        t: usize,
+        /// Ancestor columns per token.
+        t_max: u32,
+    },
+
+    /// A non-empty tree has no ancestor-mask columns (Spec 1 §4.D.1).
+    #[error("tree with T={t} has t_max=0 (Spec 1 §4.D.1)")]
+    ZeroTreeMax {
+        /// Token count.
+        t: usize,
+    },
+
+    /// Parent pointers contain a cycle and therefore do not describe a tree
+    /// (Spec 1 §4.D.1).
+    #[error("tree parent chain from token {token} contains a cycle (Spec 1 §4.D.1)")]
+    TreeCycle {
+        /// Deterministic lowest start token whose walk found the cycle.
+        token: usize,
+    },
+
+    /// A parent pointer crosses between two sequences in a flattened batch
+    /// (Spec 1 §4.D.1: −1 is the root of its sequence).
+    #[error(
+        "tree token {token} in sequence {seq} points to parent {parent} outside [{seq_start}, {seq_end}) (Spec 1 §4.D.1)"
+    )]
+    TreeParentCrossesSequence {
+        /// Token index in the flattened batch.
+        token: usize,
+        /// Parent index supplied by the scheduler.
+        parent: i32,
+        /// Sequence index.
+        seq: usize,
+        /// First flattened token belonging to the sequence.
+        seq_start: usize,
+        /// Exclusive end of the sequence's flattened token range.
+        seq_end: usize,
+    },
+
+    /// The ancestor-mask column count is too small for the longest sequence
+    /// query in the batch (Spec 1 §4.D.1).
+    #[error("tree t_max={actual} is smaller than required {required} (Spec 1 §4.D.1)")]
+    TreeMaxTooSmall {
+        /// Longest query length in the batch.
+        required: u32,
+        /// Supplied mask width.
+        actual: u32,
+    },
+
+    /// A matrix-op descriptor uses an accumulator dtype outside the closed
+    /// f32/i32 set (Spec 1 §6.1, App. A).
+    #[error("matrix accumulator dtype {got} must be f32 or i32 (Spec 1 §6.1, App. A)")]
+    InvalidAccumulator {
+        /// Rejected accumulator dtype.
+        got: DType,
+    },
+
+    /// A relative matrix-throughput rate is not finite and positive
+    /// (Spec 1 App. A).
+    #[error("invalid relative rate {value}: must be finite and > 0 (Spec 1 App. A)")]
+    NonPositiveRate {
+        /// Rejected value.
+        value: f32,
+    },
+
+    /// Collect-all wrapper: every problem found before returning
+    /// (CONVENTIONS.md §1.4). Constructors return the single problem directly
+    /// when only one exists.
+    #[error("multiple validation failures: {problems:?}")]
+    Multiple {
+        /// Every problem found, in deterministic field order.
+        problems: Box<[IrError]>,
+    },
+}

--- a/crates/r9v-ir/src/layout.rs
+++ b/crates/r9v-ir/src/layout.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Logical layout handles (Spec 1 §2.3, Spec 2 §2).
+//!
+//! Layout values (`L0`, `L1`, `L1S`, future `L2`) are owned by spec 2 §2 and
+//! defined by `r9v-format` (card A2.1). This crate carries them opaquely so
+//! tensors and the arch descriptor can name layouts without depending on
+//! `r9v-format` (card A1.1; same cycle-avoidance as [`SchemeId`](crate::SchemeId)).
+
+use std::fmt;
+
+/// Opaque logical-layout handle (Spec 1 §2.3, Spec 2 §2).
+///
+/// Accepts any `u64`: a future layout version (spec 2 §2.4: "a new fragment
+/// order is `L2`") must decode here without an update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LayoutId(u64);
+
+impl LayoutId {
+    /// Contiguous activations layout (Spec 1 §2.3: "activations use
+    /// Contiguous").
+    pub const CONTIGUOUS: Self = Self(0);
+    /// Row-major layout for lookup tables and vectors (Spec 2 §2.1).
+    pub const L0: Self = Self(1);
+    /// Tiled layout for matmul weights; also the gfx12 native B-fragment
+    /// order, which is what makes zero-copy load possible (Spec 2 §2.2).
+    pub const L1: Self = Self(2);
+    /// Tiled 2:4 structured-sparse layout over compressed K plus an index
+    /// region (Spec 2 §2.3).
+    pub const L1S: Self = Self(3);
+    /// Provisional id for the gfx1201 intra-block K/V order described in
+    /// Spec 4 §5.3 (`[d/16][32 tokens][16]` B-fragment lane order for K,
+    /// `[32 tokens][dv]` A-fragment order for V). No spec names a `LayoutId`
+    /// for it; see SI-3.
+    pub const ATTENTION_GFX1201: Self = Self(4);
+
+    /// Wraps a layout code. Code assignment for spec 2 ids is owned by
+    /// `r9v-format` (card A2.2); the `0..=4` values above are provisional
+    /// until A2.1 adopts or remaps them.
+    // DECISION(A1.1): provisional codes mirroring spec order (Contiguous from
+    // spec 1 §2.3, then spec 2 §2.1–§2.3); rejected leaving gfx1201() without
+    // layouts because card A1.1 requires both constructors with these fields.
+    pub const fn new(code: u64) -> Self {
+        Self(code)
+    }
+
+    /// Returns the underlying layout code.
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for LayoutId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::CONTIGUOUS => write!(f, "contiguous"),
+            Self::L0 => write!(f, "l0"),
+            Self::L1 => write!(f, "l1"),
+            Self::L1S => write!(f, "l1s"),
+            Self::ATTENTION_GFX1201 => write!(f, "attention_gfx1201"),
+            other => write!(f, "layout({})", other.0),
+        }
+    }
+}

--- a/crates/r9v-ir/src/lib.rs
+++ b/crates/r9v-ir/src/lib.rs
@@ -1,1 +1,33 @@
-//! R9V Op IR, graph, types, and sharding tables (Spec 1, Spec 14 §2).
+// SPDX-License-Identifier: Apache-2.0
+//! R9V Op IR core types (Spec 1 §2, App. A; card A1.1).
+//!
+//! This crate owns the API-bearing type surface the rest of the engine builds
+//! against: dtypes, quant-scheme tags, tensors, batch metadata, state
+//! handles, the arch descriptor and the IR version. Ops, graphs, sharding
+//! tables and the numerics contract are owned by card A1.2 (Spec 1 §3–§6).
+//!
+//! Repository standards: `CONVENTIONS.md`; engineering bar:
+//! `.agents/skills/r9v-engineering-standards`.
+
+pub mod arch;
+pub mod batch;
+pub mod dtype;
+pub mod error;
+pub mod layout;
+pub mod quant;
+pub mod state;
+pub mod tensor;
+pub mod version;
+
+pub use arch::{
+    ArchDescriptor, ArchFamily, GraphCapture, MatrixOp, Measured, P2pLink, P2pTransport, RelRate,
+    ValuDot,
+};
+pub use batch::{BatchMeta, BatchMetaBuilder, Positions, TreeMask, BLOCK_TABLE_SENTINEL};
+pub use dtype::DType;
+pub use error::IrError;
+pub use layout::LayoutId;
+pub use quant::{QuantScheme, SchemeId};
+pub use state::{StateHandle, StateKind};
+pub use tensor::{Class, Dim, Placement, ShapeSymbol, ShardLayout, Tensor};
+pub use version::IrVersion;

--- a/crates/r9v-ir/src/quant.rs
+++ b/crates/r9v-ir/src/quant.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Quantization schemes attached to tensors (Spec 1 §2.2).
+//!
+//! The scheme is attached to a tensor, not a dtype (Spec 1 §2.2). Block
+//! structure, scale records and dequant formulas live in spec 2 §3 and are
+//! owned by `r9v-format` (card A2.2); this crate only tags tensors.
+
+use std::fmt;
+
+use crate::DType;
+
+/// Opaque weight-scheme handle (Spec 1 §2.2 `Scheme { id }`, Spec 2 §3).
+///
+/// The code space is owned by spec 2 §3 / `r9v-format` (card A2.2), which maps
+/// its `SchemeId` enum to these codes. `r9v-ir` only transports the handle so
+/// the two crates cannot form a dependency cycle (card A1.1). Accepts any
+/// `u64`: future schemes (e.g. a new spec 2 id) must not fail to decode here.
+// DECISION(A1.1): opaque u64 newtype per CONVENTIONS.md §3.1, with codes
+// assigned by r9v-format (A2.2);
+// rejected an r9v-ir enum mirroring spec 2 §3.2–§3.3 ids because that would
+// give two crates ownership of one closed set and force a dependency cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SchemeId(u64);
+
+impl SchemeId {
+    /// Wraps a spec 2 scheme code (Spec 2 §3; code assignment owned by A2.2).
+    pub const fn new(code: u64) -> Self {
+        Self(code)
+    }
+
+    /// Returns the underlying spec 2 scheme code.
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SchemeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "scheme({})", self.0)
+    }
+}
+
+/// Quantization scheme attached to a tensor (Spec 1 §2.2).
+///
+/// Closed enum: adding a scheme is an RFC-level change (Spec 1 §7), and every
+/// `match` stays exhaustive with no wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QuantScheme {
+    /// Unquantized (Spec 1 §2.2).
+    None,
+    /// One scale per output row, weights (Spec 1 §2.2).
+    PerRow,
+    /// A spec 2 §3 scheme (`I8_B128`, `I4_K`, `I8_B32F`, ...); block structure
+    /// and scale records are defined there (Spec 1 §2.2).
+    Scheme(SchemeId),
+    /// Activations only; one scale per row of x, native path with smoothing
+    /// folded (Spec 1 §2.2).
+    PerToken,
+    /// Activations only; one scale per 32 along K, GGUF parity path
+    /// (Spec 1 §2.2, Spec 2 §3.4).
+    PerBlock32,
+}
+
+impl QuantScheme {
+    /// Scale-record dtype implied by the scheme, from the `{ scale }`
+    /// annotations in Spec 1 §2.2 (`PerRow` → f16, activation schemes → f32).
+    /// Returns `None` for [`QuantScheme::None`] (no scales) and
+    /// [`QuantScheme::Scheme`] (record format owned by Spec 2 §3 / A2.2).
+    ///
+    /// Scales themselves are data, not enum payloads: weight scale records
+    /// live in the spec 2 §3.1 region and activation scales travel as separate
+    /// tensors (e.g. `quant_act` emits `scale [T] f32`, Spec 1 §4.A).
+    // DECISION(A1.1): marker variants plus this accessor; rejected embedding
+    // live f16/f32 payloads because that would duplicate scale storage and
+    // need a half-float dependency for one annotation. Spec 1 §2.2 is silent
+    // on where a parsed scale value would live; see SI-4.
+    pub const fn scale_dtype(self) -> Option<DType> {
+        match self {
+            QuantScheme::None | QuantScheme::Scheme(_) => None,
+            QuantScheme::PerRow => Some(DType::F16),
+            QuantScheme::PerToken | QuantScheme::PerBlock32 => Some(DType::F32),
+        }
+    }
+}

--- a/crates/r9v-ir/src/state.rs
+++ b/crates/r9v-ir/src/state.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Per-sequence state handles (Spec 1 §2.6).
+//!
+//! Ops that read or write per-sequence state take a
+//! `StateHandle(layer, kind)` argument. The state manager (Spec 3, card A1.11)
+//! owns allocation, eviction, checkpoint and rollback; the IR only names the
+//! handle and declares read/write (Spec 1 §2.6). The parameterized
+//! `StateSpec` (dims, cache dtype, retention) is declared per layer by model
+//! definitions (Spec 3 §2, Spec 8) and owned by `r9v-state`, not here.
+
+/// State kind (Spec 1 §2.6).
+///
+/// Closed enum: the v1 kinds. A new kind lands via the RFC process
+/// (Spec 1 §7); every `match` stays exhaustive with no wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StateKind {
+    /// Paged KV cache (Spec 1 §2.6, Spec 3 §3).
+    KvPaged,
+    /// MLA compressed latent + rope part (Spec 1 §2.6, Spec 3 §3).
+    KvLatent,
+    /// Fixed-size per-head recurrent state (Spec 1 §2.6, Spec 3 §4).
+    Recurrent,
+    /// Convolution window state (Spec 1 §2.6, Spec 3 §4).
+    ConvWindow,
+}
+
+/// Opaque handle naming one layer's state (Spec 1 §2.6).
+///
+/// Handles are opaque: only the owning crate (`r9v-state`, Spec 3) interprets
+/// them; graph code names them (r9v-card-work §6). Fields stay private so a
+/// handle cannot be forged or destructured outside this API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StateHandle {
+    layer: u32,
+    kind: StateKind,
+}
+
+impl StateHandle {
+    /// Names the state of `layer` of the given kind (Spec 1 §2.6:
+    /// `StateHandle(layer, kind)`).
+    pub const fn new(layer: u32, kind: StateKind) -> Self {
+        Self { layer, kind }
+    }
+
+    /// Layer index this handle names.
+    pub const fn layer(self) -> u32 {
+        self.layer
+    }
+
+    /// State kind this handle names.
+    pub const fn kind(self) -> StateKind {
+        self.kind
+    }
+}

--- a/crates/r9v-ir/src/tensor.rs
+++ b/crates/r9v-ir/src/tensor.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tensors and their structural metadata (Spec 1 §2.3–§2.4, §5.1).
+//!
+//! [`Tensor::new`] enforces the structural rules spec 1 states once, at
+//! construction, so the type carries the guarantee afterwards (engineering
+//! standards §2.1): bounded non-empty shapes, legal quantization and layout
+//! combinations, and `Host`/`Tiered` placement only on `Weight` class.
+
+use std::fmt;
+
+use crate::{IrError, LayoutId, QuantScheme};
+
+/// Symbolic shape vocabulary (Spec 1 §2.4, plus weight dims).
+///
+/// `T` tokens in the batch, `S` sequences, `Dm` model dim, `Dff` FFN dim, `H`
+/// query heads, `Hkv` KV heads, `D` head dim, `E` experts, `K` top-k, `V`
+/// vocab, `Np` n-gram hash heads, and `L` layers (Spec 1 §2.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShapeSymbol {
+    /// `T`: tokens in the batch, sum of query lengths (Spec 1 §2.4).
+    T,
+    /// `S`: sequences (Spec 1 §2.4).
+    S,
+    /// `Dm`: model dim (Spec 1 §2.4).
+    Dm,
+    /// `Dff`: FFN dim (Spec 1 §2.4).
+    Dff,
+    /// `H`: query heads (Spec 1 §2.4).
+    H,
+    /// `Hkv`: KV heads (Spec 1 §2.4).
+    Hkv,
+    /// `D`: head dim (Spec 1 §2.4).
+    D,
+    /// `E`: experts (Spec 1 §2.4).
+    E,
+    /// `K`: top-k (Spec 1 §2.4).
+    K,
+    /// `V`: vocab (Spec 1 §2.4).
+    V,
+    /// `Np`: n-gram hash heads (Spec 1 §2.4).
+    Np,
+    /// `L`: layers (Spec 1 §2.4).
+    L,
+}
+
+/// One tensor dimension: concrete after capture, symbolic before.
+///
+/// Kernels see concrete integers per bucket (Spec 1 §2.4); model definitions
+/// build graphs over the symbolic form (Spec 8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Dim {
+    /// Resolved extent (Spec 1 §2.4: what kernels see per bucket).
+    Concrete(u32),
+    /// Unresolved shape symbol (Spec 1 §2.4).
+    Symbolic(ShapeSymbol),
+}
+
+/// Tensor placement (Spec 1 §2.3).
+///
+/// Placement is resolved at load time by the planner, never baked into model
+/// artifacts (D-001). A quant tool's `tiered` hint (Spec 2 §4) is resolved
+/// into per-unit placements at load (Spec 5 §3.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Placement {
+    /// Device memory on the given rank (Spec 1 §2.3).
+    Device {
+        /// Rank owning the memory.
+        rank: u32,
+    },
+    /// Pinned host memory: host-computed or host-gathered (Spec 1 §2.3).
+    /// Legal only for `Weight` class tensors (Spec 1 §2.3).
+    Host,
+    /// Slab-backed, fetched by unit (Spec 9 §6). Legal only for `Weight`
+    /// class tensors (Spec 1 §2.3).
+    Tiered,
+}
+
+impl fmt::Display for Placement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Placement::Device { rank } => write!(f, "device({rank})"),
+            Placement::Host => write!(f, "host"),
+            Placement::Tiered => write!(f, "tiered"),
+        }
+    }
+}
+
+/// Sharding assignment of a tensor (Spec 1 §5.1).
+///
+/// Each op's legal-layouts table lists legal `(inputs) → output` tuples over
+/// these values (Spec 1 §5.2); the partitioner only ever applies that table
+/// (Spec 1 §1 principle 4). `Partial` must be resolved by `all_reduce` before
+/// any op that requires `Replicated` (Spec 1 §5.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShardLayout {
+    /// Whole tensor on every rank (Spec 1 §5.1).
+    Replicated,
+    /// Split along output features, Megatron column-parallel (Spec 1 §5.1).
+    ColShard {
+        /// Sharded axis.
+        axis: u32,
+    },
+    /// Split along input features, row-parallel; consumer output is `Partial`
+    /// (Spec 1 §5.1).
+    RowShard {
+        /// Sharded axis.
+        axis: u32,
+    },
+    /// Attention heads split; KV heads and state split identically
+    /// (Spec 1 §5.1).
+    HeadShard {
+        /// Head count `H`.
+        heads: u32,
+    },
+    /// Experts distributed across ranks (Spec 1 §5.1).
+    ExpertShard {
+        /// Expert count `E`.
+        experts: u32,
+    },
+    /// Sum across ranks pending; must be resolved by `all_reduce` before any
+    /// op that requires `Replicated` (Spec 1 §5.1–§5.2).
+    Partial,
+}
+
+/// Tensor class (Spec 1 §2.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Class {
+    /// Model weights (Spec 1 §2.3).
+    Weight,
+    /// Per-step activations (Spec 1 §2.3).
+    Activation,
+    /// Sequence state, named via `StateHandle` (Spec 1 §2.3, §2.6).
+    State,
+    /// Temporary staging, e.g. `gather_staging` (Spec 1 §2.3, §3.2).
+    Staging,
+    /// Compile-time parameters, e.g. `moe_route` bias (Spec 1 §2.3, §4.C).
+    Param,
+}
+
+impl fmt::Display for Class {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Class::Weight => "weight",
+            Class::Activation => "activation",
+            Class::State => "state",
+            Class::Staging => "staging",
+            Class::Param => "param",
+        };
+        write!(f, "{name}")
+    }
+}
+
+/// An IR tensor: shape, dtype, scheme, layout, placement, sharding, class
+/// (Spec 1 §2.3).
+///
+/// Fields are private: use [`Tensor::new`], which enforces the structural
+/// rules, then read through the accessors. Reshapes and transposes are
+/// metadata on the edge, not ops (Spec 1 §2.3); that edge metadata is owned
+/// by card A1.2, not by this type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Tensor {
+    shape: Vec<Dim>,
+    dtype: crate::DType,
+    quant: QuantScheme,
+    layout: LayoutId,
+    placement: Placement,
+    sharding: ShardLayout,
+    class: Class,
+}
+
+impl Tensor {
+    /// Builds a tensor, enforcing the spec 1 §2.3 structural rules:
+    /// rank `1..=4`, nonzero concrete extents, class-appropriate quantization
+    /// and layouts, and `Host`/`Tiered` only on `Weight` class. Every failure
+    /// is reported, not just the first (CONVENTIONS.md §1.4).
+    // DECISION(A1.1): rank 0 rejected (every §4 signature has rank ≥ 1) and
+    // zero concrete extents rejected; spec 1 §2.3 states only the ≤4 bound.
+    // Rejected: accepting scalars/empty dims for later ops to trip over.
+    pub fn new(
+        shape: Vec<Dim>,
+        dtype: crate::DType,
+        quant: QuantScheme,
+        layout: LayoutId,
+        placement: Placement,
+        sharding: ShardLayout,
+        class: Class,
+    ) -> Result<Self, IrError> {
+        let mut problems = Vec::new();
+        if shape.is_empty() || shape.len() > 4 {
+            problems.push(IrError::InvalidRank { got: shape.len() });
+        }
+        for (axis, dim) in shape.iter().enumerate() {
+            if matches!(dim, Dim::Concrete(0)) {
+                problems.push(IrError::ZeroExtent { axis });
+            }
+        }
+        match (placement, class) {
+            // DECISION(A1.1): enforce the class-level placement rule here and
+            // defer semantic weight-role legality to loader/planner binding,
+            // where those roles exist; rejected adding an unspecified Tensor
+            // field solely for constructor validation. See SI-5.
+            (Placement::Host | Placement::Tiered, Class::Weight) => {}
+            (Placement::Host | Placement::Tiered, _) => {
+                problems.push(IrError::PlacementForClass { placement, class });
+            }
+            (Placement::Device { .. }, _) => {}
+        }
+        match (quant, class) {
+            (QuantScheme::None, _) => {}
+            // DECISION(A1.1): weight-side quantization also applies to
+            // Staging because ngram_gather consumes quantized i4/i8 table
+            // rows through gather_staging; rejected making that closed op
+            // unrepresentable. See SI-6 and Spec 1 §4.A.
+            (QuantScheme::PerRow | QuantScheme::Scheme(_), Class::Weight | Class::Staging) => {}
+            (QuantScheme::PerToken | QuantScheme::PerBlock32, Class::Activation) => {}
+            _ => problems.push(IrError::QuantForClass { quant, class }),
+        }
+        let invalid_layout = (class == Class::Activation && layout != LayoutId::CONTIGUOUS)
+            || (matches!(layout, LayoutId::L1 | LayoutId::L1S) && class != Class::Weight);
+        if invalid_layout {
+            problems.push(IrError::LayoutForClass { layout, class });
+        }
+        if dtype == crate::DType::I4 && !matches!(class, Class::Weight | Class::Staging) {
+            problems.push(IrError::DTypeForClass { dtype, class });
+        }
+        let invalid_quant_dtype = match quant {
+            QuantScheme::PerToken => !matches!(dtype, crate::DType::I8 | crate::DType::E4m3),
+            QuantScheme::PerBlock32 => dtype != crate::DType::I8,
+            QuantScheme::PerRow | QuantScheme::Scheme(_) => matches!(
+                dtype,
+                crate::DType::F32
+                    | crate::DType::Bf16
+                    | crate::DType::E5m2
+                    | crate::DType::I32
+                    | crate::DType::U32
+                    | crate::DType::Bool
+            ),
+            QuantScheme::None => dtype == crate::DType::I4,
+        };
+        if invalid_quant_dtype {
+            problems.push(IrError::QuantDType { quant, dtype });
+        }
+        if problems.is_empty() {
+            Ok(Self {
+                shape,
+                dtype,
+                quant,
+                layout,
+                placement,
+                sharding,
+                class,
+            })
+        } else if problems.len() == 1 {
+            Err(problems
+                // Internal invariant: this branch runs only when len == 1.
+                .pop()
+                .expect("problems holds exactly one entry"))
+        } else {
+            Err(IrError::Multiple {
+                problems: problems.into_boxed_slice(),
+            })
+        }
+    }
+
+    /// Shape dims, symbolic or concrete (Spec 1 §2.3–§2.4).
+    pub fn shape(&self) -> &[Dim] {
+        &self.shape
+    }
+
+    /// Element dtype (Spec 1 §2.1).
+    pub fn dtype(&self) -> crate::DType {
+        self.dtype
+    }
+
+    /// Quantization scheme (Spec 1 §2.2).
+    pub fn quant(&self) -> QuantScheme {
+        self.quant
+    }
+
+    /// Logical layout version (Spec 2 §2; activations use `Contiguous`).
+    pub fn layout(&self) -> LayoutId {
+        self.layout
+    }
+
+    /// Where the tensor lives (Spec 1 §2.3).
+    pub fn placement(&self) -> Placement {
+        self.placement
+    }
+
+    /// Sharding assignment (Spec 1 §5.1).
+    pub fn sharding(&self) -> ShardLayout {
+        self.sharding
+    }
+
+    /// Tensor class (Spec 1 §2.3).
+    pub fn class(&self) -> Class {
+        self.class
+    }
+
+    /// Rank (number of shape dims), always `1..=4` by construction.
+    pub fn rank(&self) -> usize {
+        self.shape.len()
+    }
+}

--- a/crates/r9v-ir/src/version.rs
+++ b/crates/r9v-ir/src/version.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//! IR version (Spec 1 §7).
+
+use std::fmt;
+
+/// IR version pinned by model definitions.
+///
+/// Removing or changing an op's signature bumps the minor version, and model
+/// definitions pin the IR version they were written against (Spec 1 §7); a
+/// `ModelSpec` whose pin mismatches is an error naming both versions
+/// (Spec 8 §4, owned by card A1.3, which also owns the compatibility rule —
+/// this type provides identity and ordering only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct IrVersion {
+    /// Major version.
+    pub major: u16,
+    /// Minor version; bumped on op signature change (Spec 1 §7).
+    pub minor: u16,
+    /// Patch version.
+    pub patch: u16,
+}
+
+impl IrVersion {
+    /// Current IR version.
+    // DECISION(A1.1): 0.1.0, tracking the spec's draft 0.1; rejected 1.0.0
+    // (nothing is frozen pre-A6.7a interface freeze).
+    pub const CURRENT: Self = Self {
+        major: 0,
+        minor: 1,
+        patch: 0,
+    };
+
+    /// Builds a version triple.
+    pub const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl fmt::Display for IrVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}

--- a/crates/r9v-ir/tests/api_shape.rs
+++ b/crates/r9v-ir/tests/api_shape.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+//! API-shape tests for r9v-ir (Spec 1 §2, App. A; r9v-card-work §6).
+//!
+//! Asserts compilation, visibility boundaries and the `Send`/`Sync` markers
+//! downstream crates rely on. Closed-set enums are additionally matched
+//! exhaustively (no wildcard) so an RFC-added variant breaks this test until
+//! the new surface is handled deliberately.
+
+use std::hash::Hash;
+
+use r9v_ir::{
+    ArchDescriptor, ArchFamily, BatchMeta, BatchMetaBuilder, Class, DType, Dim, GraphCapture,
+    IrError, IrVersion, LayoutId, MatrixOp, Measured, P2pLink, P2pTransport, Placement, Positions,
+    QuantScheme, RelRate, SchemeId, ShapeSymbol, ShardLayout, StateHandle, StateKind, Tensor,
+    TreeMask, ValuDot, BLOCK_TABLE_SENTINEL,
+};
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+fn assert_copy<T: Copy>() {}
+fn assert_clone<T: Clone>() {}
+fn assert_debug<T: std::fmt::Debug>() {}
+fn assert_display<T: std::fmt::Display>() {}
+fn assert_hash<T: Hash>() {}
+fn assert_error<T: std::error::Error>() {}
+fn assert_ord<T: Ord>() {}
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn api_shape_markers_and_errors() {
+    assert_send::<DType>();
+    assert_sync::<DType>();
+    assert_copy::<DType>();
+    assert_hash::<DType>();
+    assert_display::<DType>();
+
+    assert_send::<SchemeId>();
+    assert_sync::<SchemeId>();
+    assert_copy::<SchemeId>();
+    assert_hash::<SchemeId>();
+    assert_display::<SchemeId>();
+
+    assert_send::<QuantScheme>();
+    assert_sync::<QuantScheme>();
+    assert_copy::<QuantScheme>();
+    assert_hash::<QuantScheme>();
+
+    assert_send::<LayoutId>();
+    assert_sync::<LayoutId>();
+    assert_copy::<LayoutId>();
+    assert_hash::<LayoutId>();
+    assert_display::<LayoutId>();
+
+    assert_send::<Tensor>();
+    assert_sync::<Tensor>();
+    assert_clone::<Tensor>();
+    assert_debug::<Tensor>();
+
+    assert_send::<BatchMeta>();
+    assert_sync::<BatchMeta>();
+    assert_clone::<BatchMeta>();
+
+    assert_send::<TreeMask>();
+    assert_sync::<TreeMask>();
+    assert_clone::<TreeMask>();
+
+    assert_send::<StateHandle>();
+    assert_sync::<StateHandle>();
+    assert_copy::<StateHandle>();
+    assert_hash::<StateHandle>();
+
+    assert_send::<ArchDescriptor>();
+    assert_sync::<ArchDescriptor>();
+    assert_clone::<ArchDescriptor>();
+
+    assert_send::<IrVersion>();
+    assert_sync::<IrVersion>();
+    assert_copy::<IrVersion>();
+    assert_hash::<IrVersion>();
+    assert_display::<IrVersion>();
+    assert_ord::<IrVersion>();
+
+    assert_send::<IrError>();
+    assert_sync::<IrError>();
+    assert_clone::<IrError>();
+    assert_error::<IrError>();
+
+    assert_send::<BatchMetaBuilder>();
+    assert_sync::<BatchMetaBuilder>();
+
+    assert_send_sync::<ShapeSymbol>();
+    assert_send_sync::<Dim>();
+    assert_send_sync::<Placement>();
+    assert_send_sync::<ShardLayout>();
+    assert_send_sync::<Class>();
+    assert_send_sync::<Positions>();
+    assert_send_sync::<StateKind>();
+    assert_send_sync::<ArchFamily>();
+    assert_send_sync::<RelRate>();
+    assert_send_sync::<MatrixOp>();
+    assert_send_sync::<ValuDot>();
+    assert_send_sync::<GraphCapture>();
+    assert_send_sync::<P2pTransport>();
+    assert_send_sync::<P2pLink>();
+    assert_send_sync::<Measured>();
+
+    let _ = BLOCK_TABLE_SENTINEL;
+}
+
+#[test]
+fn api_shape_closed_sets_match_exhaustively() {
+    // No wildcard arms: adding a variant fails this test until handled.
+    let dtype = DType::F32;
+    let _ = match dtype {
+        DType::F32 => "f32",
+        DType::F16 => "f16",
+        DType::Bf16 => "bf16",
+        DType::E4m3 => "e4m3",
+        DType::E5m2 => "e5m2",
+        DType::I8 => "i8",
+        DType::I4 => "i4",
+        DType::I32 => "i32",
+        DType::U32 => "u32",
+        DType::Bool => "bool",
+    };
+
+    let scheme = QuantScheme::None;
+    let _ = match scheme {
+        QuantScheme::None => 0,
+        QuantScheme::PerRow => 1,
+        QuantScheme::Scheme(_) => 2,
+        QuantScheme::PerToken => 3,
+        QuantScheme::PerBlock32 => 4,
+    };
+
+    let class = Class::Weight;
+    let _ = match class {
+        Class::Weight => 0,
+        Class::Activation => 1,
+        Class::State => 2,
+        Class::Staging => 3,
+        Class::Param => 4,
+    };
+
+    let sharding = ShardLayout::Replicated;
+    let _ = match sharding {
+        ShardLayout::Replicated => 0,
+        ShardLayout::ColShard { .. } => 1,
+        ShardLayout::RowShard { .. } => 2,
+        ShardLayout::HeadShard { .. } => 3,
+        ShardLayout::ExpertShard { .. } => 4,
+        ShardLayout::Partial => 5,
+    };
+
+    let placement = Placement::Host;
+    let _ = match placement {
+        Placement::Device { .. } => 0,
+        Placement::Host => 1,
+        Placement::Tiered => 2,
+    };
+
+    let kind = StateKind::KvPaged;
+    let _ = match kind {
+        StateKind::KvPaged => 0,
+        StateKind::KvLatent => 1,
+        StateKind::Recurrent => 2,
+        StateKind::ConvWindow => 3,
+    };
+
+    let family = ArchFamily::Rdna4;
+    let _ = match family {
+        ArchFamily::Rdna4 => 0,
+        ArchFamily::Rdna3 => 1,
+        ArchFamily::Cdna3 => 2,
+        ArchFamily::Reference => 3,
+        ArchFamily::Cpu => 4,
+    };
+
+    let dot = ValuDot::Dot4I32I8;
+    let _ = match dot {
+        ValuDot::Dot4I32I8 => 0,
+        ValuDot::Dot2F32F16 => 1,
+        ValuDot::Dot2F32Bf16 => 2,
+    };
+
+    let capture = GraphCapture::Supported;
+    let _ = match capture {
+        GraphCapture::Supported => 0,
+        GraphCapture::Unstable => 1,
+        GraphCapture::None => 2,
+    };
+
+    let transport = P2pTransport::Direct;
+    let _ = match transport {
+        P2pTransport::Direct => 0,
+        P2pTransport::HostStaged => 1,
+    };
+
+    let dim = Dim::Concrete(1);
+    let _ = match dim {
+        Dim::Concrete(_) => 0,
+        Dim::Symbolic(_) => 1,
+    };
+
+    let symbol = ShapeSymbol::T;
+    let _ = match symbol {
+        ShapeSymbol::T => 0,
+        ShapeSymbol::S => 1,
+        ShapeSymbol::Dm => 2,
+        ShapeSymbol::Dff => 3,
+        ShapeSymbol::H => 4,
+        ShapeSymbol::Hkv => 5,
+        ShapeSymbol::D => 6,
+        ShapeSymbol::E => 7,
+        ShapeSymbol::K => 8,
+        ShapeSymbol::V => 9,
+        ShapeSymbol::Np => 10,
+        ShapeSymbol::L => 11,
+    };
+
+    let pos = Positions::PerToken(vec![]);
+    let _ = match pos {
+        Positions::PerToken(_) => 0,
+        Positions::Mrope(_) => 1,
+    };
+}
+
+#[test]
+fn api_shape_constructors_are_reachable() {
+    let scheme = SchemeId::new(7);
+    assert_eq!(scheme.as_u64(), 7);
+
+    let layout = LayoutId::new(9);
+    assert_eq!(layout.as_u64(), 9);
+    assert_eq!(LayoutId::L1, LayoutId::new(2));
+
+    let handle = StateHandle::new(3, StateKind::KvLatent);
+    assert_eq!(handle.layer(), 3);
+    assert_eq!(handle.kind(), StateKind::KvLatent);
+
+    let tensor = Tensor::new(
+        vec![Dim::Concrete(4), Dim::Symbolic(ShapeSymbol::Dm)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect("valid tensor builds");
+    assert_eq!(tensor.rank(), 2);
+
+    let rate = RelRate::new(2.0).expect("positive rate builds");
+    assert_eq!(rate.as_f32(), 2.0);
+
+    let op = MatrixOp::new([16, 16, 16], DType::I8, DType::I8, DType::I32, rate)
+        .expect("valid matrix op builds");
+    assert_eq!(op.shape, [16, 16, 16]);
+
+    let measured = Measured::empty();
+    assert!(measured.is_empty());
+
+    let link = P2pLink {
+        peer_rank: 1,
+        transport: P2pTransport::HostStaged,
+        measured_gbps: None,
+    };
+    assert_eq!(link.peer_rank, 1);
+
+    let gfx = ArchDescriptor::gfx1201();
+    assert_eq!(gfx.name, "gfx1201");
+    let cpu = ArchDescriptor::cpu();
+    assert_eq!(cpu.family, ArchFamily::Cpu);
+
+    assert_eq!(IrVersion::CURRENT, IrVersion::new(0, 1, 0));
+    assert_eq!(IrVersion::CURRENT.to_string(), "0.1.0");
+}

--- a/crates/r9v-ir/tests/invariants.rs
+++ b/crates/r9v-ir/tests/invariants.rs
@@ -1,0 +1,778 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Behavioral constructor and invariant tests for r9v-ir (card A1.1).
+//!
+//! Each test names the behavior it proves. Random inputs come from
+//! `r9v_common::SeededRng` with fixed seeds (CONVENTIONS.md §4.3): no
+//! wall-clock, no environment, deterministic across runs.
+
+use r9v_common::SeededRng;
+use r9v_ir::{
+    ArchDescriptor, ArchFamily, BatchMeta, Class, DType, Dim, GraphCapture, IrError, IrVersion,
+    LayoutId, Placement, Positions, QuantScheme, RelRate, SchemeId, ShapeSymbol, ShardLayout,
+    StateHandle, StateKind, Tensor, TreeMask, ValuDot, BLOCK_TABLE_SENTINEL,
+};
+
+fn weight_tensor() -> Tensor {
+    Tensor::new(
+        vec![Dim::Concrete(64), Dim::Concrete(64)],
+        DType::I8,
+        QuantScheme::Scheme(SchemeId::new(11)),
+        LayoutId::L1,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .expect("valid weight tensor builds")
+}
+
+type BatchParts = (Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>);
+
+fn batch_parts(g: usize, s: usize, t: usize, max_blocks: usize) -> BatchParts {
+    assert!(
+        t >= s,
+        "each of S sequences must contribute at least one token"
+    );
+    let mut query_len = vec![1; s];
+    query_len[0] += (t - s) as u32;
+    (
+        (0..s as u32).collect(),
+        query_len,
+        vec![0; s],
+        (0..(g * t) as u32).collect(),
+        vec![BLOCK_TABLE_SENTINEL; g * s * max_blocks],
+        vec![0; g * s],
+    )
+}
+
+fn valid_batch(g: u32, s: u32, t: u32, max_blocks: u32) -> BatchMeta {
+    let (seq, q, c, slots, blocks, win) =
+        batch_parts(g as usize, s as usize, t as usize, max_blocks as usize);
+    BatchMeta::builder(g, s, t, max_blocks)
+        .seq_ids(seq)
+        .query_len(q)
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0; t as usize]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .build()
+        .expect("valid batch builds")
+}
+
+#[test]
+fn tensor_rank_0_rejected() {
+    let err = Tensor::new(
+        vec![],
+        DType::F32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("rank 0 must be rejected");
+    assert_eq!(err, IrError::InvalidRank { got: 0 });
+}
+
+#[test]
+fn tensor_rank_5_rejected() {
+    let err = Tensor::new(
+        vec![Dim::Concrete(1); 5],
+        DType::F32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("rank 5 must be rejected");
+    assert_eq!(err, IrError::InvalidRank { got: 5 });
+}
+
+#[test]
+fn tensor_zero_extent_rejected() {
+    let err = Tensor::new(
+        vec![Dim::Concrete(8), Dim::Concrete(0)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("zero extent must be rejected");
+    assert_eq!(err, IrError::ZeroExtent { axis: 1 });
+}
+
+#[test]
+fn tensor_host_placement_requires_weight_class() {
+    for class in [
+        Class::Activation,
+        Class::State,
+        Class::Staging,
+        Class::Param,
+    ] {
+        let err = Tensor::new(
+            vec![Dim::Concrete(4)],
+            DType::F16,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            Placement::Host,
+            ShardLayout::Replicated,
+            class,
+        )
+        .expect_err("Host on non-Weight must be rejected");
+        assert_eq!(
+            err,
+            IrError::PlacementForClass {
+                placement: Placement::Host,
+                class,
+            }
+        );
+    }
+    let w = Tensor::new(
+        vec![Dim::Concrete(4)],
+        DType::I8,
+        QuantScheme::PerRow,
+        LayoutId::L0,
+        Placement::Tiered,
+        ShardLayout::Replicated,
+        Class::Weight,
+    );
+    assert!(w.is_ok(), "Tiered Weight must build");
+}
+
+#[test]
+fn tensor_reports_every_problem_at_once() {
+    // Rank 6 AND zero extent AND Host-on-Activation: one error, all problems.
+    let err = Tensor::new(
+        vec![Dim::Concrete(0); 6],
+        DType::F32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Host,
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("must be rejected");
+    match err {
+        IrError::Multiple { problems } => {
+            assert!(problems.contains(&IrError::InvalidRank { got: 6 }));
+            for axis in 0..6 {
+                assert!(problems.contains(&IrError::ZeroExtent { axis }));
+            }
+            assert!(problems.contains(&IrError::PlacementForClass {
+                placement: Placement::Host,
+                class: Class::Activation,
+            }));
+            assert_eq!(problems.len(), 8);
+        }
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+}
+
+#[test]
+fn tensor_quantization_class_rules_are_enforced() {
+    let activation = Tensor::new(
+        vec![Dim::Concrete(8)],
+        DType::I8,
+        QuantScheme::PerRow,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("PerRow is weights-only");
+    assert_eq!(
+        activation,
+        IrError::QuantForClass {
+            quant: QuantScheme::PerRow,
+            class: Class::Activation,
+        }
+    );
+
+    let weight = Tensor::new(
+        vec![Dim::Concrete(8)],
+        DType::I8,
+        QuantScheme::PerToken,
+        LayoutId::L1,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .expect_err("PerToken is activations-only");
+    assert_eq!(
+        weight,
+        IrError::QuantForClass {
+            quant: QuantScheme::PerToken,
+            class: Class::Weight,
+        }
+    );
+}
+
+#[test]
+fn tensor_quantized_staging_represents_ngram_rows() {
+    let staging = Tensor::new(
+        vec![
+            Dim::Symbolic(ShapeSymbol::T),
+            Dim::Symbolic(ShapeSymbol::Np),
+            Dim::Concrete(64),
+        ],
+        DType::I4,
+        QuantScheme::Scheme(SchemeId::new(11)),
+        LayoutId::L0,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Staging,
+    )
+    .expect("Spec 1 §4.A quantized gather_staging must be representable");
+    assert_eq!(staging.class(), Class::Staging);
+    assert_eq!(staging.dtype(), DType::I4);
+}
+
+#[test]
+fn tensor_activation_layout_and_quantized_dtype_are_enforced() {
+    let layout = Tensor::new(
+        vec![Dim::Concrete(8)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::L1,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("activations are contiguous");
+    assert_eq!(
+        layout,
+        IrError::LayoutForClass {
+            layout: LayoutId::L1,
+            class: Class::Activation,
+        }
+    );
+
+    let dtype = Tensor::new(
+        vec![Dim::Concrete(8)],
+        DType::F16,
+        QuantScheme::PerToken,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect_err("PerToken stores i8 or e4m3 values");
+    assert_eq!(
+        dtype,
+        IrError::QuantDType {
+            quant: QuantScheme::PerToken,
+            dtype: DType::F16,
+        }
+    );
+}
+
+#[test]
+fn tensor_valid_construction_exposes_fields() {
+    let t = weight_tensor();
+    assert_eq!(t.rank(), 2);
+    assert_eq!(t.dtype(), DType::I8);
+    assert_eq!(t.quant(), QuantScheme::Scheme(SchemeId::new(11)));
+    assert_eq!(t.layout(), LayoutId::L1);
+    assert_eq!(t.placement(), Placement::Device { rank: 0 });
+    assert_eq!(t.sharding(), ShardLayout::Replicated);
+    assert_eq!(t.class(), Class::Weight);
+}
+
+#[test]
+fn quant_scheme_scale_dtypes_follow_spec() {
+    assert_eq!(QuantScheme::None.scale_dtype(), None);
+    assert_eq!(QuantScheme::PerRow.scale_dtype(), Some(DType::F16));
+    assert_eq!(QuantScheme::PerToken.scale_dtype(), Some(DType::F32));
+    assert_eq!(QuantScheme::PerBlock32.scale_dtype(), Some(DType::F32));
+    assert_eq!(QuantScheme::Scheme(SchemeId::new(0)).scale_dtype(), None);
+}
+
+#[test]
+fn batch_zero_dims_rejected_with_numbers() {
+    let err = BatchMeta::builder(0, 2, 4, 8)
+        .seq_ids(vec![0, 1])
+        .query_len(vec![1, 1])
+        .ctx_len(vec![0, 0])
+        .positions(Positions::PerToken(vec![0; 4]))
+        .slot_map(vec![])
+        .block_table(vec![BLOCK_TABLE_SENTINEL; 0])
+        .window_start(vec![])
+        .build()
+        .expect_err("G=0 must be rejected");
+    // Length errors for the zero-sized fields accompany the dim error.
+    match err {
+        IrError::Multiple { problems } => {
+            assert!(problems.contains(&IrError::ZeroBatchDim {
+                g: 0,
+                s: 2,
+                t: 4,
+                max_blocks: 8,
+            }));
+        }
+        IrError::ZeroBatchDim {
+            g: 0,
+            s: 2,
+            t: 4,
+            max_blocks: 8,
+        } => {}
+        other => panic!("expected dim error, got {other:?}"),
+    }
+}
+
+#[test]
+fn batch_builder_missing_fields_reports_all() {
+    let err = BatchMeta::builder(1, 1, 1, 1)
+        .build()
+        .expect_err("empty builder must be rejected");
+    match err {
+        IrError::Multiple { problems } => {
+            for field in [
+                "seq_ids",
+                "query_len",
+                "ctx_len",
+                "positions",
+                "slot_map",
+                "block_table",
+                "window_start",
+            ] {
+                assert!(
+                    problems.contains(&IrError::MissingField { field }),
+                    "missing {field} not reported: {problems:?}",
+                );
+            }
+        }
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+}
+
+#[test]
+fn batch_length_mismatch_reports_every_field() {
+    let err = BatchMeta::builder(2, 3, 4, 5)
+        .seq_ids(vec![0])
+        .query_len(vec![1])
+        .ctx_len(vec![0])
+        .positions(Positions::PerToken(vec![0]))
+        .slot_map(vec![0])
+        .block_table(vec![0])
+        .window_start(vec![0])
+        .build()
+        .expect_err("short fields must be rejected");
+    match err {
+        IrError::Multiple { problems } => {
+            assert!(problems.contains(&IrError::BatchLength {
+                field: "seq_ids",
+                expected: 3,
+                actual: 1,
+            }));
+            assert!(problems.contains(&IrError::BatchLength {
+                field: "slot_map",
+                expected: 8,
+                actual: 1,
+            }));
+            assert!(problems.contains(&IrError::BatchLength {
+                field: "block_table",
+                expected: 30,
+                actual: 1,
+            }));
+            assert!(problems.contains(&IrError::BatchLength {
+                field: "window_start",
+                expected: 6,
+                actual: 1,
+            }));
+            assert!(problems.contains(&IrError::BatchLength {
+                field: "positions",
+                expected: 4,
+                actual: 1,
+            }));
+        }
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+}
+
+#[test]
+fn batch_query_lengths_must_sum_to_t() {
+    let (seq, _, c, slots, blocks, win) = batch_parts(1, 2, 3, 1);
+    let err = BatchMeta::builder(1, 2, 3, 1)
+        .seq_ids(seq)
+        .query_len(vec![1, 1])
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0; 3]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .build()
+        .expect_err("query lengths totaling 2 cannot describe T=3");
+    assert_eq!(
+        err,
+        IrError::QueryTokenCount {
+            expected: 3,
+            actual: 2,
+        }
+    );
+}
+
+#[test]
+fn batch_empty_query_len_rejected() {
+    let (seq, _, c, slots, blocks, win) = batch_parts(1, 2, 2, 1);
+    let err = BatchMeta::builder(1, 2, 2, 1)
+        .seq_ids(seq)
+        .query_len(vec![1, 0])
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0, 1]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .build()
+        .expect_err("query_len 0 must be rejected");
+    assert_eq!(
+        err,
+        IrError::Multiple {
+            problems: vec![
+                IrError::EmptyQuery { seq: 1 },
+                IrError::QueryTokenCount {
+                    expected: 2,
+                    actual: 1,
+                },
+            ]
+            .into_boxed_slice(),
+        }
+    );
+}
+
+#[test]
+fn batch_mrope_positions_accepted_at_t() {
+    let (seq, q, c, slots, blocks, win) = batch_parts(1, 2, 3, 2);
+    let b = BatchMeta::builder(1, 2, 3, 2)
+        .seq_ids(seq)
+        .query_len(q)
+        .ctx_len(c)
+        .positions(Positions::Mrope(vec![[0, 1, 2]; 3]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .build()
+        .expect("mrope positions at T must build");
+    assert_eq!(b.positions().len(), 3);
+}
+
+#[test]
+fn batch_index_helpers_read_row_major() {
+    // G=2, S=2, T=3, max_blocks=2. slot(g,t)=100g+10t... distinct per cell.
+    let g = 2u32;
+    let s = 2u32;
+    let t = 3u32;
+    let mb = 2u32;
+    let slot_map: Vec<u32> = (0..g)
+        .flat_map(|gg| (0..t).map(move |tt| gg * 100 + tt))
+        .collect();
+    let block_table: Vec<u32> = (0..g * s * mb).map(|i| 1000 + i).collect();
+    let window_start: Vec<u32> = (0..g * s).map(|i| 50 + i).collect();
+    let (seq, q, c, _, _, _) = batch_parts(g as usize, s as usize, t as usize, mb as usize);
+    let b = BatchMeta::builder(g, s, t, mb)
+        .seq_ids(seq)
+        .query_len(q)
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0; t as usize]))
+        .slot_map(slot_map)
+        .block_table(block_table)
+        .window_start(window_start)
+        .build()
+        .expect("valid batch builds");
+    assert_eq!(b.slot(1, 2), 102);
+    assert_eq!(b.slot(0, 0), 0);
+    // block(1,0,1): ((1*2+0)*2+1) = 5 -> 1005.
+    assert_eq!(b.block(1, 0, 1), 1005);
+    // window(1,1): 1*2+1 = 3 -> 53.
+    assert_eq!(b.window(1, 1), 53);
+}
+
+#[test]
+fn batch_tree_t_mismatch_rejected() {
+    let tree = TreeMask::new(vec![-1, 0], 3, vec![true; 6]).expect("tree builds");
+    let (seq, q, c, slots, blocks, win) = batch_parts(1, 1, 3, 1);
+    let err = BatchMeta::builder(1, 1, 3, 1)
+        .seq_ids(seq)
+        .query_len(q)
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0; 3]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .tree(Some(tree))
+        .build()
+        .expect_err("tree T=2 on batch T=3 must be rejected");
+    assert_eq!(
+        err,
+        IrError::TreeBatchMismatch {
+            tree_t: 2,
+            batch_t: 3,
+        }
+    );
+}
+
+#[test]
+fn tree_bad_parent_rejected() {
+    let err = TreeMask::new(vec![-1, 5], 1, vec![true; 2]).expect_err("parent 5 >= T=2 rejected");
+    assert_eq!(
+        err,
+        IrError::BadParent {
+            token: 1,
+            parent: 5,
+            t: 2,
+        }
+    );
+    let err = TreeMask::new(vec![-2, -1], 1, vec![true; 2]).expect_err("parent -2 rejected");
+    assert_eq!(
+        err,
+        IrError::BadParent {
+            token: 0,
+            parent: -2,
+            t: 2,
+        }
+    );
+}
+
+#[test]
+fn tree_self_parent_rejected() {
+    let err = TreeMask::new(vec![0, -1], 1, vec![true; 2]).expect_err("self-parent rejected");
+    assert_eq!(err, IrError::SelfParent { token: 0 });
+}
+
+#[test]
+fn tree_parent_cycle_rejected() {
+    let err = TreeMask::new(vec![-1, 2, 1], 3, vec![true; 9]).expect_err("parent cycle rejected");
+    assert_eq!(err, IrError::TreeCycle { token: 1 });
+}
+
+#[test]
+fn tree_zero_column_width_rejected() {
+    let err = TreeMask::new(vec![-1], 0, vec![]).expect_err("non-empty tree needs columns");
+    assert_eq!(err, IrError::ZeroTreeMax { t: 1 });
+}
+
+#[test]
+fn tree_parent_cannot_cross_sequence_boundary() {
+    let tree = TreeMask::new(vec![-1, 0, 0, -1], 2, vec![true; 8]).expect("forest builds");
+    let (seq, _, c, slots, blocks, win) = batch_parts(1, 2, 4, 1);
+    let err = BatchMeta::builder(1, 2, 4, 1)
+        .seq_ids(seq)
+        .query_len(vec![2, 2])
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0; 4]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .tree(Some(tree))
+        .build()
+        .expect_err("a parent cannot point into another sequence");
+    assert_eq!(
+        err,
+        IrError::TreeParentCrossesSequence {
+            token: 2,
+            parent: 0,
+            seq: 1,
+            seq_start: 2,
+            seq_end: 4,
+        }
+    );
+}
+
+#[test]
+fn tree_columns_cover_longest_query() {
+    let tree = TreeMask::new(vec![-1, 0, 1], 2, vec![true; 6]).expect("tree builds");
+    let (seq, q, c, slots, blocks, win) = batch_parts(1, 1, 3, 1);
+    let err = BatchMeta::builder(1, 1, 3, 1)
+        .seq_ids(seq)
+        .query_len(q)
+        .ctx_len(c)
+        .positions(Positions::PerToken(vec![0; 3]))
+        .slot_map(slots)
+        .block_table(blocks)
+        .window_start(win)
+        .tree(Some(tree))
+        .build()
+        .expect_err("t_max must cover the query");
+    assert_eq!(
+        err,
+        IrError::TreeMaxTooSmall {
+            required: 3,
+            actual: 2,
+        }
+    );
+}
+
+#[test]
+fn tree_ancestor_length_rejected() {
+    let err = TreeMask::new(vec![-1, 0], 3, vec![true; 5]).expect_err("5 != 2*3 rejected");
+    assert_eq!(
+        err,
+        IrError::AncestorLength {
+            t: 2,
+            t_max: 3,
+            expected: 6,
+            actual: 5,
+        }
+    );
+}
+
+#[test]
+fn tree_valid_construction_and_lookup() {
+    // Chain 0 <- 1 <- 2, t_max=3, row i marks self + ancestors.
+    let ancestors = vec![
+        true, false, false, // tok 0: {0}
+        true, true, false, // tok 1: {0,1}
+        true, true, true, // tok 2: {0,1,2}
+    ];
+    let tree = TreeMask::new(vec![-1, 0, 1], 3, ancestors).expect("chain builds");
+    assert_eq!(tree.t(), 3);
+    assert_eq!(tree.t_max(), 3);
+    assert_eq!(tree.parents(), &[-1, 0, 1]);
+    assert!(tree.is_ancestor(2, 0));
+    assert!(!tree.is_ancestor(0, 2));
+}
+
+#[test]
+fn relrate_rejects_nonpositive_nonnumeric() {
+    for bad in [0.0, -1.0, f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let err = RelRate::new(bad).expect_err("bad rate rejected");
+        match err {
+            IrError::NonPositiveRate { .. } => {}
+            other => panic!("expected NonPositiveRate, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn matrix_op_rejects_invalid_accumulator() {
+    let rate = RelRate::new(1.0).expect("positive rate builds");
+    let err = r9v_ir::MatrixOp::new([16, 16, 16], DType::F16, DType::F16, DType::Bf16, rate)
+        .expect_err("matrix accumulation must be f32 or i32");
+    assert_eq!(err, IrError::InvalidAccumulator { got: DType::Bf16 });
+}
+
+#[test]
+fn gfx1201_initial_values_match_spec() {
+    let a = ArchDescriptor::gfx1201();
+    assert_eq!(a.family, ArchFamily::Rdna4);
+    assert_eq!(a.wave_size, 32);
+    assert_eq!(a.cu_count, 64);
+    assert_eq!(a.lds_bytes_per_wg, 64 * 1024);
+    assert_eq!(a.vgprs_per_lane, 256);
+    assert_eq!(a.l2_bytes, 8 * 1024 * 1024);
+    assert_eq!(a.l3_bytes, 64 * 1024 * 1024);
+    assert_eq!(a.vram_bytes, 32 * 1024 * 1024 * 1024);
+    assert_eq!(a.mem_bw_gbps, 640.0);
+    assert_eq!(a.clock_mhz, 2350.0);
+    assert_eq!(a.max_wg_size, 1024);
+    assert!(a.fp8_convert);
+    assert!(a.sparse_matrix);
+    assert_eq!(a.graph_capture, GraphCapture::Supported);
+    assert_eq!(a.valu_dot, vec![ValuDot::Dot4I32I8]);
+    assert_eq!(a.fragment_layout, LayoutId::L1);
+    assert!(a.measured.is_empty());
+    assert!(a.p2p.is_empty());
+    // f16/bf16 at 1x, fp8/iu8/iu4 at 2x nominal (Spec 1 App. A).
+    let rates: Vec<f32> = a.matrix_ops.iter().map(|m| m.rate.as_f32()).collect();
+    assert_eq!(rates, vec![1.0, 1.0, 2.0, 2.0, 2.0, 2.0]);
+    for m in &a.matrix_ops {
+        assert!(matches!(m.acc, DType::F32 | DType::I32));
+    }
+    assert_eq!(a.matrix_ops.last().map(|op| op.shape), Some([16, 16, 32]));
+}
+
+#[test]
+fn cpu_reports_reference_identity() {
+    let c = ArchDescriptor::cpu();
+    assert_eq!(c.family, ArchFamily::Cpu);
+    assert_eq!(c.name, "cpu");
+    assert_eq!(c.graph_capture, GraphCapture::None);
+    assert!(c.matrix_ops.is_empty());
+    assert!(c.valu_dot.is_empty());
+    assert!(!c.fp8_convert);
+    assert!(!c.sparse_matrix);
+    assert!(c.measured.is_empty());
+    assert!(c.p2p.is_empty());
+}
+
+#[test]
+fn ir_version_orders_and_displays() {
+    assert_eq!(IrVersion::CURRENT.to_string(), "0.1.0");
+    assert!(IrVersion::new(0, 2, 0) > IrVersion::CURRENT);
+    assert!(IrVersion::new(1, 0, 0) > IrVersion::new(0, 99, 99));
+}
+
+#[test]
+fn state_handle_names_layer_and_kind() {
+    let h = StateHandle::new(7, StateKind::Recurrent);
+    assert_eq!(h.layer(), 7);
+    assert_eq!(h.kind(), StateKind::Recurrent);
+    assert_eq!(h, StateHandle::new(7, StateKind::Recurrent));
+    assert_ne!(h, StateHandle::new(7, StateKind::ConvWindow));
+}
+
+#[test]
+fn seeded_batches_build_identically_twice() {
+    // Determinism: same seed, same dims and ids, bit-identical metadata.
+    fn build(seed: u64) -> BatchMeta {
+        let mut rng = SeededRng::new(seed);
+        let g = (1 + rng.next_u64() % 3) as u32;
+        let s = (1 + rng.next_u64() % 7) as u32;
+        let t = s + (rng.next_u64() % 15) as u32;
+        let mb = (1 + rng.next_u64() % 7) as u32;
+        let (seq, q, c, slots, blocks, win) =
+            batch_parts(g as usize, s as usize, t as usize, mb as usize);
+        BatchMeta::builder(g, s, t, mb)
+            .seq_ids(seq)
+            .query_len(q)
+            .ctx_len(c)
+            .positions(Positions::PerToken(vec![0; t as usize]))
+            .slot_map(slots)
+            .block_table(blocks)
+            .window_start(win)
+            .build()
+            .expect("seeded batch builds")
+    }
+    assert_eq!(build(0xC10C), build(0xC10C));
+    assert_eq!(valid_batch(2, 4, 8, 4), valid_batch(2, 4, 8, 4));
+}
+
+#[test]
+fn seeded_tensor_shapes_vary_without_breaking_invariants() {
+    // Same seed replays the same shape stream; every shape still validates.
+    let mut rng = SeededRng::new(0xA11CE);
+    for _ in 0..32 {
+        let rank = (1 + rng.next_u64() % 4) as usize;
+        let shape: Vec<Dim> = (0..rank)
+            .map(|_| Dim::Concrete((1 + rng.next_u64() % 128) as u32))
+            .collect();
+        let t = Tensor::new(
+            shape.clone(),
+            DType::F16,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )
+        .expect("seeded shape builds");
+        assert_eq!(t.shape(), shape.as_slice());
+    }
+    // Symbolic dims ride along untouched.
+    let t = Tensor::new(
+        vec![
+            Dim::Symbolic(ShapeSymbol::T),
+            Dim::Symbolic(ShapeSymbol::Dm),
+        ],
+        DType::I8,
+        QuantScheme::PerToken,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .expect("symbolic shape builds");
+    assert_eq!(t.rank(), 2);
+}


### PR DESCRIPTION
## Card
A1.1 — ir types   (kind: API; GPU: no; size: S)

## Spec sections implemented
- spec 1 §2.1: closed `DType` surface.
- spec 1 §2.2: typed quantization tags and opaque scheme identity.
- spec 1 §2.3–§2.4: tensor, dimension, placement, class, and layout metadata with structural validation.
- spec 1 §2.5 and §4.D.1: fixed-shape batch metadata and speculative tree masks.
- spec 1 §2.6: opaque state handles and the v1 state-kind set.
- spec 1 §5.1: closed sharding-layout set.
- spec 1 §7: current, ordered IR version identity.
- spec 1 Appendix A: complete architecture descriptor plus gfx1201 and CPU constructors.

## Deliverables
- [x] `DType` and `QuantScheme`, including opaque `SchemeId`.
- [x] `Tensor`, `Dim`, `Placement`, `LayoutId`, `ShardLayout`, and `Class`.
- [x] `BatchMeta` with `G`, `[G,T]`, `[G,S,max_blocks]`, `[G,S]`, and `TreeMask` semantics.
- [x] `StateHandle` and `StateKind`.
- [x] `ArchDescriptor`, measured block, `gfx1201()`, and `cpu()`.
- [x] `IrVersion`.
- [x] Public documentation and API-shape coverage.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| public surface, closed-set exhaustiveness, visibility, and Send/Sync | `crates/r9v-ir/tests/api_shape.rs` | cpu-only | green |
| tensor, batch, tree, descriptor, state, and version invariants | `crates/r9v-ir/tests/invariants.rs` | cpu-only | green |
| every public item names its governing spec | strict rustdoc with `-D warnings -D missing-docs` | cpu-only | green |
| workspace regression suite | `cargo test --workspace --locked` | cpu-only | green |

## Decisions
- `crates/r9v-ir/src/arch.rs:115` — gfx1201 advertises only the VALU dot form App. A names.
- `crates/r9v-ir/src/arch.rs:161` — absent P2P measurement is `None`, not a false zero measurement.
- `crates/r9v-ir/src/arch.rs:273` — required gfx1201 search bounds use the A0 receipt hardware facts instead of unusable zero sentinels.
- `crates/r9v-ir/src/arch.rs:279` — the e5m2 form uses e4m3 as its first operand because e5m2 is second-operand-only.
- `crates/r9v-ir/src/arch.rs:328` — the CPU constructor describes the scalar reference identity without host-specific capability guesses.
- `crates/r9v-ir/src/batch.rs:18` — block-table padding uses `u32::MAX`, preserving block id zero.
- `crates/r9v-ir/src/batch.rs:65` — `TreeMask` carries the scheduler-produced `T_max` and validates it at batch binding.
- `crates/r9v-ir/src/layout.rs:39` — IR-owned opaque layout codes break the dependency cycle pending the SI-3 spec resolution.
- `crates/r9v-ir/src/quant.rs:18` — opaque ids use the repository-standard private `u64` representation.
- `crates/r9v-ir/src/quant.rs:73` — quant variants describe scale metadata while scale arrays remain format/op data; see SI-4.
- `crates/r9v-ir/src/tensor.rs:176` — tensors reject rank zero and zero concrete extents because every closed v1 op signature is non-scalar.
- `crates/r9v-ir/src/tensor.rs:198` — role-specific Host/Tiered checks stay at loader/planner binding; see SI-5.
- `crates/r9v-ir/src/tensor.rs:210` — quantized n-gram rows remain representable as `Staging`; see SI-6.
- `crates/r9v-ir/src/version.rs:25` — current IR is `0.1.0` until the A6.7a interface freeze.

## SPEC-ISSUES filed
- SI-3: assigns canonical ownership and a missing id for layout identities needed by the IR and descriptor.
- SI-4: clarifies whether QuantScheme scale notation is metadata or an impossible scalar payload.
- SI-5: locates semantic weight-role placement validation where roles are available.
- SI-6: resolves the weights-only wording against the quantized `ngram_gather` staging tensor.

## New dependencies
- `thiserror`: required by `CONVENTIONS.md` §1.1 for the public per-crate `IrError`; already present in the workspace lockfile.

## Hardware
Tests run here: hosted cpu-only; A1.1 has no GPU test requirement.
Tests pending on the runner: none.
Measured numbers (if any): no new measurement. `gfx1201()` consumes the existing gfx1201/R9700 A0 receipts in `spikes/wmma-l1/RESULT.md` and `spikes/dot4-gemv/RESULT.md`; their recorded commands and fingerprints are the provenance for the native i4 tile, cache sizes, and reference clock.

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- none

## Size check
Diff size vs card size class: 2,948 changed lines vs S — the card aggregates ten foundational public type families; 1,055 lines are API/invariant tests and most source volume is required public-item/spec documentation. No op, graph, executor, or kernel behavior from later cards is included.
