### PR TITLE
ops: codify Gemini quota wakeup protocol

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -20,6 +20,10 @@ Use this order without substitution:
 
 If the required `agy` model is not exposed by the installed client, report the exact availability problem. Do not silently substitute another model for production work.
 
+## Gemini quota orchestration
+
+The zero-cost machine-readable status command is `agy -p '/usage' --output-format json`. Gemini availability is constrained by both `gemini-5h` and `gemini-weekly` buckets; `reset_time` values are rolling-window timestamps. After any quota-exhaustion response, the root starts a non-blocking background timer for the latest `reset_time` among depleted Gemini buckets, continues on Muse meanwhile, re-queries status when the timer fires, rearms if necessary, and immediately returns new work to Gemini once both buckets permit it.
+
 ## Communication
 
 Between work periods, communicate only completed evidence, decisions, blockers that need action, and the next material dispatch. Do not spend usage repeating that an agent is still running or narrating routine matching and testing.


### PR DESCRIPTION
## Card
Operational documentation — Gemini quota wakeup protocol (kind: docs; GPU: no; size: S)

## Spec sections implemented
- None: orchestration documentation only.

## Deliverables
- [x] Document the zero-cost machine-readable Gemini usage command.
- [x] Document both limiting Gemini quota buckets and rolling reset timestamps.
- [x] Require a non-blocking wakeup timer, Muse fallback, recheck, and immediate Gemini restoration after quota exhaustion.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| Markdown diff check | `ORCHESTRATION.md` | cpu-only | green |

## Decisions
- none

## SPEC-ISSUES filed
- none

## New dependencies
- none

## Hardware
Tests run here: hosted cpu-only.
Tests pending on the runner: none.
Measured numbers (if any): none.

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- Card-specific code and test items are not applicable to an orchestration-only documentation change.

## Size check
Diff size vs card size class: 4 lines vs S — ok.
