### PR TITLE
A1.2: typed ops and step graph

### DIFF
--- a/SPEC-ISSUES.md
+++ b/SPEC-ISSUES.md
@@ -47,3 +47,45 @@ What: The core-type notes call `i4`, `PerRow`, and `Scheme` weights-only, while 
 Why it blocks or misleads: Enforcing “weights-only” as `Tensor.class == Weight` makes the specified n-gram op impossible to construct, even though its staging bytes remain quantized weight-origin data with their scale records. Treating the staging tensor as unquantized would misdescribe its bytes and break reference dequantization.
 Option taken: Allowed weight-side quant schemes and `i4` on `Class::Staging` as well as `Class::Weight`; `PerToken` and `PerBlock32` remain activation-only. The exception is limited to the class explicitly used by `gather_staging`.
 Proposed resolution: Clarify in §2.1–§2.2 that “weights-only” includes quantized weight-origin rows in `Staging` tensors, or give `gather_staging` a distinct closed scheme/class representation.
+
+## SI-7 — A1.2 — spec 1 §4.A `quant_act`
+What: Spec 1 §4.A specifies `quant_act` as `x [T, N] (f16|bf16|f32) -> xq [T, N] (i8|e4m3) PerToken, scale [T] f32` with attrs `target: i8|e4m3, smoothing: None|Folded`, omitting `PerBlock32` and rank-2 scale even though Spec 2 §3.4 and Card A1.5 require `i8 PerBlock32` with scale `[T, N/32] f32`.
+Why it blocks or misleads: Standard GGUF models without `r9v.*` metadata require `i8 PerBlock32` activation quantization for llama.cpp MMQ parity. Strictly enforcing Spec 1 §4.A's closed signature prevents the IR from expressing block-scaled activation quantization.
+Option taken: Added a `scheme: QuantScheme` attribute to `QuantActOp` supporting `PerToken` and `PerBlock32`. Validated that `PerBlock32` requires target `i8`, `N` divisible by 32, and scale rank 2 `[T, N/32] f32`, while rejecting `e4m3 PerBlock32`.
+Proposed resolution: Update Spec 1 §4.A to add `scheme: PerToken | PerBlock32` to `attrs` and document the conditional `scale` shape (`[T]` for `PerToken`, `[T, N/32]` for `PerBlock32`).
+
+## SI-8 — A1.2 — spec 1 §4.A `ngram_gather`
+What: Spec 1 §4.A specifies `ngram_gather` consuming `gather_staging [T, Np, Dn] (i4|i8, Block), row_scales -> x [T, Np·Dn] act_dtype`, notes a `Device` table mode where hashing occurs on device and `gather_staging` is unused, but provides no signature for device-table mode.
+Why it blocks or misleads: Without a signature for the device-table case, the op cannot validate its inputs when gathering directly from a device table, and ignoring input tensors leads to silent signature mismatch between graph and execution.
+Option taken: Added a closed `source: NgramSource` attribute (`Staged` vs `Device`). Validated an exact two-tensor signature for each mode: `(gather_staging, row_scales)` for staged mode, and `(token_ids [T] u32, table [TotalEntries, Dn])` with `Device` placement and `Weight` class for device-table mode.
+Proposed resolution: Explicitly document the two input tensor signatures for staged mode and device-table mode in Spec 1 §4.A.
+
+## SI-9 — A1.2 — spec 1 §4.C `matmul`
+What: Spec 1 §4.C lists `epilogue: None|Bias|Residual|Act(act)` and includes `bias? [N] f32` in the input signature, but omits the `residual` activation tensor `[M, N]` from the signature.
+Why it blocks or misleads: Spec 1 §3.4 and §5.2 explicitly permit matmul residual epilogues and partial sum flow through them. Without a formal input tensor for the residual operand, the step graph cannot represent or validate fused matmul-residual nodes.
+Option taken: Validated input tensors conditionally based on `epilogue`: `None` and `Act` require exactly 2 inputs `(x, w)`, `Bias` requires 3 inputs `(x, w, bias [N] f32)`, and `Residual` requires 3 inputs `(x, w, residual [M, N])` with matching activation dtype.
+Proposed resolution: Update Spec 1 §4.C to list `epilogue_in?` in inputs, specifying `bias [N] f32` for `Bias` and `residual [M, N] act_dtype` for `Residual`.
+
+## SI-10 — A1.2 — spec 1 §4.A `gather_rows` and `scatter_add_rows`
+What: Spec 1 §4.A names `gather_rows` and `scatter_add_rows` as ops exposed for reference-tier MoE and tree-verify bookkeeping, but omits their input/output tensor signatures, ranks, and dtypes.
+Why it blocks or misleads: Without declared tensor signatures, graph construction, op validation, and sharding tables for these ops cannot be verified against the specification.
+Option taken: Defined and validated explicit signatures: `gather_rows(x [N, D], indices [M] u32) -> y [M, D]` and `scatter_add_rows(x [M, D], indices [M] u32, dest? [N, D]) -> y [N, D]`.
+Proposed resolution: Add explicit signature blocks and shape/dtype constraints for `gather_rows` and `scatter_add_rows` in Spec 1 §4.A.
+
+## SI-11 — A1.2 — spec 1 §4.G collective operations
+What: Spec 1 §4.G lists collective ops `all_reduce`, `all_gather`, `reduce_scatter`, `all_to_all(counts)`, `send(peer)`, `recv(peer)`, `barrier` and groups attributes `group: GroupId`, `dtype`, `reduce_in: f32` at the section level, but omits explicit per-op argument mappings.
+Why it blocks or misleads: The absence of per-op attribute definitions leaves `send` and `recv` without an explicit communicator `group`, `reduce_scatter` and `all_gather` without a partition axis, `recv` without an expected shape, and `all_to_all` without an explicit counts tensor signature.
+Option taken: Added `group: GroupId` to `SendOp` and `RecvOp`, `shape: Box<[Dim]>` to `RecvOp`, `axis: u32` to `AllGatherOp` and `ReduceScatterOp`, `reduce_in == DType::F32` validation to `AllReduceOp` and `ReduceScatterOp`, and validated a two-tensor input signature `(x, counts [P] u32)` for `AllToAllOp`.
+Proposed resolution: Provide individual op signatures and attribute listings for each collective operation in Spec 1 §4.G.
+
+## SI-12 — A1.2 — spec 1 §3.1, §3.2, §4.D, §4.F non-Tensor step graph inputs
+What: Spec 1 §3.1 defines a graph as a DAG of op instances over tensors, but §3.2, §4.D, and §4.F describe `BatchMeta`, `SamplingParams`, `rng_state`, and `TreeMask` as graph inputs or op arguments without defining them as Tensors.
+Why it blocks or misleads: Modeling non-tensor execution metadata as fake `Tensor` instances compromises tensor invariant validation, while omitting them prevents step graphs from capturing complete runtime inputs.
+Option taken: Kept `rng_state`, `BatchMeta` (including its optional `TreeMask`), and `SamplingParams` as typed non-Tensor external values because `DType` is closed. Op-level `validate(&self, inputs, outputs)` validates only the tensor portions of signatures, while structured non-tensor metadata and parameters are validated via dedicated typed validation methods (such as `SamplingParams::validate()`).
+Proposed resolution: Clarify in Spec 1 §3.1 and §3.2 that step graphs capture structured non-tensor external inputs alongside tensor edges, and specify that op tensor validation applies strictly to tensor portions.
+
+## SI-13 — A1.2 — spec 1 §3.4 `logits_postprocess -> sample` fusion
+What: Spec 1 §3.4 lists `logits_postprocess -> sample` as a permitted fusion pattern, but `logits_postprocess` emits `probs [S, q, V] f32` (rank 3) while `sample` consumes `probs [S, V] f32` (rank 2).
+Why it blocks or misleads: During decode `q = 1` the query dimension is degenerate, but prefill and speculative verify steps have `q > 1`, creating a structural rank contradiction across the fused edge.
+Option taken: Modeled the fusion pattern for decode-class steps where `q = 1` allows squeezing the degenerate dimension into `[S, V]`, and documented that multi-token sampling requires per-token dispatch.
+Proposed resolution: Clarify in Spec 1 §3.4 that `logits_postprocess -> sample` fusion applies specifically to decode-class sequences with `q = 1`.

--- a/crates/r9v-ir/src/error.rs
+++ b/crates/r9v-ir/src/error.rs
@@ -262,6 +262,261 @@ pub enum IrError {
         value: f32,
     },
 
+    /// An op received an unexpected number of input tensors (Spec 1 §4).
+    #[error("op `{op}` expected {expected} inputs, got {got} (Spec 1 §4)")]
+    OpInputCountMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Expected input count.
+        expected: usize,
+        /// Actual input count.
+        got: usize,
+    },
+
+    /// An op received an unexpected number of input tensors when multiple counts are accepted (Spec 1 §4).
+    #[error("op `{op}` expected one of {expected:?} inputs, got {got} (Spec 1 §4)")]
+    OpInputCountCandidatesMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Accepted input counts.
+        expected: Box<[usize]>,
+        /// Actual input count.
+        got: usize,
+    },
+
+    /// An op received an unexpected number of output tensors (Spec 1 §4).
+    #[error("op `{op}` expected {expected} outputs, got {got} (Spec 1 §4)")]
+    OpOutputCountMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Expected output count.
+        expected: usize,
+        /// Actual output count.
+        got: usize,
+    },
+
+    /// An op received an unexpected number of output tensors when multiple counts are accepted (Spec 1 §4).
+    #[error("op `{op}` expected one of {expected:?} outputs, got {got} (Spec 1 §4)")]
+    OpOutputCountCandidatesMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Accepted output counts.
+        expected: Box<[usize]>,
+        /// Actual output count.
+        got: usize,
+    },
+
+    /// An op tensor has an unexpected dtype (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` expected dtype in {expected:?}, got {got} (Spec 1 §4)")]
+    OpDTypeMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Allowed dtypes.
+        expected: Box<[DType]>,
+        /// Actual dtype.
+        got: DType,
+    },
+
+    /// An op tensor has an unexpected rank (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` expected rank {expected}, got {got} (Spec 1 §4)")]
+    OpRankMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Expected rank.
+        expected: usize,
+        /// Actual rank.
+        got: usize,
+    },
+
+    /// An op tensor has a shape mismatch against constraints (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` shape mismatch: {detail} (Spec 1 §4)")]
+    OpShapeMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Detail of the mismatch.
+        detail: String,
+    },
+
+    /// An op tensor has an unexpected layout (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` expected layout {expected}, got {got} (Spec 1 §4)")]
+    OpLayoutMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Expected layout.
+        expected: LayoutId,
+        /// Actual layout.
+        got: LayoutId,
+    },
+
+    /// An op tensor has an unexpected quantization scheme (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` unexpected quant scheme {quant:?} (Spec 1 §4)")]
+    OpQuantMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Actual quant scheme.
+        quant: QuantScheme,
+    },
+
+    /// An op tensor has an illegal placement (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` illegal placement {placement} (Spec 1 §4)")]
+    OpPlacementMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Actual placement.
+        placement: Placement,
+    },
+
+    /// An op tensor has an unexpected class (Spec 1 §4).
+    #[error("op `{op}` tensor `{tensor}` expected class {expected}, got {got} (Spec 1 §4)")]
+    OpClassMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor role or parameter name.
+        tensor: &'static str,
+        /// Expected class.
+        expected: Class,
+        /// Actual class.
+        got: Class,
+    },
+
+    /// An op attribute violates its specification (Spec 1 §4).
+    #[error("op `{op}` attribute `{attribute}` invalid: {reason} (Spec 1 §4)")]
+    OpAttributeInvalid {
+        /// Op name.
+        op: &'static str,
+        /// Attribute name.
+        attribute: &'static str,
+        /// Failure reason.
+        reason: String,
+    },
+
+    /// An op received an incompatible state handle kind (Spec 1 §4.D, §4.E).
+    #[error("op `{op}` expected state kind {expected:?}, got {got:?} (Spec 1 §4)")]
+    StateHandleKindMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Expected state kind.
+        expected: crate::StateKind,
+        /// Actual state kind.
+        got: crate::StateKind,
+    },
+
+    /// A batch axis value exceeded the maximum bucket size of 4096 (Spec 1 §3.5).
+    #[error("axis `{axis}` value {value} exceeds max bucket {max} (Spec 1 §3.5)")]
+    BucketExceeded {
+        /// Axis name.
+        axis: &'static str,
+        /// Actual value.
+        value: u32,
+        /// Maximum bucket size (4096).
+        max: u32,
+    },
+
+    /// A bucket value is not valid for the given axis (Spec 1 §3.5).
+    #[error("invalid bucket value {value} for axis `{axis}` (Spec 1 §3.5)")]
+    InvalidBucket {
+        /// Axis name.
+        axis: &'static str,
+        /// Value.
+        value: u32,
+    },
+
+    /// Graph contains a cycle (Spec 1 §3.1).
+    #[error("graph contains a cycle involving node {node} (Spec 1 §3.1)")]
+    GraphCycle {
+        /// Offending node index.
+        node: usize,
+    },
+
+    /// Referenced graph node does not exist.
+    #[error("graph node {node} not found")]
+    GraphNodeNotFound {
+        /// Missing node id.
+        node: usize,
+    },
+
+    /// Referenced graph edge does not exist.
+    #[error("graph edge {edge} not found")]
+    GraphEdgeNotFound {
+        /// Missing edge id.
+        edge: usize,
+    },
+
+    /// A graph op requires a structured external input that was not bound
+    /// (Spec 1 §3.2, §4).
+    #[error("graph op `{required_by}` requires external input {kind:?} (Spec 1 §3.2, §4)")]
+    GraphExternalInputMissing {
+        /// Missing structured input kind.
+        kind: crate::graph::ExternalInputKind,
+        /// Op that requires the input.
+        required_by: &'static str,
+    },
+
+    /// A graph op mutates structured state but its external output was not
+    /// declared (Spec 1 §3.2, §4.F).
+    #[error("graph op `{required_by}` requires external output {kind:?} (Spec 1 §3.2, §4.F)")]
+    GraphExternalOutputMissing {
+        /// Missing structured output kind.
+        kind: crate::graph::ExternalOutputKind,
+        /// Op that requires the output.
+        required_by: &'static str,
+    },
+
+    /// An external output was bound to an edge that is not produced by an op
+    /// in this graph (Spec 1 §3.1–§3.2).
+    #[error("external output {kind:?} cannot bind unproduced edge {edge} (Spec 1 §3.1–§3.2)")]
+    GraphExternalOutputUnproduced {
+        /// External output kind being bound.
+        kind: crate::graph::ExternalOutputKind,
+        /// Edge without an operation producer.
+        edge: usize,
+    },
+
+    /// A graph-owned source tensor uses a class reserved for request-time or
+    /// operation-produced data (Spec 1 §2.3, §3.1–§3.2).
+    #[error("graph-owned source edge cannot use tensor class {class} (Spec 1 §2.3, §3.1–§3.2)")]
+    GraphSourceClassInvalid {
+        /// Rejected tensor class.
+        class: Class,
+    },
+
+    /// A tensor edge is placed on a device other than the graph capture rank
+    /// (Spec 1 §3.1).
+    #[error("graph edge {edge} is on device rank {tensor_rank}, expected graph rank {graph_rank} (Spec 1 §3.1)")]
+    GraphTensorRankMismatch {
+        /// Edge carrying the mismatched tensor.
+        edge: usize,
+        /// Rank in the tensor placement.
+        tensor_rank: u32,
+        /// Rank in the step-graph key.
+        graph_rank: u32,
+    },
+
+    /// A stride mismatch occurred between actual and expected layout (Spec 1 §3.3).
+    #[error(
+        "stride mismatch on edge {edge}: actual {actual:?}, expected {expected:?} (Spec 1 §3.3)"
+    )]
+    StrideMismatch {
+        /// Edge id.
+        edge: usize,
+        /// Actual strides.
+        actual: Box<[i64]>,
+        /// Expected contiguous strides.
+        expected: Box<[i64]>,
+    },
+
     /// Collect-all wrapper: every problem found before returning
     /// (CONVENTIONS.md §1.4). Constructors return the single problem directly
     /// when only one exists.
@@ -270,4 +525,20 @@ pub enum IrError {
         /// Every problem found, in deterministic field order.
         problems: Box<[IrError]>,
     },
+}
+
+impl IrError {
+    /// Collapses a list of accumulated errors into `Ok(())`, single `Err(e)`,
+    /// or [`IrError::Multiple`] per CONVENTIONS.md §1.4.
+    pub fn from_problems(mut problems: Vec<IrError>) -> Result<(), Self> {
+        if problems.is_empty() {
+            Ok(())
+        } else if problems.len() == 1 {
+            Err(problems.pop().expect("problems holds exactly one entry"))
+        } else {
+            Err(Self::Multiple {
+                problems: problems.into_boxed_slice(),
+            })
+        }
+    }
 }

--- a/crates/r9v-ir/src/fusion.rs
+++ b/crates/r9v-ir/src/fusion.rs
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Closed fusion table (Spec 1 §3.4; card A1.2).
+//!
+//! The compiler may fuse only pairs/chains listed in the fusion table. Every
+//! fused kernel must satisfy the union of the fused ops' numerics contracts
+//! (Spec 1 §1 Principle 7). Anything else requires an RFC (Spec 1 §7).
+//! Fusion never changes an op's declared sharding rule (Spec 1 §3.4).
+
+use crate::{Epilogue, Op};
+
+/// Closed set of permitted compiler fusion patterns (Spec 1 §3.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FusionPattern {
+    /// `residual_add → norm`: fused add-norm, f32 stats.
+    ResidualAddNorm,
+    /// `norm → quant_act`: norm emits quantized activation + per-token scale directly.
+    NormQuantAct,
+    /// `matmul → bias / residual_add / activation`: epilogue.
+    MatmulEpilogue,
+    /// `matmul(gate) ∥ matmul(up) → act_mul`: interleaved gate/up GEMM with gated epilogue.
+    GatedMatmulActMul,
+    /// `rope → state_write_kv`: rope applied on the write path.
+    RopeStateWriteKv,
+    /// `rope → attention` (prefill): rope applied in the Q load.
+    RopeAttentionPrefill,
+    /// `state_write_kv → attention` (decode, `query_len ≤ 16`): single launch:
+    /// write the new K/V, then attend; prefill keeps them separate.
+    StateWriteKvAttentionDecode,
+    /// `logits_postprocess → sample`: single sampling kernel.
+    LogitsPostprocessSample,
+    /// `quant_act → all_to_all` (EP): dispatch already-quantized tokens.
+    QuantActAllToAll,
+}
+
+/// An entry in the exact fusion table (Spec 1 §3.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FusionEntry {
+    /// Permitted fusion pattern identifier.
+    pub pattern: FusionPattern,
+    /// Spec-defined result description.
+    pub description: &'static str,
+    /// Condition or sequence-class constraint (e.g. prefill, decode query_len <= 16, EP).
+    pub condition: Option<&'static str>,
+}
+
+/// Exact fusion table defined by Spec 1 §3.4.
+pub const FUSION_TABLE: &[FusionEntry] = &[
+    FusionEntry {
+        pattern: FusionPattern::ResidualAddNorm,
+        description: "fused add-norm, f32 stats",
+        condition: None,
+    },
+    FusionEntry {
+        pattern: FusionPattern::NormQuantAct,
+        description: "norm emits quantized activation + per-token scale directly",
+        condition: None,
+    },
+    FusionEntry {
+        pattern: FusionPattern::MatmulEpilogue,
+        description: "epilogue",
+        condition: None,
+    },
+    FusionEntry {
+        pattern: FusionPattern::GatedMatmulActMul,
+        description: "interleaved gate/up GEMM with gated epilogue",
+        condition: None,
+    },
+    FusionEntry {
+        pattern: FusionPattern::RopeStateWriteKv,
+        description: "rope applied on the write path",
+        condition: None,
+    },
+    FusionEntry {
+        pattern: FusionPattern::RopeAttentionPrefill,
+        description: "rope applied in the Q load",
+        condition: Some("prefill"),
+    },
+    FusionEntry {
+        pattern: FusionPattern::StateWriteKvAttentionDecode,
+        description: "single launch: write the new K/V, then attend; prefill keeps them separate",
+        condition: Some("decode, query_len <= 16"),
+    },
+    FusionEntry {
+        pattern: FusionPattern::LogitsPostprocessSample,
+        description: "single sampling kernel",
+        condition: None,
+    },
+    FusionEntry {
+        pattern: FusionPattern::QuantActAllToAll,
+        description: "dispatch already-quantized tokens",
+        condition: Some("EP"),
+    },
+];
+
+/// Returns the exact fusion table as data (Spec 1 §3.4).
+pub fn fusion_table() -> &'static [FusionEntry] {
+    FUSION_TABLE
+}
+
+/// Checks if a fusion pattern is permitted by the fusion table.
+pub fn is_permitted_fusion(pattern: FusionPattern) -> bool {
+    FUSION_TABLE.iter().any(|entry| entry.pattern == pattern)
+}
+
+/// Checks if a producer-consumer op pair matches a permitted fusion pattern (Spec 1 §3.4).
+///
+/// Exhaustively matches all 29 closed `Op` variants without wildcards (CONVENTIONS.md §3.2).
+// DECISION(A1.2): typed pair matching on &Op replaces stringly APIs per Spec 1 §3.4; pseudo-op bias is removed because bias is an epilogue attribute/operand on MatmulOp rather than an Op node.
+pub fn is_permitted_pair(producer: &Op, consumer: &Op) -> Option<FusionPattern> {
+    match_pair(producer, consumer)
+}
+
+/// Typed pair matching on `&Op` (Spec 1 §3.4).
+///
+/// Exhaustively matches all 29 closed `Op` variants without wildcards (CONVENTIONS.md §3.2).
+fn match_pair(producer: &Op, consumer: &Op) -> Option<FusionPattern> {
+    match producer {
+        Op::ResidualAdd(_) => match consumer {
+            Op::Norm(_) => Some(FusionPattern::ResidualAddNorm),
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::Attention(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::Norm(_) => match consumer {
+            Op::QuantAct(_) => Some(FusionPattern::NormQuantAct),
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::Norm(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::Attention(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::Matmul(matmul) => match consumer {
+            Op::ResidualAdd(_) | Op::Activation(_) if matmul.epilogue == Epilogue::None => {
+                Some(FusionPattern::MatmulEpilogue)
+            }
+            Op::ResidualAdd(_) | Op::Activation(_) => None,
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::Norm(_)
+            | Op::ActMul(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::Attention(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::Rope(_) => match consumer {
+            Op::StateWriteKv(_) => Some(FusionPattern::RopeStateWriteKv),
+            Op::Attention(_) => Some(FusionPattern::RopeAttentionPrefill),
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::Norm(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::StateWriteKv(_) => match consumer {
+            Op::Attention(_) => Some(FusionPattern::StateWriteKvAttentionDecode),
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::Norm(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::LogitsPostprocess(_) => match consumer {
+            Op::Sample(_) => Some(FusionPattern::LogitsPostprocessSample),
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::Norm(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::Attention(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::QuantAct(_) => match consumer {
+            Op::AllToAll(_) => Some(FusionPattern::QuantActAllToAll),
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::Norm(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::Matmul(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::Attention(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::EmbedGather(_)
+        | Op::NgramGather(_)
+        | Op::Cast(_)
+        | Op::Copy(_)
+        | Op::GatherRows(_)
+        | Op::ScatterAddRows(_)
+        | Op::ActMul(_)
+        | Op::Activation(_)
+        | Op::MoeRoute(_)
+        | Op::MoeFfn(_)
+        | Op::Attention(_)
+        | Op::CausalConv1d(_)
+        | Op::LinearAttnScan(_)
+        | Op::Sample(_)
+        | Op::Verify(_)
+        | Op::AllReduce(_)
+        | Op::AllGather(_)
+        | Op::ReduceScatter(_)
+        | Op::AllToAll(_)
+        | Op::Send(_)
+        | Op::Recv(_)
+        | Op::Barrier(_) => None,
+    }
+}
+
+/// Typed gated two-producer matcher for `matmul(gate) ∥ matmul(up) → act_mul` (Spec 1 §3.4).
+///
+/// Exhaustively matches all 29 closed `Op` variants without wildcards (CONVENTIONS.md §3.2).
+pub fn match_gated_pair(
+    gate_producer: &Op,
+    up_producer: &Op,
+    consumer: &Op,
+) -> Option<FusionPattern> {
+    match gate_producer {
+        Op::Matmul(gate) => match up_producer {
+            Op::Matmul(up) => match consumer {
+                Op::ActMul(_)
+                    if gate.epilogue == Epilogue::None && up.epilogue == Epilogue::None =>
+                {
+                    Some(FusionPattern::GatedMatmulActMul)
+                }
+                Op::ActMul(_) => None,
+                Op::EmbedGather(_)
+                | Op::NgramGather(_)
+                | Op::QuantAct(_)
+                | Op::Cast(_)
+                | Op::Copy(_)
+                | Op::GatherRows(_)
+                | Op::ScatterAddRows(_)
+                | Op::Norm(_)
+                | Op::ResidualAdd(_)
+                | Op::Activation(_)
+                | Op::Rope(_)
+                | Op::Matmul(_)
+                | Op::MoeRoute(_)
+                | Op::MoeFfn(_)
+                | Op::StateWriteKv(_)
+                | Op::Attention(_)
+                | Op::CausalConv1d(_)
+                | Op::LinearAttnScan(_)
+                | Op::LogitsPostprocess(_)
+                | Op::Sample(_)
+                | Op::Verify(_)
+                | Op::AllReduce(_)
+                | Op::AllGather(_)
+                | Op::ReduceScatter(_)
+                | Op::AllToAll(_)
+                | Op::Send(_)
+                | Op::Recv(_)
+                | Op::Barrier(_) => None,
+            },
+            Op::EmbedGather(_)
+            | Op::NgramGather(_)
+            | Op::QuantAct(_)
+            | Op::Cast(_)
+            | Op::Copy(_)
+            | Op::GatherRows(_)
+            | Op::ScatterAddRows(_)
+            | Op::Norm(_)
+            | Op::ResidualAdd(_)
+            | Op::ActMul(_)
+            | Op::Activation(_)
+            | Op::Rope(_)
+            | Op::MoeRoute(_)
+            | Op::MoeFfn(_)
+            | Op::StateWriteKv(_)
+            | Op::Attention(_)
+            | Op::CausalConv1d(_)
+            | Op::LinearAttnScan(_)
+            | Op::LogitsPostprocess(_)
+            | Op::Sample(_)
+            | Op::Verify(_)
+            | Op::AllReduce(_)
+            | Op::AllGather(_)
+            | Op::ReduceScatter(_)
+            | Op::AllToAll(_)
+            | Op::Send(_)
+            | Op::Recv(_)
+            | Op::Barrier(_) => None,
+        },
+        Op::EmbedGather(_)
+        | Op::NgramGather(_)
+        | Op::QuantAct(_)
+        | Op::Cast(_)
+        | Op::Copy(_)
+        | Op::GatherRows(_)
+        | Op::ScatterAddRows(_)
+        | Op::Norm(_)
+        | Op::ResidualAdd(_)
+        | Op::ActMul(_)
+        | Op::Activation(_)
+        | Op::Rope(_)
+        | Op::MoeRoute(_)
+        | Op::MoeFfn(_)
+        | Op::StateWriteKv(_)
+        | Op::Attention(_)
+        | Op::CausalConv1d(_)
+        | Op::LinearAttnScan(_)
+        | Op::LogitsPostprocess(_)
+        | Op::Sample(_)
+        | Op::Verify(_)
+        | Op::AllReduce(_)
+        | Op::AllGather(_)
+        | Op::ReduceScatter(_)
+        | Op::AllToAll(_)
+        | Op::Send(_)
+        | Op::Recv(_)
+        | Op::Barrier(_) => None,
+    }
+}
+
+/// Checks if an op chain exactly matches a permitted fusion-table transition (Spec 1 §3.4).
+///
+/// Multi-op chains of length != 2 return `None`: Spec 1 §3.4 specifies only exact pair
+/// transitions and gated two-producer GEMM. Invented multi-epilogue chains require an RFC.
+pub fn match_chain(ops: &[&Op]) -> Option<FusionPattern> {
+    if let [producer, consumer] = ops {
+        is_permitted_pair(producer, consumer)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ActMulOp, ActivationKind, ActivationOp, AllToAllOp, AttentionMask, AttentionOp,
+        CacheScaleGranularity, DType, GroupId, LogitsPostprocessOp, MatmulOp, NormAxis, NormKind,
+        NormOp, QuantActOp, QuantScheme, ResidualAddOp, RngAlgorithm, RopeOp, RopeScaling,
+        RopeStyle, SampleOp, Smoothing, StateHandle, StateKind, StateWriteKvOp,
+    };
+
+    fn make_ops() -> (Op, Op, Op, Op, Op, Op, Op, Op, Op, Op, Op) {
+        let res_add = Op::ResidualAdd(ResidualAddOp {
+            out_dtype: DType::F16,
+        });
+        let norm = Op::Norm(NormOp {
+            kind: NormKind::Rms,
+            eps: 1e-5,
+            axis: NormAxis::Last,
+            weight_offset: 0.0,
+            out_dtype: DType::F16,
+        });
+        let quant_act = Op::QuantAct(QuantActOp {
+            scheme: QuantScheme::PerToken,
+            target: DType::I8,
+            smoothing: Smoothing::None,
+        });
+        let matmul = Op::Matmul(MatmulOp {
+            out_dtype: DType::F16,
+            epilogue: crate::Epilogue::None,
+            transpose_w: false,
+        });
+        let act = Op::Activation(ActivationOp {
+            act: ActivationKind::Silu,
+            clamp: None,
+        });
+        let act_mul = Op::ActMul(ActMulOp {
+            act: ActivationKind::Silu,
+            clamp: None,
+        });
+        let rope = Op::Rope(RopeOp {
+            rot_dim: 64,
+            theta: 10000.0,
+            style: RopeStyle::Neox,
+            scaling: RopeScaling::None,
+            mrope_sections: None,
+            out_dtype: DType::F16,
+        });
+        let state_write = Op::StateWriteKv(StateWriteKvOp {
+            cache_dtype: DType::F16,
+            scale_granularity: CacheScaleGranularity::PerTokenHead,
+            latent: None,
+            handle: StateHandle::new(0, StateKind::KvPaged),
+        });
+        let attn = Op::Attention(AttentionOp {
+            softmax_scale: 0.125,
+            mask: AttentionMask::Causal,
+            sinks: 0,
+            logit_softcap: None,
+            mla: None,
+            out_dtype: DType::F16,
+            handle: StateHandle::new(0, StateKind::KvPaged),
+        });
+        let logits = Op::LogitsPostprocess(LogitsPostprocessOp);
+        let sample = Op::Sample(SampleOp {
+            rng: RngAlgorithm::Philox4x32,
+        });
+        (
+            res_add,
+            norm,
+            quant_act,
+            matmul,
+            act,
+            act_mul,
+            rope,
+            state_write,
+            attn,
+            logits,
+            sample,
+        )
+    }
+
+    #[test]
+    fn fusion_table_encodes_all_nine_patterns() {
+        assert_eq!(FUSION_TABLE.len(), 9);
+        assert_eq!(fusion_table().len(), 9);
+    }
+
+    #[test]
+    fn typed_pair_queries_match_spec() {
+        let (
+            res_add,
+            norm,
+            quant_act,
+            matmul,
+            act,
+            act_mul,
+            rope,
+            state_write,
+            attn,
+            logits,
+            sample,
+        ) = make_ops();
+        let all_to_all = Op::AllToAll(AllToAllOp {
+            group: GroupId::new(0),
+            dtype: DType::F16,
+        });
+
+        assert_eq!(
+            is_permitted_pair(&res_add, &norm),
+            Some(FusionPattern::ResidualAddNorm)
+        );
+        assert_eq!(
+            is_permitted_pair(&norm, &quant_act),
+            Some(FusionPattern::NormQuantAct)
+        );
+        assert_eq!(
+            is_permitted_pair(&matmul, &res_add),
+            Some(FusionPattern::MatmulEpilogue)
+        );
+        assert_eq!(
+            is_permitted_pair(&matmul, &act),
+            Some(FusionPattern::MatmulEpilogue)
+        );
+        assert_eq!(
+            is_permitted_pair(&rope, &state_write),
+            Some(FusionPattern::RopeStateWriteKv)
+        );
+        assert_eq!(
+            is_permitted_pair(&rope, &attn),
+            Some(FusionPattern::RopeAttentionPrefill)
+        );
+        assert_eq!(
+            is_permitted_pair(&state_write, &attn),
+            Some(FusionPattern::StateWriteKvAttentionDecode)
+        );
+        assert_eq!(
+            is_permitted_pair(&logits, &sample),
+            Some(FusionPattern::LogitsPostprocessSample)
+        );
+        assert_eq!(
+            is_permitted_pair(&quant_act, &all_to_all),
+            Some(FusionPattern::QuantActAllToAll)
+        );
+
+        // Disallowed combinations
+        assert_eq!(is_permitted_pair(&norm, &matmul), None);
+        assert_eq!(is_permitted_pair(&attn, &norm), None);
+        assert_eq!(is_permitted_pair(&matmul, &act_mul), None); // Gated GEMM requires 2 producers!
+    }
+
+    #[test]
+    fn typed_gated_two_producer_matcher() {
+        let (_, _, _, matmul, _, act_mul, _, _, _, _, _) = make_ops();
+        let matmul_gate = matmul.clone();
+        let matmul_up = matmul.clone();
+
+        assert_eq!(
+            match_gated_pair(&matmul_gate, &matmul_up, &act_mul),
+            Some(FusionPattern::GatedMatmulActMul)
+        );
+    }
+
+    #[test]
+    fn no_multi_epilogue_chains() {
+        let (res_add, norm, _, matmul, act, _, _, _, _, _, _) = make_ops();
+        assert_eq!(
+            match_chain(&[&res_add, &norm]),
+            Some(FusionPattern::ResidualAddNorm)
+        );
+        assert_eq!(match_chain(&[&matmul]), None);
+        assert_eq!(match_chain(&[&matmul, &res_add, &act]), None);
+    }
+}

--- a/crates/r9v-ir/src/graph.rs
+++ b/crates/r9v-ir/src/graph.rs
@@ -1,0 +1,2076 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Step graph DAG, typed edges, stride tracking, and copy insertion (Spec 1 §3; card A1.2).
+//!
+//! A graph is a DAG of op instances over tensors. There is one graph kind,
+//! the **step graph**, captured per `(plan, rank, S_bucket, T_dec_bucket, T_pre_bucket, segment)`
+//! (Spec 1 §3.1; Spec 6 §5.1).
+//!
+//! The compiler tracks strides. A `copy` op is inserted only when a kernel's
+//! declared input requirement cannot be met by a view. Every inserted copy is
+//! reported in the graph summary (Spec 1 §3.3).
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::op::{CopyKind, CopyOp};
+use crate::{
+    Class, DType, Dim, IrError, LayoutId, Op, Placement, QuantScheme, ShapeSymbol, ShardLayout,
+    Tensor,
+};
+
+// -----------------------------------------------------------------------------
+// StepGraphKey and Bucket Functions (Spec 1 §3.1, §3.5)
+// -----------------------------------------------------------------------------
+
+/// Opaque plan identifier (Spec 1 §3.1, CONVENTIONS.md §3.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PlanId(u64);
+
+impl PlanId {
+    /// Creates a new plan identifier.
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the underlying raw integer value.
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Allowed discrete shape bucket sizes for S, T_dec, and T_pre (Spec 1 §3.5).
+pub const BUCKET_SIZES: [u32; 13] = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+
+/// Resolves a sequence count `S` to its discrete bucket size (Spec 1 §3.5).
+// DECISION(A1.2): bucket functions reject zero batch dims and values > 4096 with explicit IrError variants carrying axis and value; rejected wrapping or silent clamping to 4096 (Spec 1 §3.5).
+pub fn bucket_s(s: u32) -> Result<u32, IrError> {
+    if s == 0 {
+        return Err(IrError::InvalidBucket {
+            axis: "S",
+            value: s,
+        });
+    }
+    for &b in &BUCKET_SIZES {
+        if s <= b {
+            return Ok(b);
+        }
+    }
+    Err(IrError::BucketExceeded {
+        axis: "S",
+        value: s,
+        max: 4096,
+    })
+}
+
+/// Resolves a decode token count `T_dec` to its discrete bucket size (Spec 1 §3.5).
+pub fn bucket_t_dec(t_dec: u32) -> Result<u32, IrError> {
+    if t_dec == 0 {
+        return Err(IrError::InvalidBucket {
+            axis: "T_dec",
+            value: t_dec,
+        });
+    }
+    for &b in &BUCKET_SIZES {
+        if t_dec <= b {
+            return Ok(b);
+        }
+    }
+    Err(IrError::BucketExceeded {
+        axis: "T_dec",
+        value: t_dec,
+        max: 4096,
+    })
+}
+
+/// Resolves a prefill token count `T_pre` to its discrete bucket size (Spec 1 §3.5).
+///
+/// `T_pre = 0` is legal and represents a pure decode step with no prefill chunk.
+pub fn bucket_t_pre(t_pre: u32) -> Result<u32, IrError> {
+    if t_pre == 0 {
+        return Ok(0);
+    }
+    for &b in &BUCKET_SIZES {
+        if t_pre <= b {
+            return Ok(b);
+        }
+    }
+    Err(IrError::BucketExceeded {
+        axis: "T_pre",
+        value: t_pre,
+        max: 4096,
+    })
+}
+
+/// Resolves `(S, T_dec, T_pre)` into their discrete bucket tuple (Spec 1 §3.5).
+pub fn bucket_step(s: u32, t_dec: u32, t_pre: u32) -> Result<(u32, u32, u32), IrError> {
+    let mut problems = Vec::new();
+    let b_s = match bucket_s(s) {
+        Ok(v) => v,
+        Err(e) => {
+            problems.push(e);
+            0
+        }
+    };
+    let b_dec = match bucket_t_dec(t_dec) {
+        Ok(v) => v,
+        Err(e) => {
+            problems.push(e);
+            0
+        }
+    };
+    let b_pre = match bucket_t_pre(t_pre) {
+        Ok(v) => v,
+        Err(e) => {
+            problems.push(e);
+            0
+        }
+    };
+    IrError::from_problems(problems)?;
+    Ok((b_s, b_dec, b_pre))
+}
+
+/// Capture key for step graphs (Spec 1 §3.1; Spec 6 §5.1; card A1.2).
+///
+/// Graphs are captured per `(plan, rank, S_bucket, T_dec_bucket, T_pre_bucket, segment)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StepGraphKey {
+    /// Execution plan identifier.
+    pub plan_id: PlanId,
+    /// Device rank executing this graph instance.
+    pub rank: u32,
+    /// Bucketed sequence count `S`.
+    pub s: u32,
+    /// Bucketed decode token count `T_dec`.
+    pub t_dec: u32,
+    /// Bucketed prefill token count `T_pre` (0 if decode-only).
+    pub t_pre: u32,
+    /// Model segment index (for host-computed expert pipelining, Spec 6 §5.1).
+    pub segment: u32,
+}
+
+impl StepGraphKey {
+    /// Constructs a step-graph key, validating that dimensions match bucket boundaries.
+    pub fn new(
+        plan_id: PlanId,
+        rank: u32,
+        s: u32,
+        t_dec: u32,
+        t_pre: u32,
+        segment: u32,
+    ) -> Result<Self, IrError> {
+        let mut problems = Vec::new();
+        if s > 4096 {
+            problems.push(IrError::BucketExceeded {
+                axis: "S",
+                value: s,
+                max: 4096,
+            });
+        } else if !BUCKET_SIZES.contains(&s) {
+            problems.push(IrError::InvalidBucket {
+                axis: "S",
+                value: s,
+            });
+        }
+        if t_dec > 4096 {
+            problems.push(IrError::BucketExceeded {
+                axis: "T_dec",
+                value: t_dec,
+                max: 4096,
+            });
+        } else if !BUCKET_SIZES.contains(&t_dec) {
+            problems.push(IrError::InvalidBucket {
+                axis: "T_dec",
+                value: t_dec,
+            });
+        }
+        if t_pre > 4096 {
+            problems.push(IrError::BucketExceeded {
+                axis: "T_pre",
+                value: t_pre,
+                max: 4096,
+            });
+        } else if t_pre != 0 && !BUCKET_SIZES.contains(&t_pre) {
+            problems.push(IrError::InvalidBucket {
+                axis: "T_pre",
+                value: t_pre,
+            });
+        }
+        IrError::from_problems(problems)?;
+        Ok(Self {
+            plan_id,
+            rank,
+            s,
+            t_dec,
+            t_pre,
+            segment,
+        })
+    }
+
+    /// Constructs a step-graph key by bucketing raw counts.
+    pub fn from_unbucketed(
+        plan_id: PlanId,
+        rank: u32,
+        raw_s: u32,
+        raw_t_dec: u32,
+        raw_t_pre: u32,
+        segment: u32,
+    ) -> Result<Self, IrError> {
+        let (s, t_dec, t_pre) = bucket_step(raw_s, raw_t_dec, raw_t_pre)?;
+        Ok(Self {
+            plan_id,
+            rank,
+            s,
+            t_dec,
+            t_pre,
+            segment,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// External Inputs and Outputs (Spec 1 §3.2)
+// -----------------------------------------------------------------------------
+
+/// Closed set of external inputs provided to a step graph (Spec 1 §3.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExternalInputKind {
+    /// Token IDs batch `[T] u32`.
+    TokenIds,
+    /// Batch metadata struct.
+    BatchMeta,
+    /// PRNG states per sequence `[S]`.
+    RngState,
+    /// N-gram staging rows gathered by host `[T, Np, Dn]`.
+    GatherStaging,
+    /// Grammar acceptance mask per sequence and token position `[S, q, V] bool`.
+    GrammarMask,
+    /// Per-sequence sampling parameters.
+    SamplingParams,
+    /// Multimodal embedding override tensor `[T, Dm]`.
+    EmbedOverride,
+    /// Multimodal embedding replacement mask `[T] bool`.
+    EmbedMask,
+}
+
+impl ExternalInputKind {
+    /// Returns true if this external input kind represents a tensor-backed edge (Spec 1 §3.2, SI-12).
+    pub const fn is_tensor_backed(&self) -> bool {
+        match self {
+            Self::TokenIds
+            | Self::GatherStaging
+            | Self::GrammarMask
+            | Self::EmbedOverride
+            | Self::EmbedMask => true,
+            Self::BatchMeta | Self::SamplingParams | Self::RngState => false,
+        }
+    }
+}
+
+/// Closed set of external outputs emitted by a step graph (Spec 1 §3.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExternalOutputKind {
+    /// Sampled token IDs `[S, k+1] u32`.
+    Sampled,
+    /// Number of accepted tokens per sequence `[S] u32`.
+    AcceptLen,
+    /// Unnormalized output logits (optional, for logprobs).
+    Logits,
+    /// Pre-lm_head final hidden state `[T, Dm]` (optional, for proposers).
+    Hidden,
+    /// Updated PRNG states per sequence `[S]`.
+    UpdatedRngState,
+}
+
+impl ExternalOutputKind {
+    /// Returns true if this external output kind represents a tensor-backed edge (Spec 1 §3.2, SI-12).
+    pub const fn is_tensor_backed(&self) -> bool {
+        match self {
+            Self::Sampled | Self::AcceptLen | Self::Logits | Self::Hidden => true,
+            Self::UpdatedRngState => false,
+        }
+    }
+}
+
+/// External input binding registered with a step graph (Spec 1 §3.2, SI-12).
+// DECISION(A1.2): structured BatchMeta, SamplingParams, and RngState are registered without fake Tensor descriptors, while tensor-backed inputs require valid Tensors and create edges; rejected synthesizing dummy Tensor descriptors for metadata (Spec 1 §3.1, §3.2; SI-12).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalInput {
+    /// Tensor-backed external input bound to a specific DAG edge.
+    Tensor {
+        /// Semantic external input kind.
+        kind: ExternalInputKind,
+        /// Edge identifier carrying the tensor.
+        edge: EdgeId,
+    },
+    /// Non-tensor batch execution metadata (Spec 1 §2.5, §3.2).
+    BatchMeta,
+    /// Non-tensor per-sequence sampling parameters (Spec 1 §3.2).
+    SamplingParams,
+    /// Non-tensor PRNG state per sequence (Spec 1 §3.2).
+    RngState,
+}
+
+impl ExternalInput {
+    /// Returns the semantic kind of this external input.
+    pub const fn kind(&self) -> ExternalInputKind {
+        match self {
+            Self::Tensor { kind, .. } => *kind,
+            Self::BatchMeta => ExternalInputKind::BatchMeta,
+            Self::SamplingParams => ExternalInputKind::SamplingParams,
+            Self::RngState => ExternalInputKind::RngState,
+        }
+    }
+
+    /// Returns the associated edge ID if this is a tensor-backed input.
+    pub const fn edge_id(&self) -> Option<EdgeId> {
+        match self {
+            Self::Tensor { edge, .. } => Some(*edge),
+            Self::BatchMeta | Self::SamplingParams | Self::RngState => None,
+        }
+    }
+}
+
+/// External output binding registered with a step graph (Spec 1 §3.2, SI-12).
+// DECISION(A1.2): updated RngState is registered as an explicit non-tensor external output binding without a fake Tensor descriptor or EdgeId, while tensor-backed outputs bind to producing DAG edges; rejected synthesizing dummy Tensor descriptors for state (Spec 1 §3.2; SI-12).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExternalOutput {
+    /// Tensor-backed external output bound to a specific DAG edge.
+    Tensor {
+        /// Semantic external output kind.
+        kind: ExternalOutputKind,
+        /// Edge identifier producing the output tensor.
+        edge: EdgeId,
+    },
+    /// Non-tensor updated PRNG state per sequence (Spec 1 §3.2).
+    UpdatedRngState,
+}
+
+impl ExternalOutput {
+    /// Returns the semantic kind of this external output.
+    pub const fn kind(&self) -> ExternalOutputKind {
+        match self {
+            Self::Tensor { kind, .. } => *kind,
+            Self::UpdatedRngState => ExternalOutputKind::UpdatedRngState,
+        }
+    }
+
+    /// Returns the associated edge ID if this is a tensor-backed output.
+    pub const fn edge_id(&self) -> Option<EdgeId> {
+        match self {
+            Self::Tensor { edge, .. } => Some(*edge),
+            Self::UpdatedRngState => None,
+        }
+    }
+}
+
+fn bucket_dim_matches(dim: Dim, concrete: u32, symbolic: ShapeSymbol) -> bool {
+    matches!(dim, Dim::Concrete(value) if value == concrete)
+        || matches!(dim, Dim::Symbolic(value) if value == symbolic)
+}
+
+fn validate_external_tensor_common(
+    role: &'static str,
+    tensor: &Tensor,
+    expected_rank: usize,
+    expected_dtypes: &[DType],
+    expected_class: Class,
+    device_rank: u32,
+) -> Vec<IrError> {
+    let mut problems = Vec::new();
+    if tensor.shape().len() != expected_rank {
+        problems.push(IrError::OpRankMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            expected: expected_rank,
+            got: tensor.shape().len(),
+        });
+    }
+    if !expected_dtypes.contains(&tensor.dtype()) {
+        problems.push(IrError::OpDTypeMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            expected: expected_dtypes.to_vec().into_boxed_slice(),
+            got: tensor.dtype(),
+        });
+    }
+    if tensor.class() != expected_class {
+        problems.push(IrError::OpClassMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            expected: expected_class,
+            got: tensor.class(),
+        });
+    }
+    if tensor.layout() != LayoutId::CONTIGUOUS {
+        problems.push(IrError::OpLayoutMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            expected: LayoutId::CONTIGUOUS,
+            got: tensor.layout(),
+        });
+    }
+    if tensor.placement() != (Placement::Device { rank: device_rank }) {
+        problems.push(IrError::OpPlacementMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            placement: tensor.placement(),
+        });
+    }
+    problems
+}
+
+type ExternalTensorContract = (
+    &'static str,
+    usize,
+    &'static [DType],
+    Class,
+    Option<(u32, ShapeSymbol)>,
+);
+
+fn validate_external_input_tensor(
+    key: StepGraphKey,
+    kind: ExternalInputKind,
+    tensor: &Tensor,
+) -> Result<(), IrError> {
+    let total_tokens = key.t_dec.saturating_add(key.t_pre);
+    let (role, rank, dtypes, class, leading): ExternalTensorContract = match kind {
+        ExternalInputKind::TokenIds => (
+            "token_ids",
+            1,
+            &[DType::U32],
+            Class::Activation,
+            Some((total_tokens, ShapeSymbol::T)),
+        ),
+        ExternalInputKind::GatherStaging => (
+            "gather_staging",
+            3,
+            &[DType::I4, DType::I8],
+            Class::Staging,
+            Some((total_tokens, ShapeSymbol::T)),
+        ),
+        ExternalInputKind::GrammarMask => (
+            "grammar_mask",
+            3,
+            &[DType::Bool],
+            Class::Activation,
+            Some((key.s, ShapeSymbol::S)),
+        ),
+        ExternalInputKind::EmbedOverride => (
+            "embed_override",
+            2,
+            &[DType::F16, DType::Bf16, DType::F32],
+            Class::Activation,
+            Some((total_tokens, ShapeSymbol::T)),
+        ),
+        ExternalInputKind::EmbedMask => (
+            "embed_mask",
+            1,
+            &[DType::Bool],
+            Class::Activation,
+            Some((total_tokens, ShapeSymbol::T)),
+        ),
+        ExternalInputKind::BatchMeta
+        | ExternalInputKind::RngState
+        | ExternalInputKind::SamplingParams => {
+            return Err(IrError::OpAttributeInvalid {
+                op: "add_external_input",
+                attribute: "kind",
+                reason: format!(
+                    "{kind:?} is non-tensor structured data and cannot bind a Tensor edge"
+                ),
+            });
+        }
+    };
+
+    let mut problems = validate_external_tensor_common(role, tensor, rank, dtypes, class, key.rank);
+    let quant_is_valid = match kind {
+        ExternalInputKind::GatherStaging => {
+            matches!(tensor.quant(), QuantScheme::Scheme(_))
+        }
+        ExternalInputKind::TokenIds
+        | ExternalInputKind::GrammarMask
+        | ExternalInputKind::EmbedOverride
+        | ExternalInputKind::EmbedMask => tensor.quant() == QuantScheme::None,
+        ExternalInputKind::BatchMeta
+        | ExternalInputKind::RngState
+        | ExternalInputKind::SamplingParams => false,
+    };
+    if !quant_is_valid {
+        problems.push(IrError::OpQuantMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            quant: tensor.quant(),
+        });
+    }
+    if let Some((concrete, symbolic)) = leading {
+        if let Some(&dim) = tensor.shape().first() {
+            if !bucket_dim_matches(dim, concrete, symbolic) {
+                problems.push(IrError::OpShapeMismatch {
+                    op: "step_graph_external",
+                    tensor: role,
+                    detail: format!(
+                        "leading dimension must be {concrete} for this bucket or symbolic {symbolic:?}, got {dim:?}"
+                    ),
+                });
+            }
+        }
+    }
+    IrError::from_problems(problems)
+}
+
+fn validate_external_output_tensor(
+    key: StepGraphKey,
+    kind: ExternalOutputKind,
+    tensor: &Tensor,
+) -> Result<(), IrError> {
+    let total_tokens = key.t_dec.saturating_add(key.t_pre);
+    let (role, rank, dtypes, leading): (&'static str, usize, &[DType], Option<(u32, ShapeSymbol)>) =
+        match kind {
+            ExternalOutputKind::Sampled => {
+                ("sampled", 2, &[DType::U32], Some((key.s, ShapeSymbol::S)))
+            }
+            ExternalOutputKind::AcceptLen => (
+                "accept_len",
+                1,
+                &[DType::U32],
+                Some((key.s, ShapeSymbol::S)),
+            ),
+            ExternalOutputKind::Logits => {
+                ("logits", 3, &[DType::F32], Some((key.s, ShapeSymbol::S)))
+            }
+            ExternalOutputKind::Hidden => (
+                "hidden",
+                2,
+                &[DType::F16, DType::Bf16, DType::F32],
+                Some((total_tokens, ShapeSymbol::T)),
+            ),
+            ExternalOutputKind::UpdatedRngState => {
+                return Err(IrError::OpAttributeInvalid {
+                op: "add_external_output",
+                attribute: "kind",
+                reason: "UpdatedRngState is non-tensor structured data and cannot bind a Tensor edge"
+                    .to_string(),
+            });
+            }
+        };
+
+    let mut problems =
+        validate_external_tensor_common(role, tensor, rank, dtypes, Class::Activation, key.rank);
+    if tensor.quant() != QuantScheme::None {
+        problems.push(IrError::OpQuantMismatch {
+            op: "step_graph_external",
+            tensor: role,
+            quant: tensor.quant(),
+        });
+    }
+    if let Some((concrete, symbolic)) = leading {
+        if let Some(&dim) = tensor.shape().first() {
+            if !bucket_dim_matches(dim, concrete, symbolic) {
+                problems.push(IrError::OpShapeMismatch {
+                    op: "step_graph_external",
+                    tensor: role,
+                    detail: format!(
+                        "leading dimension must be {concrete} for this bucket or symbolic {symbolic:?}, got {dim:?}"
+                    ),
+                });
+            }
+        }
+    }
+    IrError::from_problems(problems)
+}
+
+// -----------------------------------------------------------------------------
+// DAG Types, Stride Requirements, and Stride Tracking (Spec 1 §3.1, §3.3)
+// -----------------------------------------------------------------------------
+
+/// Unique node index in a `Graph`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NodeId(pub usize);
+
+/// Unique edge index in a `Graph`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EdgeId(pub usize);
+
+/// Closed set of input stride requirements enforced by kernel implementations (Spec 1 §2.3, §3.3; card A1.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum StrideRequirement {
+    /// The kernel accepts any stride configuration (e.g. elementwise or stride-aware kernels).
+    #[default]
+    Any,
+    /// The kernel requires standard row-major contiguous strides.
+    Contiguous,
+}
+
+impl StrideRequirement {
+    /// Returns true if the provided strides satisfy this requirement for the given shape.
+    pub fn is_satisfied(&self, strides: &[i64], shape: &[Dim]) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Contiguous => strides == compute_contiguous_strides(shape),
+        }
+    }
+}
+
+/// Computes standard row-major contiguous strides for a shape (Spec 1 §2.3, §3.3).
+// DECISION(A1.2): symbolic dimensions use a synthetic non-unit extent for stride
+// comparison. A unit extent would collapse every symbolic stride to one and make
+// transposed symbolic views appear contiguous.
+pub fn compute_contiguous_strides(shape: &[Dim]) -> Vec<i64> {
+    let mut strides = vec![1i64; shape.len()];
+    if shape.is_empty() {
+        return strides;
+    }
+    let mut stride = 1i64;
+    for i in (0..shape.len()).rev() {
+        strides[i] = stride;
+        let extent = match shape[i] {
+            Dim::Concrete(c) => c as i64,
+            Dim::Symbolic(_) => 2i64,
+        };
+        stride = stride.saturating_mul(extent.max(1));
+    }
+    strides
+}
+
+fn concrete_element_count(shape: &[Dim]) -> Option<u128> {
+    shape.iter().try_fold(1u128, |count, dim| match dim {
+        Dim::Concrete(extent) => Some(count * u128::from(*extent)),
+        Dim::Symbolic(_) => None,
+    })
+}
+
+/// A typed tensor edge in the graph DAG (Spec 1 §3.1, §3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphEdge {
+    /// Unique edge identifier.
+    pub id: EdgeId,
+    /// Tensor metadata (shape, dtype, quant, layout, placement, sharding, class).
+    pub tensor: Tensor,
+    /// Memory strides tracked across views and transposes.
+    pub strides: Vec<i64>,
+    /// Parent edge for a metadata-only view, or `None` for source and op-produced edges.
+    pub source_edge: Option<EdgeId>,
+}
+
+impl GraphEdge {
+    /// Returns true if this edge has standard contiguous row-major strides.
+    pub fn is_contiguous(&self) -> bool {
+        let expected = compute_contiguous_strides(self.tensor.shape());
+        self.strides == expected
+    }
+}
+
+/// A node in the step graph DAG (Spec 1 §3.1).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphNode {
+    /// Unique node identifier.
+    pub id: NodeId,
+    /// Operation descriptor.
+    pub op: Op,
+    /// Incoming input edge IDs in signature order.
+    pub inputs: Vec<EdgeId>,
+    /// Per-input stride requirements in signature order (Spec 1 §3.3).
+    pub input_requirements: Vec<StrideRequirement>,
+    /// Outgoing output edge IDs in signature order.
+    pub outputs: Vec<EdgeId>,
+}
+
+/// Record of an explicit copy inserted due to a stride mismatch (Spec 1 §3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InsertedCopy {
+    /// NodeId of the inserted `Copy` op.
+    pub copy_node: NodeId,
+    /// EdgeId carrying the non-contiguous source tensor.
+    pub source_edge: EdgeId,
+    /// EdgeId carrying the newly contiguized destination tensor.
+    pub dest_edge: EdgeId,
+    /// Consumer nodes whose inputs were rewired to the shared copy output.
+    pub consumer_nodes: Vec<NodeId>,
+    /// Actual memory strides before contiguization.
+    pub actual_strides: Vec<i64>,
+    /// Expected contiguous strides required by the consumer kernel.
+    pub expected_strides: Vec<i64>,
+    /// Diagnostic explanation.
+    pub reason: &'static str,
+}
+
+/// High-level report of a captured step graph (Spec 1 §3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphSummary {
+    /// Step-graph key.
+    pub key: StepGraphKey,
+    /// Total number of operation nodes in the DAG.
+    pub op_count: usize,
+    /// Total number of tensor edges in the DAG.
+    pub edge_count: usize,
+    /// Registered external inputs.
+    pub external_inputs: Vec<ExternalInputKind>,
+    /// Registered external outputs.
+    pub external_outputs: Vec<ExternalOutputKind>,
+    /// All copies inserted by the compiler on stride mismatches.
+    pub inserted_copies: Vec<InsertedCopy>,
+}
+
+impl GraphSummary {
+    /// Returns the number of copies inserted to resolve stride mismatches.
+    pub fn inserted_copy_count(&self) -> usize {
+        self.inserted_copies.len()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Graph DAG Implementation
+// -----------------------------------------------------------------------------
+
+/// Step graph DAG (Spec 1 §3.1, §3.3; card A1.2).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Graph {
+    key: StepGraphKey,
+    nodes: Vec<GraphNode>,
+    edges: Vec<GraphEdge>,
+    external_inputs: Vec<ExternalInput>,
+    external_outputs: Vec<ExternalOutput>,
+    inserted_copies: Vec<InsertedCopy>,
+}
+
+impl Graph {
+    /// Creates an empty step graph with the given capture key.
+    pub fn new(key: StepGraphKey) -> Self {
+        Self {
+            key,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            external_inputs: Vec::new(),
+            external_outputs: Vec::new(),
+            inserted_copies: Vec::new(),
+        }
+    }
+
+    /// Step graph capture key.
+    pub fn key(&self) -> StepGraphKey {
+        self.key
+    }
+
+    /// Returns a slice of all op nodes in insertion order.
+    pub fn nodes(&self) -> &[GraphNode] {
+        &self.nodes
+    }
+
+    /// Returns a slice of all tensor edges.
+    pub fn edges(&self) -> &[GraphEdge] {
+        &self.edges
+    }
+
+    /// Returns a slice of registered external inputs.
+    pub fn external_inputs(&self) -> &[ExternalInput] {
+        &self.external_inputs
+    }
+
+    /// Returns a slice of registered external outputs.
+    pub fn external_outputs(&self) -> &[ExternalOutput] {
+        &self.external_outputs
+    }
+
+    /// Returns a slice of inserted copy records.
+    pub fn inserted_copies(&self) -> &[InsertedCopy] {
+        &self.inserted_copies
+    }
+
+    fn push_tensor_edge(&mut self, tensor: Tensor) -> EdgeId {
+        let edge_id = EdgeId(self.edges.len());
+        let strides = compute_contiguous_strides(tensor.shape());
+        self.edges.push(GraphEdge {
+            id: edge_id,
+            tensor,
+            strides,
+            source_edge: None,
+        });
+        edge_id
+    }
+
+    /// Adds a graph-owned weight, parameter, or state source and returns its edge.
+    ///
+    /// Request-time activation and staging sources must use the typed external
+    /// input API; they cannot bypass the Spec 1 §3.2 signature.
+    pub fn add_tensor(&mut self, tensor: Tensor) -> Result<EdgeId, IrError> {
+        let mut problems = Vec::new();
+        if !matches!(tensor.class(), Class::Weight | Class::Param | Class::State) {
+            problems.push(IrError::GraphSourceClassInvalid {
+                class: tensor.class(),
+            });
+        }
+        if let Placement::Device { rank } = tensor.placement() {
+            if rank != self.key.rank {
+                problems.push(IrError::GraphTensorRankMismatch {
+                    edge: self.edges.len(),
+                    tensor_rank: rank,
+                    graph_rank: self.key.rank,
+                });
+            }
+        }
+        IrError::from_problems(problems)?;
+        Ok(self.push_tensor_edge(tensor))
+    }
+
+    /// Registers an external input tensor, creating and returning an input edge (Spec 1 §3.2).
+    ///
+    /// Non-tensor inputs (`BatchMeta`, `SamplingParams`, `RngState`) must be registered via
+    /// [`add_external_non_tensor`](Self::add_external_non_tensor) or dedicated convenience methods
+    /// without fake tensor descriptors.
+    pub fn add_external_input(
+        &mut self,
+        kind: ExternalInputKind,
+        tensor: Tensor,
+    ) -> Result<EdgeId, IrError> {
+        if !kind.is_tensor_backed() {
+            return Err(IrError::OpAttributeInvalid {
+                op: "add_external_input",
+                attribute: "kind",
+                reason: format!(
+                    "{kind:?} is a non-tensor input; register without a fake Tensor descriptor via add_external_non_tensor or convenience method"
+                ),
+            });
+        }
+
+        if self
+            .external_inputs
+            .iter()
+            .any(|input| input.kind() == kind)
+        {
+            return Err(IrError::OpAttributeInvalid {
+                op: "add_external_input",
+                attribute: "kind",
+                reason: format!("duplicate {kind:?} external input"),
+            });
+        }
+        validate_external_input_tensor(self.key, kind, &tensor)?;
+
+        let edge_id = self.push_tensor_edge(tensor);
+        self.external_inputs.push(ExternalInput::Tensor {
+            kind,
+            edge: edge_id,
+        });
+        Ok(edge_id)
+    }
+
+    /// Registers a non-tensor external input (`BatchMeta`, `SamplingParams`, or `RngState`) without a fake tensor descriptor (Spec 1 §3.2, SI-12).
+    pub fn add_external_non_tensor(&mut self, kind: ExternalInputKind) -> Result<(), IrError> {
+        match kind {
+            ExternalInputKind::BatchMeta => {
+                if self
+                    .external_inputs
+                    .iter()
+                    .any(|i| matches!(i, ExternalInput::BatchMeta))
+                {
+                    return Err(IrError::OpAttributeInvalid {
+                        op: "add_external_non_tensor",
+                        attribute: "kind",
+                        reason: "duplicate BatchMeta external input; step graph admits exactly one BatchMeta".to_string(),
+                    });
+                }
+                self.external_inputs.push(ExternalInput::BatchMeta);
+                Ok(())
+            }
+            ExternalInputKind::SamplingParams => {
+                if self
+                    .external_inputs
+                    .iter()
+                    .any(|i| matches!(i, ExternalInput::SamplingParams))
+                {
+                    return Err(IrError::OpAttributeInvalid {
+                        op: "add_external_non_tensor",
+                        attribute: "kind",
+                        reason: "duplicate SamplingParams external input; step graph admits exactly one SamplingParams".to_string(),
+                    });
+                }
+                self.external_inputs.push(ExternalInput::SamplingParams);
+                Ok(())
+            }
+            ExternalInputKind::RngState => {
+                if self
+                    .external_inputs
+                    .iter()
+                    .any(|i| matches!(i, ExternalInput::RngState))
+                {
+                    return Err(IrError::OpAttributeInvalid {
+                        op: "add_external_non_tensor",
+                        attribute: "kind",
+                        reason: "duplicate RngState external input; step graph admits exactly one RngState".to_string(),
+                    });
+                }
+                self.external_inputs.push(ExternalInput::RngState);
+                Ok(())
+            }
+            ExternalInputKind::TokenIds
+            | ExternalInputKind::GatherStaging
+            | ExternalInputKind::GrammarMask
+            | ExternalInputKind::EmbedOverride
+            | ExternalInputKind::EmbedMask => Err(IrError::OpAttributeInvalid {
+                op: "add_external_non_tensor",
+                attribute: "kind",
+                reason: format!(
+                    "{kind:?} is a tensor-backed input; register via add_external_input with a valid Tensor descriptor"
+                ),
+            }),
+        }
+    }
+
+    /// Registers the non-tensor `BatchMeta` external input signature (Spec 1 §2.5, §3.2).
+    pub fn add_batch_meta_input(&mut self) -> Result<(), IrError> {
+        self.add_external_non_tensor(ExternalInputKind::BatchMeta)
+    }
+
+    /// Registers the non-tensor `SamplingParams` external input signature (Spec 1 §3.2).
+    pub fn add_sampling_params_input(&mut self) -> Result<(), IrError> {
+        self.add_external_non_tensor(ExternalInputKind::SamplingParams)
+    }
+
+    /// Registers the non-tensor `RngState` external input signature (Spec 1 §3.2).
+    pub fn add_rng_state_input(&mut self) -> Result<(), IrError> {
+        self.add_external_non_tensor(ExternalInputKind::RngState)
+    }
+
+    /// Registers an external output, binding it to an existing edge (Spec 1 §3.2).
+    ///
+    /// Non-tensor outputs (`UpdatedRngState`) must be registered via
+    /// [`add_external_non_tensor_output`](Self::add_external_non_tensor_output) or
+    /// [`add_updated_rng_state_output`](Self::add_updated_rng_state_output).
+    pub fn add_external_output(
+        &mut self,
+        kind: ExternalOutputKind,
+        edge: EdgeId,
+    ) -> Result<(), IrError> {
+        if !kind.is_tensor_backed() {
+            return Err(IrError::OpAttributeInvalid {
+                op: "add_external_output",
+                attribute: "kind",
+                reason: format!(
+                    "{kind:?} is a non-tensor output; register without a fake Tensor descriptor via add_external_non_tensor_output or add_updated_rng_state_output"
+                ),
+            });
+        }
+        if edge.0 >= self.edges.len() {
+            return Err(IrError::GraphEdgeNotFound { edge: edge.0 });
+        }
+        if self
+            .external_outputs
+            .iter()
+            .any(|output| output.kind() == kind)
+        {
+            return Err(IrError::OpAttributeInvalid {
+                op: "add_external_output",
+                attribute: "kind",
+                reason: format!("duplicate {kind:?} external output"),
+            });
+        }
+        validate_external_output_tensor(self.key, kind, &self.edges[edge.0].tensor)?;
+        let producers = self.producer_map();
+        if self.resolve_producer(edge, &producers).is_none() {
+            return Err(IrError::GraphExternalOutputUnproduced { kind, edge: edge.0 });
+        }
+        self.external_outputs
+            .push(ExternalOutput::Tensor { kind, edge });
+        Ok(())
+    }
+
+    /// Registers a non-tensor external output (`UpdatedRngState`) without a fake tensor descriptor (Spec 1 §3.2, SI-12).
+    pub fn add_external_non_tensor_output(
+        &mut self,
+        kind: ExternalOutputKind,
+    ) -> Result<(), IrError> {
+        match kind {
+            ExternalOutputKind::UpdatedRngState => {
+                if self
+                    .external_outputs
+                    .iter()
+                    .any(|o| matches!(o, ExternalOutput::UpdatedRngState))
+                {
+                    return Err(IrError::OpAttributeInvalid {
+                        op: "add_external_non_tensor_output",
+                        attribute: "kind",
+                        reason: "duplicate UpdatedRngState external output; step graph admits exactly one UpdatedRngState".to_string(),
+                    });
+                }
+                self.external_outputs.push(ExternalOutput::UpdatedRngState);
+                Ok(())
+            }
+            ExternalOutputKind::Sampled
+            | ExternalOutputKind::AcceptLen
+            | ExternalOutputKind::Logits
+            | ExternalOutputKind::Hidden => Err(IrError::OpAttributeInvalid {
+                op: "add_external_non_tensor_output",
+                attribute: "kind",
+                reason: format!(
+                    "{kind:?} is a tensor-backed output; register via add_external_output with a valid EdgeId"
+                ),
+            }),
+        }
+    }
+
+    /// Registers the non-tensor `UpdatedRngState` external output signature (Spec 1 §3.2).
+    pub fn add_updated_rng_state_output(&mut self) -> Result<(), IrError> {
+        self.add_external_non_tensor_output(ExternalOutputKind::UpdatedRngState)
+    }
+
+    /// Adds an operation node to the graph without imposing a stride requirement.
+    ///
+    /// Kernels that require contiguous inputs use
+    /// [`add_op_with_requirements`](Self::add_op_with_requirements) to declare it.
+    pub fn add_op(
+        &mut self,
+        op: Op,
+        input_edges: &[EdgeId],
+        output_tensors: &[Tensor],
+    ) -> Result<NodeId, IrError> {
+        let default_requirements = vec![StrideRequirement::Any; input_edges.len()];
+        self.add_op_with_requirements(op, input_edges, &default_requirements, output_tensors)
+    }
+
+    /// Adds an operation node with explicit per-input stride requirements (Spec 1 §3.3; card A1.2).
+    pub fn add_op_with_requirements(
+        &mut self,
+        op: Op,
+        input_edges: &[EdgeId],
+        input_requirements: &[StrideRequirement],
+        output_tensors: &[Tensor],
+    ) -> Result<NodeId, IrError> {
+        let mut problems = Vec::new();
+
+        for &e in input_edges {
+            if e.0 >= self.edges.len() {
+                problems.push(IrError::GraphEdgeNotFound { edge: e.0 });
+            }
+        }
+
+        if input_requirements.len() != input_edges.len() {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "add_op",
+                expected: input_edges.len(),
+                got: input_requirements.len(),
+            });
+        }
+
+        IrError::from_problems(problems)?;
+
+        let node_id = NodeId(self.nodes.len());
+        let mut output_edge_ids = Vec::with_capacity(output_tensors.len());
+
+        for t in output_tensors {
+            let edge_id = EdgeId(self.edges.len());
+            let strides = compute_contiguous_strides(t.shape());
+            self.edges.push(GraphEdge {
+                id: edge_id,
+                tensor: t.clone(),
+                strides,
+                source_edge: None,
+            });
+            output_edge_ids.push(edge_id);
+        }
+
+        self.nodes.push(GraphNode {
+            id: node_id,
+            op,
+            inputs: input_edges.to_vec(),
+            input_requirements: input_requirements.to_vec(),
+            outputs: output_edge_ids,
+        });
+
+        Ok(node_id)
+    }
+
+    fn producer_map(&self) -> HashMap<EdgeId, usize> {
+        let mut producers = HashMap::new();
+        for node in &self.nodes {
+            for &output in &node.outputs {
+                producers.insert(output, node.id.0);
+            }
+        }
+        producers
+    }
+
+    fn resolve_producer(&self, edge: EdgeId, producers: &HashMap<EdgeId, usize>) -> Option<usize> {
+        let mut current = edge;
+        for _ in 0..=self.edges.len() {
+            if let Some(&producer) = producers.get(&current) {
+                return Some(producer);
+            }
+            current = self.edges.get(current.0)?.source_edge?;
+        }
+        None
+    }
+
+    /// Returns node IDs in dependency-safe execution order.
+    ///
+    /// Node IDs remain stable insertion identifiers, including across compiler
+    /// copy insertion. Executors use this order rather than assuming numeric
+    /// IDs are topologically sorted.
+    pub fn topological_order(&self) -> Result<Vec<NodeId>, IrError> {
+        let node_count = self.nodes.len();
+        let producers = self.producer_map();
+        let mut in_degree = vec![0usize; node_count];
+        let mut adjacency = vec![Vec::new(); node_count];
+        let mut problems = Vec::new();
+
+        for node in &self.nodes {
+            for &input in &node.inputs {
+                if input.0 >= self.edges.len() {
+                    problems.push(IrError::GraphEdgeNotFound { edge: input.0 });
+                } else if let Some(producer) = self.resolve_producer(input, &producers) {
+                    adjacency[producer].push(node.id.0);
+                    in_degree[node.id.0] += 1;
+                }
+            }
+        }
+        IrError::from_problems(problems)?;
+
+        let mut queue = VecDeque::new();
+        for (node, &degree) in in_degree.iter().enumerate() {
+            if degree == 0 {
+                queue.push_back(node);
+            }
+        }
+
+        let mut order = Vec::with_capacity(node_count);
+        while let Some(node) = queue.pop_front() {
+            order.push(NodeId(node));
+            for &consumer in &adjacency[node] {
+                in_degree[consumer] -= 1;
+                if in_degree[consumer] == 0 {
+                    queue.push_back(consumer);
+                }
+            }
+        }
+
+        if order.len() != node_count {
+            let node = in_degree.iter().position(|&degree| degree > 0).unwrap_or(0);
+            return Err(IrError::GraphCycle { node });
+        }
+        Ok(order)
+    }
+
+    /// Modifies the memory strides of an edge (e.g. for testing stride tracking).
+    pub fn set_edge_strides(&mut self, edge: EdgeId, strides: Vec<i64>) -> Result<(), IrError> {
+        if edge.0 >= self.edges.len() {
+            return Err(IrError::GraphEdgeNotFound { edge: edge.0 });
+        }
+
+        let rank = self.edges[edge.0].tensor.shape().len();
+        if strides.len() != rank {
+            return Err(IrError::OpRankMismatch {
+                op: "set_edge_strides",
+                tensor: "edge",
+                expected: rank,
+                got: strides.len(),
+            });
+        }
+
+        self.edges[edge.0].strides = strides;
+        Ok(())
+    }
+
+    /// Modifies the stride requirement for an existing node's input.
+    pub fn set_node_input_requirement(
+        &mut self,
+        node: NodeId,
+        input_pos: usize,
+        requirement: StrideRequirement,
+    ) -> Result<(), IrError> {
+        if node.0 >= self.nodes.len() {
+            return Err(IrError::GraphNodeNotFound { node: node.0 });
+        }
+        if input_pos >= self.nodes[node.0].inputs.len() {
+            return Err(IrError::OpInputCountMismatch {
+                op: "set_node_input_requirement",
+                expected: self.nodes[node.0].inputs.len(),
+                got: input_pos,
+            });
+        }
+
+        self.nodes[node.0].input_requirements[input_pos] = requirement;
+        Ok(())
+    }
+
+    /// Applies a dimension transpose permutation to an edge, updating logical shape
+    /// and retaining physical memory strides to model a view (Spec 1 §2.3).
+    pub fn transpose_edge(&mut self, edge: EdgeId, perm: &[usize]) -> Result<EdgeId, IrError> {
+        if edge.0 >= self.edges.len() {
+            return Err(IrError::GraphEdgeNotFound { edge: edge.0 });
+        }
+
+        let old_edge = &self.edges[edge.0];
+        let old_shape = old_edge.tensor.shape();
+        let rank = old_shape.len();
+
+        if perm.len() != rank {
+            return Err(IrError::OpRankMismatch {
+                op: "transpose_view",
+                tensor: "edge",
+                expected: rank,
+                got: perm.len(),
+            });
+        }
+
+        let mut problems = Vec::new();
+        let mut seen = vec![false; rank];
+        let mut out_of_bounds = Vec::new();
+        let mut duplicates = Vec::new();
+
+        for &p in perm {
+            if p >= rank {
+                out_of_bounds.push(p);
+            } else if seen[p] {
+                duplicates.push(p);
+            } else {
+                seen[p] = true;
+            }
+        }
+
+        if !out_of_bounds.is_empty() {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "transpose_view",
+                attribute: "perm",
+                reason: format!(
+                    "permutation indices {out_of_bounds:?} out of bounds for rank {rank}"
+                ),
+            });
+        }
+
+        if !duplicates.is_empty() {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "transpose_view",
+                attribute: "perm",
+                reason: format!("permutation contains duplicate axes: {duplicates:?}"),
+            });
+        }
+
+        let missing: Vec<usize> = seen
+            .iter()
+            .enumerate()
+            .filter(|(_, &s)| !s)
+            .map(|(i, _)| i)
+            .collect();
+        if !missing.is_empty() && duplicates.is_empty() && out_of_bounds.is_empty() {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "transpose_view",
+                attribute: "perm",
+                reason: format!("permutation missing axes: {missing:?}"),
+            });
+        }
+
+        IrError::from_problems(problems)?;
+
+        let mut new_shape = Vec::with_capacity(rank);
+        let mut new_strides = Vec::with_capacity(rank);
+        for &p in perm {
+            new_shape.push(old_shape[p]);
+            new_strides.push(old_edge.strides[p]);
+        }
+
+        let remap_axis = |old_axis: u32| -> u32 {
+            perm.iter()
+                .position(|&source_axis| source_axis == old_axis as usize)
+                .map_or(old_axis, |new_axis| new_axis as u32)
+        };
+        let new_sharding = match old_edge.tensor.sharding() {
+            ShardLayout::Replicated => ShardLayout::Replicated,
+            ShardLayout::ColShard { axis } => ShardLayout::ColShard {
+                axis: remap_axis(axis),
+            },
+            ShardLayout::RowShard { axis } => ShardLayout::RowShard {
+                axis: remap_axis(axis),
+            },
+            ShardLayout::HeadShard { heads } => ShardLayout::HeadShard { heads },
+            ShardLayout::ExpertShard { experts } => ShardLayout::ExpertShard { experts },
+            ShardLayout::Partial => ShardLayout::Partial,
+        };
+
+        let new_tensor = Tensor::new(
+            new_shape,
+            old_edge.tensor.dtype(),
+            old_edge.tensor.quant(),
+            old_edge.tensor.layout(),
+            old_edge.tensor.placement(),
+            new_sharding,
+            old_edge.tensor.class(),
+        )?;
+
+        let new_edge_id = EdgeId(self.edges.len());
+        self.edges.push(GraphEdge {
+            id: new_edge_id,
+            tensor: new_tensor,
+            strides: new_strides,
+            source_edge: Some(edge),
+        });
+
+        Ok(new_edge_id)
+    }
+
+    /// Creates a metadata-only contiguous reshape view of an edge (Spec 1 §2.3).
+    ///
+    /// Concrete shapes must preserve element count. Symbolic relations are
+    /// checked after capture, when all dimensions are concrete. A non-contiguous
+    /// source must first be materialized because its reshape strides cannot be
+    /// inferred as a row-major view.
+    pub fn reshape_edge(&mut self, edge: EdgeId, new_shape: Vec<Dim>) -> Result<EdgeId, IrError> {
+        if edge.0 >= self.edges.len() {
+            return Err(IrError::GraphEdgeNotFound { edge: edge.0 });
+        }
+
+        let old_edge = &self.edges[edge.0];
+        let expected_strides = compute_contiguous_strides(old_edge.tensor.shape());
+        if old_edge.strides != expected_strides {
+            return Err(IrError::StrideMismatch {
+                edge: edge.0,
+                actual: old_edge.strides.clone().into_boxed_slice(),
+                expected: expected_strides.into_boxed_slice(),
+            });
+        }
+        if old_edge.tensor.layout() != LayoutId::CONTIGUOUS {
+            return Err(IrError::OpLayoutMismatch {
+                op: "reshape_view",
+                tensor: "edge",
+                expected: LayoutId::CONTIGUOUS,
+                got: old_edge.tensor.layout(),
+            });
+        }
+        if new_shape != old_edge.tensor.shape()
+            && !matches!(
+                old_edge.tensor.sharding(),
+                ShardLayout::Replicated | ShardLayout::Partial
+            )
+        {
+            return Err(IrError::OpAttributeInvalid {
+                op: "reshape_view",
+                attribute: "sharding",
+                reason: format!(
+                    "reshape of {:?} requires an explicit sharding remap",
+                    old_edge.tensor.sharding()
+                ),
+            });
+        }
+        if let (Some(old_count), Some(new_count)) = (
+            concrete_element_count(old_edge.tensor.shape()),
+            concrete_element_count(&new_shape),
+        ) {
+            if old_count != new_count {
+                return Err(IrError::OpShapeMismatch {
+                    op: "reshape_view",
+                    tensor: "edge",
+                    detail: format!(
+                        "reshape must preserve element count, got {old_count} -> {new_count}"
+                    ),
+                });
+            }
+        }
+
+        let new_tensor = Tensor::new(
+            new_shape,
+            old_edge.tensor.dtype(),
+            old_edge.tensor.quant(),
+            old_edge.tensor.layout(),
+            old_edge.tensor.placement(),
+            old_edge.tensor.sharding(),
+            old_edge.tensor.class(),
+        )?;
+        let new_edge_id = EdgeId(self.edges.len());
+        let strides = compute_contiguous_strides(new_tensor.shape());
+        self.edges.push(GraphEdge {
+            id: new_edge_id,
+            tensor: new_tensor,
+            strides,
+            source_edge: Some(edge),
+        });
+        Ok(new_edge_id)
+    }
+
+    /// Rewires an input of a node to a new edge (used for graph transformations and tests).
+    pub fn rewire_node_input(
+        &mut self,
+        node: NodeId,
+        input_pos: usize,
+        new_edge: EdgeId,
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+        if node.0 >= self.nodes.len() {
+            problems.push(IrError::GraphNodeNotFound { node: node.0 });
+        }
+        if new_edge.0 >= self.edges.len() {
+            problems.push(IrError::GraphEdgeNotFound { edge: new_edge.0 });
+        }
+        if node.0 < self.nodes.len() && input_pos >= self.nodes[node.0].inputs.len() {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "rewire",
+                expected: self.nodes[node.0].inputs.len(),
+                got: input_pos,
+            });
+        }
+
+        IrError::from_problems(problems)?;
+
+        self.nodes[node.0].inputs[input_pos] = new_edge;
+        Ok(())
+    }
+
+    /// Scans the graph for stride mismatches on inputs to nodes and inserts
+    /// an explicit `CopyOp` where non-contiguous strides cannot be satisfied by a view (Spec 1 §3.3).
+    ///
+    /// Copies are deduplicated per source edge: all consumers requiring contiguous layout from
+    /// the same non-contiguous source edge share exactly one inserted copy node.
+    // DECISION(A1.2): materialize_copies checks explicit per-input StrideRequirement and inserts Contiguize copies only when a Contiguous requirement is failed by a view, deduplicating per source edge; rejected blanket contiguization of all noncontiguous edges or silent transmutation (Spec 1 §2.3, §3.3).
+    pub fn materialize_copies(&mut self) -> Result<usize, IrError> {
+        struct CopyPlan {
+            src_edge_id: EdgeId,
+            actual_strides: Vec<i64>,
+            expected_strides: Vec<i64>,
+            consumers: Vec<(usize, usize)>,
+        }
+
+        let mut plans: Vec<CopyPlan> = Vec::new();
+        let mut plan_by_source: HashMap<EdgeId, usize> = HashMap::new();
+        let mut existing_rewires: Vec<(EdgeId, usize, usize)> = Vec::new();
+
+        for (node_idx, node) in self.nodes.iter().enumerate() {
+            // Copy op itself accepts any stride configuration to contiguize it.
+            if matches!(node.op, Op::Copy(_)) {
+                continue;
+            }
+
+            for (input_pos, &edge_id) in node.inputs.iter().enumerate() {
+                let req = node
+                    .input_requirements
+                    .get(input_pos)
+                    .copied()
+                    .unwrap_or(StrideRequirement::Any);
+
+                match req {
+                    StrideRequirement::Any => {
+                        // Kernel accepts arbitrary strides, no copy inserted.
+                        continue;
+                    }
+                    StrideRequirement::Contiguous => {
+                        let edge = &self.edges[edge_id.0];
+                        let expected = compute_contiguous_strides(edge.tensor.shape());
+                        if edge.strides != expected {
+                            // Check if this source edge was already contiguized in a previous pass
+                            if let Some(existing) = self
+                                .inserted_copies
+                                .iter()
+                                .find(|c| c.source_edge == edge_id)
+                            {
+                                existing_rewires.push((existing.dest_edge, node_idx, input_pos));
+                            } else if let Some(&plan_idx) = plan_by_source.get(&edge_id) {
+                                plans[plan_idx].consumers.push((node_idx, input_pos));
+                            } else {
+                                let plan_idx = plans.len();
+                                plan_by_source.insert(edge_id, plan_idx);
+                                plans.push(CopyPlan {
+                                    src_edge_id: edge_id,
+                                    actual_strides: edge.strides.clone(),
+                                    expected_strides: expected,
+                                    consumers: vec![(node_idx, input_pos)],
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Apply rewires for previously inserted copies (incremental materialization)
+        for (dest_edge, node_idx, input_pos) in existing_rewires {
+            self.nodes[node_idx].inputs[input_pos] = dest_edge;
+            if let Some(existing) = self
+                .inserted_copies
+                .iter_mut()
+                .find(|c| c.dest_edge == dest_edge)
+            {
+                let consumer_node_id = NodeId(node_idx);
+                if !existing.consumer_nodes.contains(&consumer_node_id) {
+                    existing.consumer_nodes.push(consumer_node_id);
+                    existing.consumer_nodes.sort_by_key(|n| n.0);
+                }
+            }
+        }
+
+        let count = plans.len();
+        for plan in plans {
+            let src_edge = &self.edges[plan.src_edge_id.0];
+            let copy_out_tensor = Tensor::new(
+                src_edge.tensor.shape().to_vec(),
+                src_edge.tensor.dtype(),
+                src_edge.tensor.quant(),
+                LayoutId::CONTIGUOUS,
+                src_edge.tensor.placement(),
+                src_edge.tensor.sharding(),
+                src_edge.tensor.class(),
+            )?;
+
+            let copy_out_edge_id = EdgeId(self.edges.len());
+            let copy_out_strides = compute_contiguous_strides(copy_out_tensor.shape());
+            self.edges.push(GraphEdge {
+                id: copy_out_edge_id,
+                tensor: copy_out_tensor,
+                strides: copy_out_strides,
+                source_edge: None,
+            });
+
+            let copy_node_id = NodeId(self.nodes.len());
+            self.nodes.push(GraphNode {
+                id: copy_node_id,
+                op: Op::Copy(CopyOp {
+                    kind: CopyKind::Contiguize,
+                }),
+                inputs: vec![plan.src_edge_id],
+                input_requirements: vec![StrideRequirement::Any],
+                outputs: vec![copy_out_edge_id],
+            });
+
+            // Consumer lists are deterministic and deduplicated per source contiguization.
+            let mut consumer_nodes: Vec<NodeId> = plan
+                .consumers
+                .iter()
+                .map(|(node_idx, _)| NodeId(*node_idx))
+                .collect();
+            consumer_nodes.sort_by_key(|n| n.0);
+            consumer_nodes.dedup();
+
+            for &(node_idx, input_pos) in &plan.consumers {
+                self.nodes[node_idx].inputs[input_pos] = copy_out_edge_id;
+            }
+
+            self.inserted_copies.push(InsertedCopy {
+                copy_node: copy_node_id,
+                source_edge: plan.src_edge_id,
+                dest_edge: copy_out_edge_id,
+                consumer_nodes,
+                actual_strides: plan.actual_strides,
+                expected_strides: plan.expected_strides,
+                reason: "stride mismatch against contiguous kernel requirement",
+            });
+        }
+
+        Ok(count)
+    }
+
+    /// Validates graph structure: checks for cycles, validates every node's op constraints,
+    /// requires global structured inputs needed by Attention, LogitsPostprocess, Sample, and Verify,
+    /// and verifies edge references (Spec 1 §3.1, §3.2, §4).
+    // DECISION(A1.2): graph validation requires global structured inputs needed by Attention, LogitsPostprocess, Sample, and Verify (BatchMeta, SamplingParams, RngState); rejected deferring missing structured metadata checks to runtime (Spec 1 §3.2, §4.D, §4.F; SI-12).
+    pub fn validate(&self) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        for edge in &self.edges {
+            if let Placement::Device { rank } = edge.tensor.placement() {
+                if rank != self.key.rank {
+                    problems.push(IrError::GraphTensorRankMismatch {
+                        edge: edge.id.0,
+                        tensor_rank: rank,
+                        graph_rank: self.key.rank,
+                    });
+                }
+            }
+        }
+
+        // 1. Cycle detection includes metadata-only view dependencies.
+        if let Err(problem) = self.topological_order() {
+            match problem {
+                IrError::Multiple { problems: inner } => problems.extend(inner),
+                other => problems.push(other),
+            }
+        }
+
+        // 2. Global structured inputs requirement checks
+        let has_batch_meta = self
+            .external_inputs
+            .iter()
+            .any(|i| matches!(i, ExternalInput::BatchMeta));
+        let has_sampling_params = self
+            .external_inputs
+            .iter()
+            .any(|i| matches!(i, ExternalInput::SamplingParams));
+        let has_rng_state = self
+            .external_inputs
+            .iter()
+            .any(|i| matches!(i, ExternalInput::RngState));
+        let has_updated_rng_state = self
+            .external_outputs
+            .iter()
+            .any(|output| matches!(output, ExternalOutput::UpdatedRngState));
+
+        let mut needs_batch_meta_attention = false;
+        let mut needs_batch_meta_state_write = false;
+        let mut needs_sampling_params = false;
+        let mut needs_rng_sample = false;
+        let mut needs_rng_verify = false;
+
+        for node in &self.nodes {
+            match node.op {
+                Op::StateWriteKv(_) => needs_batch_meta_state_write = true,
+                Op::Attention(_) => needs_batch_meta_attention = true,
+                Op::LogitsPostprocess(_) => needs_sampling_params = true,
+                Op::Sample(_) => needs_rng_sample = true,
+                Op::Verify(_) => needs_rng_verify = true,
+                Op::EmbedGather(_)
+                | Op::NgramGather(_)
+                | Op::QuantAct(_)
+                | Op::Cast(_)
+                | Op::Copy(_)
+                | Op::GatherRows(_)
+                | Op::ScatterAddRows(_)
+                | Op::Norm(_)
+                | Op::ResidualAdd(_)
+                | Op::ActMul(_)
+                | Op::Activation(_)
+                | Op::Rope(_)
+                | Op::Matmul(_)
+                | Op::MoeRoute(_)
+                | Op::MoeFfn(_)
+                | Op::CausalConv1d(_)
+                | Op::LinearAttnScan(_)
+                | Op::AllReduce(_)
+                | Op::AllGather(_)
+                | Op::ReduceScatter(_)
+                | Op::AllToAll(_)
+                | Op::Send(_)
+                | Op::Recv(_)
+                | Op::Barrier(_) => {}
+            }
+        }
+
+        if needs_batch_meta_attention && !has_batch_meta {
+            problems.push(IrError::GraphExternalInputMissing {
+                kind: ExternalInputKind::BatchMeta,
+                required_by: "attention",
+            });
+        }
+        if needs_batch_meta_state_write && !has_batch_meta {
+            problems.push(IrError::GraphExternalInputMissing {
+                kind: ExternalInputKind::BatchMeta,
+                required_by: "state_write_kv",
+            });
+        }
+        if needs_sampling_params && !has_sampling_params {
+            problems.push(IrError::GraphExternalInputMissing {
+                kind: ExternalInputKind::SamplingParams,
+                required_by: "logits_postprocess",
+            });
+        }
+        if needs_rng_sample && !has_rng_state {
+            problems.push(IrError::GraphExternalInputMissing {
+                kind: ExternalInputKind::RngState,
+                required_by: "sample",
+            });
+        }
+        if needs_rng_verify && !has_rng_state {
+            problems.push(IrError::GraphExternalInputMissing {
+                kind: ExternalInputKind::RngState,
+                required_by: "verify",
+            });
+        }
+        if needs_rng_sample && !has_updated_rng_state {
+            problems.push(IrError::GraphExternalOutputMissing {
+                kind: ExternalOutputKind::UpdatedRngState,
+                required_by: "sample",
+            });
+        }
+        if needs_rng_verify && !has_updated_rng_state {
+            problems.push(IrError::GraphExternalOutputMissing {
+                kind: ExternalOutputKind::UpdatedRngState,
+                required_by: "verify",
+            });
+        }
+
+        // 3. Validate every node's op constraints over typed tensor edges
+        for node in &self.nodes {
+            let mut in_tensors = Vec::with_capacity(node.inputs.len());
+            let mut edge_missing = false;
+            for &e in &node.inputs {
+                if e.0 < self.edges.len() {
+                    in_tensors.push(self.edges[e.0].tensor.clone());
+                } else {
+                    problems.push(IrError::GraphEdgeNotFound { edge: e.0 });
+                    edge_missing = true;
+                }
+            }
+
+            let mut out_tensors = Vec::with_capacity(node.outputs.len());
+            for &e in &node.outputs {
+                if e.0 < self.edges.len() {
+                    out_tensors.push(self.edges[e.0].tensor.clone());
+                } else {
+                    problems.push(IrError::GraphEdgeNotFound { edge: e.0 });
+                    edge_missing = true;
+                }
+            }
+
+            if !edge_missing {
+                if let Err(problem) = node.op.validate(&in_tensors, &out_tensors) {
+                    match problem {
+                        IrError::Multiple { problems: inner } => problems.extend(inner),
+                        other => problems.push(other),
+                    }
+                }
+            }
+        }
+
+        // 4. Validate external outputs referencing DAG edges
+        for out in &self.external_outputs {
+            if let ExternalOutput::Tensor { edge, .. } = out {
+                if edge.0 >= self.edges.len() {
+                    problems.push(IrError::GraphEdgeNotFound { edge: edge.0 });
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Generates a graph summary report (Spec 1 §3.3).
+    pub fn summary(&self) -> GraphSummary {
+        GraphSummary {
+            key: self.key,
+            op_count: self.nodes.len(),
+            edge_count: self.edges.len(),
+            external_inputs: self.external_inputs.iter().map(|i| i.kind()).collect(),
+            external_outputs: self.external_outputs.iter().map(|o| o.kind()).collect(),
+            inserted_copies: self.inserted_copies.clone(),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Unit Tests (CONVENTIONS.md §4.1)
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::op::{
+        AttentionMask, AttentionOp, CacheScaleGranularity, CastOp, LogitsPostprocessOp,
+        RngAlgorithm, SampleOp, StateWriteKvOp, VerifyMethod, VerifyOp,
+    };
+    use crate::{Class, DType, Placement, QuantScheme, ShardLayout, StateHandle, StateKind};
+
+    fn make_tensor(shape: Vec<Dim>, dtype: DType) -> Tensor {
+        Tensor::new(
+            shape,
+            dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )
+        .expect("valid tensor")
+    }
+
+    #[test]
+    fn structured_non_tensor_contract_and_convenience_methods() {
+        let plan = PlanId::new(10);
+        let key = StepGraphKey::new(plan, 0, 4, 4, 0, 0).expect("valid key");
+        let mut graph = Graph::new(key);
+
+        // Register structured non-tensor inputs via convenience methods
+        graph.add_batch_meta_input().expect("batch meta registers");
+        graph
+            .add_sampling_params_input()
+            .expect("sampling params registers");
+        graph.add_rng_state_input().expect("rng state registers");
+
+        // Duplicate registration must be rejected
+        assert!(graph.add_batch_meta_input().is_err());
+        assert!(graph.add_sampling_params_input().is_err());
+        assert!(graph.add_rng_state_input().is_err());
+
+        // Registering non-tensor as tensor-backed with fake Tensor descriptor must fail
+        let fake_tensor = make_tensor(vec![Dim::Concrete(4)], DType::U32);
+        assert!(graph
+            .add_external_input(ExternalInputKind::BatchMeta, fake_tensor.clone())
+            .is_err());
+        assert!(graph
+            .add_external_input(ExternalInputKind::SamplingParams, fake_tensor.clone())
+            .is_err());
+        assert!(graph
+            .add_external_input(ExternalInputKind::RngState, fake_tensor)
+            .is_err());
+
+        // Registering tensor-backed kind via non-tensor registration must fail
+        assert!(graph
+            .add_external_non_tensor(ExternalInputKind::TokenIds)
+            .is_err());
+
+        // Register non-tensor output via convenience method
+        graph
+            .add_updated_rng_state_output()
+            .expect("updated rng state registers");
+        assert!(graph.add_updated_rng_state_output().is_err());
+
+        // Registering non-tensor output with a fake edge must fail
+        assert!(graph
+            .add_external_output(ExternalOutputKind::UpdatedRngState, EdgeId(0))
+            .is_err());
+
+        // Check bindings
+        assert_eq!(graph.external_inputs().len(), 3);
+        assert_eq!(graph.external_inputs()[0], ExternalInput::BatchMeta);
+        assert_eq!(graph.external_inputs()[1], ExternalInput::SamplingParams);
+        assert_eq!(graph.external_inputs()[2], ExternalInput::RngState);
+
+        assert_eq!(graph.external_outputs().len(), 1);
+        assert_eq!(graph.external_outputs()[0], ExternalOutput::UpdatedRngState);
+
+        // Summary correctly reflects all external inputs and outputs
+        let summary = graph.summary();
+        assert_eq!(
+            summary.external_inputs,
+            vec![
+                ExternalInputKind::BatchMeta,
+                ExternalInputKind::SamplingParams,
+                ExternalInputKind::RngState,
+            ]
+        );
+        assert_eq!(
+            summary.external_outputs,
+            vec![ExternalOutputKind::UpdatedRngState]
+        );
+    }
+
+    #[test]
+    fn graph_validation_requires_global_structured_inputs_and_outputs() {
+        let plan = PlanId::new(20);
+        let key = StepGraphKey::new(plan, 0, 4, 4, 0, 0).expect("valid key");
+
+        // 1. Attention requires BatchMeta
+        let mut g_attn = Graph::new(key);
+        let q_tensor = make_tensor(
+            vec![Dim::Concrete(4), Dim::Concrete(8), Dim::Concrete(64)],
+            DType::F16,
+        );
+        let flat_q = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(512)], DType::F16);
+        let e_flat_q = g_attn
+            .add_external_input(ExternalInputKind::EmbedOverride, flat_q)
+            .expect("flat q input");
+        let e_q = g_attn
+            .reshape_edge(
+                e_flat_q,
+                vec![Dim::Concrete(4), Dim::Concrete(8), Dim::Concrete(64)],
+            )
+            .expect("q reshape");
+        let attn_op = Op::Attention(AttentionOp {
+            softmax_scale: 0.125,
+            mask: AttentionMask::Causal,
+            sinks: 0,
+            logit_softcap: None,
+            mla: None,
+            out_dtype: DType::F16,
+            handle: StateHandle::new(0, StateKind::KvPaged),
+        });
+        g_attn
+            .add_op(attn_op, &[e_q], &[q_tensor])
+            .expect("add attention");
+        // Validation fails because BatchMeta is missing
+        assert!(g_attn.validate().is_err());
+        // Adding BatchMeta fixes it
+        g_attn.add_batch_meta_input().expect("add batch meta");
+        assert!(g_attn.validate().is_ok());
+
+        // 2. StateWriteKv consumes slot_map through BatchMeta.
+        let mut g_state_write = Graph::new(key);
+        let flat_k = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(16)], DType::F16);
+        let e_flat_k = g_state_write
+            .add_external_input(ExternalInputKind::EmbedOverride, flat_k)
+            .expect("flat key input");
+        let e_k = g_state_write
+            .reshape_edge(
+                e_flat_k,
+                vec![Dim::Concrete(4), Dim::Concrete(2), Dim::Concrete(8)],
+            )
+            .expect("key reshape");
+        let kv = make_tensor(
+            vec![Dim::Concrete(4), Dim::Concrete(2), Dim::Concrete(8)],
+            DType::F16,
+        );
+        let v_node = g_state_write
+            .add_op(Op::Cast(CastOp { dtype: DType::F16 }), &[e_k], &[kv])
+            .expect("value producer");
+        let e_v = g_state_write.nodes()[v_node.0].outputs[0];
+        g_state_write
+            .add_op(
+                Op::StateWriteKv(StateWriteKvOp {
+                    cache_dtype: DType::F16,
+                    scale_granularity: CacheScaleGranularity::PerTokenHead,
+                    latent: None,
+                    handle: StateHandle::new(0, StateKind::KvPaged),
+                }),
+                &[e_k, e_v],
+                &[],
+            )
+            .expect("state write");
+        assert!(matches!(
+            g_state_write.validate(),
+            Err(IrError::GraphExternalInputMissing {
+                kind: ExternalInputKind::BatchMeta,
+                required_by: "state_write_kv"
+            })
+        ));
+        g_state_write
+            .add_batch_meta_input()
+            .expect("add batch meta");
+        assert!(g_state_write.validate().is_ok());
+
+        // 3. LogitsPostprocess requires SamplingParams
+        let mut g_lp = Graph::new(key);
+        let logits_tensor = make_tensor(
+            vec![Dim::Concrete(4), Dim::Concrete(1), Dim::Concrete(32)],
+            DType::F32,
+        );
+        let probs_tensor = make_tensor(
+            vec![Dim::Concrete(4), Dim::Concrete(1), Dim::Concrete(32)],
+            DType::F32,
+        );
+        let flat_logits = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(32)], DType::F32);
+        let e_flat_logits = g_lp
+            .add_external_input(ExternalInputKind::EmbedOverride, flat_logits)
+            .expect("flat logits input");
+        let e_logits = g_lp
+            .reshape_edge(
+                e_flat_logits,
+                vec![Dim::Concrete(4), Dim::Concrete(1), Dim::Concrete(32)],
+            )
+            .expect("logits reshape");
+        assert_eq!(g_lp.edges()[e_logits.0].tensor, logits_tensor);
+        let lp_op = Op::LogitsPostprocess(LogitsPostprocessOp);
+        g_lp.add_op(lp_op, &[e_logits], &[probs_tensor])
+            .expect("add lp");
+        // Validation fails because SamplingParams is missing
+        assert!(g_lp.validate().is_err());
+        // Adding SamplingParams fixes it
+        g_lp.add_sampling_params_input()
+            .expect("add sampling params");
+        assert!(g_lp.validate().is_ok());
+
+        // 4. Sample requires RngState
+        let mut g_sample = Graph::new(key);
+        let s_probs = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(32)], DType::F32);
+        let s_token = make_tensor(vec![Dim::Concrete(4)], DType::U32);
+        let e_sprobs = g_sample
+            .add_external_input(ExternalInputKind::EmbedOverride, s_probs)
+            .expect("sample probabilities input");
+        let sample_op = Op::Sample(SampleOp {
+            rng: RngAlgorithm::Philox4x32,
+        });
+        g_sample
+            .add_op(sample_op, &[e_sprobs], &[s_token])
+            .expect("add sample");
+        // Validation fails because RngState is missing
+        assert!(g_sample.validate().is_err());
+        // Both input and updated-state output are part of the structured contract.
+        g_sample.add_rng_state_input().expect("add rng state");
+        assert!(g_sample.validate().is_err());
+        g_sample
+            .add_updated_rng_state_output()
+            .expect("add updated rng state");
+        assert!(g_sample.validate().is_ok());
+
+        // 5. Verify requires RngState
+        let mut g_verify = Graph::new(key);
+        let draft_tokens = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(1)], DType::U32);
+        let target_probs = make_tensor(
+            vec![Dim::Concrete(4), Dim::Concrete(2), Dim::Concrete(32)],
+            DType::F32,
+        );
+        let accepted = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(2)], DType::U32);
+        let accept_len = make_tensor(vec![Dim::Concrete(4)], DType::U32);
+        let token_ids = make_tensor(vec![Dim::Concrete(4)], DType::U32);
+        let e_token_ids = g_verify
+            .add_external_input(ExternalInputKind::TokenIds, token_ids)
+            .expect("token IDs input");
+        let e_draft = g_verify
+            .reshape_edge(e_token_ids, vec![Dim::Concrete(4), Dim::Concrete(1)])
+            .expect("draft token reshape");
+        assert_eq!(g_verify.edges()[e_draft.0].tensor, draft_tokens);
+        let flat_target = make_tensor(vec![Dim::Concrete(4), Dim::Concrete(64)], DType::F32);
+        let e_flat_target = g_verify
+            .add_external_input(ExternalInputKind::EmbedOverride, flat_target)
+            .expect("flat target probabilities input");
+        let e_target = g_verify
+            .reshape_edge(
+                e_flat_target,
+                vec![Dim::Concrete(4), Dim::Concrete(2), Dim::Concrete(32)],
+            )
+            .expect("target probability reshape");
+        assert_eq!(g_verify.edges()[e_target.0].tensor, target_probs);
+        let verify_op = Op::Verify(VerifyOp {
+            method: VerifyMethod::Greedy,
+        });
+        g_verify
+            .add_op(verify_op, &[e_draft, e_target], &[accepted, accept_len])
+            .expect("add verify");
+        // Validation fails because RngState is missing
+        assert!(g_verify.validate().is_err());
+        // Both input and updated-state output are required.
+        g_verify.add_rng_state_input().expect("add rng state");
+        assert!(g_verify.validate().is_err());
+        g_verify
+            .add_updated_rng_state_output()
+            .expect("add updated rng state");
+        assert!(g_verify.validate().is_ok());
+    }
+
+    #[test]
+    fn materialize_copies_deduplicates_with_deterministic_consumers() {
+        let plan = PlanId::new(30);
+        let key = StepGraphKey::new(plan, 0, 4, 16, 0, 0).expect("valid key");
+        let mut graph = Graph::new(key);
+
+        let t_in = make_tensor(vec![Dim::Concrete(16), Dim::Concrete(64)], DType::F16);
+        let e_in = graph
+            .add_external_input(ExternalInputKind::EmbedOverride, t_in)
+            .expect("activation input");
+
+        // Transpose creates non-contiguous view [64, 16] with strides [1, 64]
+        let e_trans = graph.transpose_edge(e_in, &[1, 0]).expect("transpose");
+        assert!(!graph.edges()[e_trans.0].is_contiguous());
+
+        let t_out1 = make_tensor(vec![Dim::Concrete(64), Dim::Concrete(16)], DType::F16);
+        let t_out2 = make_tensor(vec![Dim::Concrete(64), Dim::Concrete(16)], DType::F16);
+
+        let op1 = Op::Activation(crate::op::ActivationOp {
+            act: crate::op::ActivationKind::Silu,
+            clamp: None,
+        });
+        let op2 = Op::Activation(crate::op::ActivationOp {
+            act: crate::op::ActivationKind::Gelu,
+            clamp: None,
+        });
+
+        // Node 0 and Node 1 both consume e_trans with Contiguous requirement
+        let n0 = graph
+            .add_op_with_requirements(op1, &[e_trans], &[StrideRequirement::Contiguous], &[t_out1])
+            .expect("n0");
+        let n1 = graph
+            .add_op_with_requirements(op2, &[e_trans], &[StrideRequirement::Contiguous], &[t_out2])
+            .expect("n1");
+
+        // Exactly one copy must be inserted for e_trans
+        let count = graph.materialize_copies().expect("materialize");
+        assert_eq!(
+            count, 1,
+            "Exactly one shared copy must be inserted for e_trans"
+        );
+
+        let summary = graph.summary();
+        assert_eq!(summary.inserted_copy_count(), 1);
+        let copy_info = &summary.inserted_copies[0];
+        assert_eq!(copy_info.source_edge, e_trans);
+        // Consumers are deterministic and deduplicated
+        assert_eq!(copy_info.consumer_nodes, vec![n0, n1]);
+
+        // Both nodes rewired to the single shared copy output
+        assert_eq!(graph.nodes()[n0.0].inputs[0], copy_info.dest_edge);
+        assert_eq!(graph.nodes()[n1.0].inputs[0], copy_info.dest_edge);
+
+        // Idempotent
+        assert_eq!(graph.materialize_copies().expect("second run"), 0);
+        assert_eq!(graph.summary().inserted_copy_count(), 1);
+    }
+}

--- a/crates/r9v-ir/src/lib.rs
+++ b/crates/r9v-ir/src/lib.rs
@@ -13,8 +13,13 @@ pub mod arch;
 pub mod batch;
 pub mod dtype;
 pub mod error;
+pub mod fusion;
+pub mod graph;
 pub mod layout;
+pub mod numerics;
+pub mod op;
 pub mod quant;
+pub mod sharding;
 pub mod state;
 pub mod tensor;
 pub mod version;
@@ -26,8 +31,32 @@ pub use arch::{
 pub use batch::{BatchMeta, BatchMetaBuilder, Positions, TreeMask, BLOCK_TABLE_SENTINEL};
 pub use dtype::DType;
 pub use error::IrError;
+pub use fusion::{
+    fusion_table, is_permitted_fusion, is_permitted_pair, match_chain, match_gated_pair,
+    FusionEntry, FusionPattern, FUSION_TABLE,
+};
+pub use graph::{
+    bucket_s, bucket_step, bucket_t_dec, bucket_t_pre, compute_contiguous_strides, EdgeId,
+    ExternalInput, ExternalInputKind, ExternalOutput, ExternalOutputKind, Graph, GraphEdge,
+    GraphNode, GraphSummary, InsertedCopy, NodeId, PlanId, StepGraphKey, StrideRequirement,
+    BUCKET_SIZES,
+};
 pub use layout::LayoutId;
+pub use numerics::{matmul_numerics, moe_ffn_gemm_numerics, Numerics, ReductionOrder};
+pub use op::{
+    ActMulOp, ActivationKind, ActivationOp, AllGatherOp, AllReduceOp, AllToAllOp, AttentionMask,
+    AttentionOp, BarrierOp, CacheScaleGranularity, CastOp, CausalConv1dOp, ConvActivation,
+    CopyKind, CopyOp, EmbedGatherOp, Epilogue, GatherRowsOp, GroupId, HashId, LinearAttnKind,
+    LinearAttnScanOp, LogitsPostprocessOp, MatmulOp, MlaAttentionSpec, MlaLatent, MoeFfnOp,
+    MoeGroup, MoeRouteOp, MoeScoring, NgramCombine, NgramGatherOp, NgramSource, NormAxis, NormKind,
+    NormOp, Op, QuantActOp, RecvOp, ReduceOp, ReduceScatterOp, ResidualAddOp, RngAlgorithm, RopeOp,
+    RopeScaling, RopeStyle, SampleOp, SamplingParams, ScatterAddRowsOp, SendOp, Smoothing,
+    StateWriteKvOp, VerifyMethod, VerifyOp,
+};
 pub use quant::{QuantScheme, SchemeId};
+pub use sharding::{
+    legal_layout_tuples, legal_layouts, ExpertCount, HeadCount, ShardLayoutPattern, ShardingRule,
+};
 pub use state::{StateHandle, StateKind};
 pub use tensor::{Class, Dim, Placement, ShapeSymbol, ShardLayout, Tensor};
 pub use version::IrVersion;

--- a/crates/r9v-ir/src/numerics.rs
+++ b/crates/r9v-ir/src/numerics.rs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Op numerics contract (Spec 1 §6; card A1.2).
+//!
+//! Every op defines its numerics contract: accumulation dtype (`f32` or `i32`,
+//! never `f16`/`bf16`, Spec 1 §6.1) and a deterministic reduction order tag.
+
+use crate::{DType, IrError, QuantScheme};
+
+/// Deterministic reduction order tag (Spec 1 §6.1).
+///
+/// Batch invariance and cross-tier reproducibility require reductions to follow
+/// a fixed, documented order (Spec 1 §6.1, engineering standards §2.5–§2.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReductionOrder {
+    /// No reduction performed by this op.
+    None,
+    /// Ascending K feature dimension order (e.g. full-K matmul accumulate).
+    AscendingK,
+    /// Ascending block index order (e.g. PerBlock32 matmul, attention KV blocks).
+    AscendingBlock,
+    /// Ascending feature axis order (e.g. norm mean and variance reductions).
+    AscendingAxis,
+    /// Ascending device rank order (e.g. all-reduce, reduce-scatter collectives).
+    AscendingRank,
+    /// Ascending token or expert index order (e.g. sampling CDF, MoE combine,
+    /// scatter-add rows).
+    AscendingIndex,
+}
+
+/// Numerics contract per op (Spec 1 §6; card A1.2).
+///
+/// Encapsulates the accumulator dtype (must be `f32` or `i32` if an accumulator
+/// is used, Spec 1 §6.1) and the reduction order tag. Used by op-level test
+/// harnesses (card A1.10) to verify determinism and precision guarantees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Numerics {
+    /// Accumulator dtype, or `None` if the op performs no accumulation.
+    pub accumulator: Option<DType>,
+    /// Tag indicating the deterministic reduction order.
+    pub reduction_order: ReductionOrder,
+}
+
+impl Numerics {
+    /// Creates a numerics contract, validating that any declared accumulator
+    /// is either `f32` or `i32` per Spec 1 §6.1.
+    pub fn new(
+        accumulator: Option<DType>,
+        reduction_order: ReductionOrder,
+    ) -> Result<Self, IrError> {
+        if let Some(acc) = accumulator {
+            if acc != DType::F32 && acc != DType::I32 {
+                return Err(IrError::InvalidAccumulator { got: acc });
+            }
+        }
+        Ok(Self {
+            accumulator,
+            reduction_order,
+        })
+    }
+
+    /// Helper for `f32` accumulation with the given reduction order.
+    pub const fn f32(reduction_order: ReductionOrder) -> Self {
+        Self {
+            accumulator: Some(DType::F32),
+            reduction_order,
+        }
+    }
+
+    /// Helper for `i32` accumulation with the given reduction order.
+    pub const fn i32(reduction_order: ReductionOrder) -> Self {
+        Self {
+            accumulator: Some(DType::I32),
+            reduction_order,
+        }
+    }
+
+    /// Helper for ops that perform no reduction or accumulation.
+    pub const fn none() -> Self {
+        Self {
+            accumulator: None,
+            reduction_order: ReductionOrder::None,
+        }
+    }
+
+    /// Computes the input-dependent numerics contract for a matmul operation (Spec 1 §4.C, §6.2).
+    pub fn for_matmul(
+        x_dtype: DType,
+        w_dtype: DType,
+        x_quant: QuantScheme,
+        w_quant: QuantScheme,
+    ) -> Result<Self, IrError> {
+        matmul_numerics(x_dtype, w_dtype, x_quant, w_quant)
+    }
+
+    /// Computes the input-dependent numerics contract for MoE FFN GEMM (Spec 1 §4.C, §6.2).
+    pub fn for_moe_ffn(
+        x_dtype: DType,
+        w_dtype: DType,
+        x_quant: QuantScheme,
+        w_quant: QuantScheme,
+    ) -> Result<Self, IrError> {
+        moe_ffn_gemm_numerics(x_dtype, w_dtype, x_quant, w_quant)
+    }
+}
+
+/// Returns the input-dependent numerics contract for matmul operations (Spec 1 §4.C, §6.1, §6.2).
+///
+/// Integer activation/weight pairs use `i32`; mixed or floating-point pairs
+/// dequantize/convert before `f32` accumulation. True block-scaled operands use
+/// ascending block order; folded per-row scales use full-K ascending order.
+// DECISION(A1.2): matmul_numerics accepts both x_quant and w_quant per Spec 1 §6.2; rejected omitting w_quant which makes distinguishing folded per-row vs true per-block scales impossible.
+pub fn matmul_numerics(
+    x_dtype: DType,
+    w_dtype: DType,
+    x_quant: QuantScheme,
+    w_quant: QuantScheme,
+) -> Result<Numerics, IrError> {
+    let valid_x_quant = match x_dtype {
+        DType::F16 | DType::Bf16 => x_quant == QuantScheme::None,
+        DType::I8 => matches!(x_quant, QuantScheme::PerToken | QuantScheme::PerBlock32),
+        DType::E4m3 => x_quant == QuantScheme::PerToken,
+        DType::F32 | DType::E5m2 | DType::I4 | DType::I32 | DType::U32 | DType::Bool => {
+            return Err(IrError::OpDTypeMismatch {
+                op: "matmul",
+                tensor: "x",
+                expected: vec![DType::F16, DType::Bf16, DType::I8, DType::E4m3].into_boxed_slice(),
+                got: x_dtype,
+            });
+        }
+    };
+    if !valid_x_quant {
+        return Err(IrError::OpQuantMismatch {
+            op: "matmul",
+            tensor: "x",
+            quant: x_quant,
+        });
+    }
+
+    let valid_w_quant = match w_dtype {
+        DType::I4 | DType::I8 | DType::E4m3 => {
+            matches!(w_quant, QuantScheme::PerRow | QuantScheme::Scheme(_))
+        }
+        DType::F16 => w_quant == QuantScheme::None,
+        DType::F32 | DType::Bf16 | DType::E5m2 | DType::I32 | DType::U32 | DType::Bool => {
+            return Err(IrError::OpDTypeMismatch {
+                op: "matmul",
+                tensor: "w",
+                expected: vec![DType::I4, DType::I8, DType::E4m3, DType::F16].into_boxed_slice(),
+                got: w_dtype,
+            });
+        }
+    };
+    if !valid_w_quant {
+        return Err(IrError::OpQuantMismatch {
+            op: "matmul",
+            tensor: "w",
+            quant: w_quant,
+        });
+    }
+
+    let reduction_order =
+        if x_quant == QuantScheme::PerBlock32 || matches!(w_quant, QuantScheme::Scheme(_)) {
+            ReductionOrder::AscendingBlock
+        } else {
+            ReductionOrder::AscendingK
+        };
+    if x_dtype == DType::I8 && matches!(w_dtype, DType::I4 | DType::I8) {
+        Ok(Numerics::i32(reduction_order))
+    } else {
+        Ok(Numerics::f32(reduction_order))
+    }
+}
+
+/// Computes the input-dependent numerics contract for MoE FFN GEMM (Spec 1 §4.C, §6.2).
+pub fn moe_ffn_gemm_numerics(
+    x_dtype: DType,
+    w_dtype: DType,
+    x_quant: QuantScheme,
+    w_quant: QuantScheme,
+) -> Result<Numerics, IrError> {
+    matmul_numerics(x_dtype, w_dtype, x_quant, w_quant)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SchemeId;
+
+    #[test]
+    fn matmul_numerics_expresses_exact_spec6_rules() {
+        // i8 PerToken x PerRow -> i32 AscendingK (full-K)
+        let n_i8_token = matmul_numerics(
+            DType::I8,
+            DType::I8,
+            QuantScheme::PerToken,
+            QuantScheme::PerRow,
+        )
+        .unwrap();
+        assert_eq!(n_i8_token.accumulator, Some(DType::I32));
+        assert_eq!(n_i8_token.reduction_order, ReductionOrder::AscendingK);
+
+        // i8 PerToken x Scheme(true per-block) -> i32 AscendingBlock
+        let n_i8_true_block = matmul_numerics(
+            DType::I8,
+            DType::I8,
+            QuantScheme::PerToken,
+            QuantScheme::Scheme(SchemeId::new(1)),
+        )
+        .unwrap();
+        assert_eq!(n_i8_true_block.accumulator, Some(DType::I32));
+        assert_eq!(
+            n_i8_true_block.reduction_order,
+            ReductionOrder::AscendingBlock
+        );
+
+        // i8 PerBlock32 -> i32 AscendingBlock
+        let n_i8_block = matmul_numerics(
+            DType::I8,
+            DType::I8,
+            QuantScheme::PerBlock32,
+            QuantScheme::PerRow,
+        )
+        .unwrap();
+        assert_eq!(n_i8_block.accumulator, Some(DType::I32));
+        assert_eq!(n_i8_block.reduction_order, ReductionOrder::AscendingBlock);
+
+        // i8 x i4 with PerRow -> i32 AscendingK
+        let n_i4_perrow = matmul_numerics(
+            DType::I8,
+            DType::I4,
+            QuantScheme::PerToken,
+            QuantScheme::PerRow,
+        )
+        .unwrap();
+        assert_eq!(n_i4_perrow.accumulator, Some(DType::I32));
+        assert_eq!(n_i4_perrow.reduction_order, ReductionOrder::AscendingK);
+
+        // i8 x i4 with Scheme (true per-block) -> i32 AscendingBlock
+        let n_i4_block = matmul_numerics(
+            DType::I8,
+            DType::I4,
+            QuantScheme::PerToken,
+            QuantScheme::Scheme(SchemeId::new(2)),
+        )
+        .unwrap();
+        assert_eq!(n_i4_block.accumulator, Some(DType::I32));
+        assert_eq!(n_i4_block.reduction_order, ReductionOrder::AscendingBlock);
+
+        // e4m3 x e4m3 -> f32 AscendingK
+        let n_fp8 = matmul_numerics(
+            DType::E4m3,
+            DType::E4m3,
+            QuantScheme::PerToken,
+            QuantScheme::PerRow,
+        )
+        .unwrap();
+        assert_eq!(n_fp8.accumulator, Some(DType::F32));
+        assert_eq!(n_fp8.reduction_order, ReductionOrder::AscendingK);
+
+        // f16 x f16 -> f32 AscendingK
+        let n_f16 =
+            matmul_numerics(DType::F16, DType::F16, QuantScheme::None, QuantScheme::None).unwrap();
+        assert_eq!(n_f16.accumulator, Some(DType::F32));
+        assert_eq!(n_f16.reduction_order, ReductionOrder::AscendingK);
+
+        // bf16 activations x f16 weights -> f32 AscendingK
+        let n_bf16 = matmul_numerics(
+            DType::Bf16,
+            DType::F16,
+            QuantScheme::None,
+            QuantScheme::None,
+        )
+        .unwrap();
+        assert_eq!(n_bf16.accumulator, Some(DType::F32));
+        assert_eq!(n_bf16.reduction_order, ReductionOrder::AscendingK);
+
+        // Typed error for unsupported x dtype
+        assert!(matches!(
+            matmul_numerics(DType::F32, DType::F16, QuantScheme::None, QuantScheme::None),
+            Err(IrError::OpDTypeMismatch { .. })
+        ));
+
+        // Mixed integer activation and f16 weight dequantizes to f32.
+        let n_i8_f16 = matmul_numerics(
+            DType::I8,
+            DType::F16,
+            QuantScheme::PerToken,
+            QuantScheme::None,
+        )
+        .unwrap();
+        assert_eq!(n_i8_f16.accumulator, Some(DType::F32));
+
+        // Typed error for unsupported weight dtype.
+        assert!(matches!(
+            matmul_numerics(
+                DType::I8,
+                DType::Bf16,
+                QuantScheme::PerToken,
+                QuantScheme::None
+            ),
+            Err(IrError::OpDTypeMismatch { .. })
+        ));
+
+        // Typed error for unsupported quant scheme on x
+        assert!(matches!(
+            matmul_numerics(DType::I8, DType::I8, QuantScheme::None, QuantScheme::PerRow),
+            Err(IrError::OpQuantMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn moe_ffn_gemm_helper_matches_matmul() {
+        let n_matmul = matmul_numerics(
+            DType::I8,
+            DType::I8,
+            QuantScheme::PerToken,
+            QuantScheme::PerRow,
+        )
+        .unwrap();
+        let n_moe_ffn = moe_ffn_gemm_numerics(
+            DType::I8,
+            DType::I8,
+            QuantScheme::PerToken,
+            QuantScheme::PerRow,
+        )
+        .unwrap();
+        assert_eq!(n_matmul, n_moe_ffn);
+    }
+
+    #[test]
+    fn invalid_accumulators_are_rejected() {
+        assert!(Numerics::new(Some(DType::F16), ReductionOrder::AscendingK).is_err());
+        assert!(Numerics::new(Some(DType::Bf16), ReductionOrder::AscendingK).is_err());
+        assert!(Numerics::new(Some(DType::F32), ReductionOrder::AscendingK).is_ok());
+        assert!(Numerics::new(Some(DType::I32), ReductionOrder::AscendingK).is_ok());
+        assert!(Numerics::new(None, ReductionOrder::None).is_ok());
+    }
+}

--- a/crates/r9v-ir/src/op.rs
+++ b/crates/r9v-ir/src/op.rs
@@ -1,0 +1,6986 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Closed Op catalog and op-level validation (Spec 1 §4; card A1.2).
+//!
+//! Every operation supported by the R9V inference engine belongs to the closed
+//! set defined in Spec 1 §4. Ops are immutable descriptors with typed attributes.
+//! Validation collects every failure before returning (CONVENTIONS.md §1.4).
+
+use crate::sharding::{self, ShardingRule};
+use crate::{
+    matmul_numerics, moe_ffn_gemm_numerics, Class, DType, Dim, IrError, LayoutId, Numerics,
+    Placement, QuantScheme, ReductionOrder, ShardLayoutPattern, StateHandle, StateKind,
+};
+
+// -----------------------------------------------------------------------------
+// Attribute types and closed sets (Spec 1 §4)
+// -----------------------------------------------------------------------------
+
+/// Opaque n-gram hash function identifier (Spec 1 §4.A, CONVENTIONS.md §3.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HashId(u64);
+
+impl HashId {
+    /// Creates a new hash identifier.
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the underlying raw identifier value.
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+/// N-gram combination mode across hash heads (Spec 1 §4.A).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NgramCombine {
+    /// Concatenate head embeddings along the feature axis.
+    Concat,
+    /// Elementwise sum across head embeddings.
+    Sum,
+}
+
+// DECISION(A1.2): NgramSource specifies Staged versus Device per Spec 1 §4.A and SI-8; rejected unconstrained signatures because staged and device modes have distinct tensor signatures and placement rules.
+/// N-gram source mode (Spec 1 §4.A, SI-8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NgramSource {
+    /// Staged mode: host gathers rows into gather_staging [T, Np, Dn] and row_scales.
+    Staged,
+    /// Device-table mode: hashes on device and gathers directly from table [TotalEntries, Dn].
+    Device,
+}
+
+/// Weight smoothing representation for activation quantization (Spec 1 §4.A).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Smoothing {
+    /// No smoothing transform applied.
+    None,
+    /// Folded smoothing pre-applied into weight matrices.
+    Folded,
+}
+
+/// Normalization kind (Spec 1 §4.B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NormKind {
+    /// Root Mean Square normalization.
+    Rms,
+    /// Layer normalization (mean and variance centering).
+    Layer,
+}
+
+/// Normalization axis (Spec 1 §4.B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NormAxis {
+    /// Normalize over the last feature dimension `N`.
+    Last,
+    /// Normalize over head dimension `D` for per-head QK-norm.
+    Head(u32),
+}
+
+/// Non-linear activation function kind (Spec 1 §4.B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ActivationKind {
+    /// SiLU (swish) activation.
+    Silu,
+    /// Standard Gaussian Error Linear Unit.
+    Gelu,
+    /// GELU with tanh approximation.
+    GeluTanh,
+    /// Squared ReLU: max(0, x)^2.
+    Relu2,
+    /// Identity pass-through.
+    Identity,
+}
+
+/// Rotary Position Embedding style (Spec 1 §4.B).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RopeStyle {
+    /// GPT-NeoX style (split halves).
+    Neox,
+    /// LLaMA interleaved pairs style.
+    Interleaved,
+}
+
+/// Rotary Position Embedding frequency scaling configuration (Spec 1 §4.B).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RopeScaling {
+    /// No context window scaling.
+    None,
+    /// Linear position interpolation by a constant factor.
+    Linear(f32),
+    /// YaRN context extension scaling.
+    Yarn {
+        /// Interpolation factor.
+        factor: f32,
+        /// Fast beta frequency cutoff.
+        beta_fast: f32,
+        /// Slow beta frequency cutoff.
+        beta_slow: f32,
+        /// Original model training context limit.
+        orig_ctx: u32,
+        /// Target scale factor.
+        mscale: f32,
+    },
+    /// Dynamic runtime NTK-aware frequency scaling.
+    Dynamic,
+}
+
+/// Matmul epilogue fusion specification (Spec 1 §4.C).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Epilogue {
+    /// No epilogue.
+    None,
+    /// Add bias vector.
+    Bias,
+    /// Add residual activation tensor.
+    Residual,
+    /// Compute fused activation function.
+    Act(ActivationKind),
+}
+
+/// MoE router scoring method (Spec 1 §4.C).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MoeScoring {
+    /// Softmax over router logits.
+    Softmax,
+    /// Independent sigmoid gating per expert.
+    Sigmoid,
+}
+
+/// Grouped MoE configuration (Spec 1 §4.C).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MoeGroup {
+    /// Total number of expert groups.
+    pub n_group: u32,
+    /// Experts selected per group.
+    pub topk_group: u32,
+}
+
+/// Cache scale quantization granularity (Spec 1 §4.D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CacheScaleGranularity {
+    /// One scale per token per attention head.
+    PerTokenHead,
+    /// One scale per 32 or 64-element KV block.
+    PerBlock,
+}
+
+/// MLA latent projection specification (Spec 1 §4.D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MlaLatent {
+    /// Low-rank KV compression rank.
+    pub kv_lora_rank: u32,
+    /// Rotary embedding dimension for decoupled key.
+    pub rope_dim: u32,
+}
+
+/// Attention causal and verification mask kind (Spec 1 §4.D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AttentionMask {
+    /// Standard autoregressive lower-triangular causal mask.
+    Causal,
+    /// Sliding window causal mask with window length `w`.
+    CausalWindow(u32),
+    /// Tree-verification mask driven by speculative parent pointers.
+    Tree,
+}
+
+/// Multi-Head Latent Attention detailed configuration (Spec 1 §4.D, Spec 8 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MlaAttentionSpec {
+    /// Query low-rank compression rank, if present.
+    pub q_lora_rank: Option<u32>,
+    /// KV low-rank compression rank.
+    pub kv_lora_rank: u32,
+    /// Non-rotary head dimension for Q/K.
+    pub qk_nope_dim: u32,
+    /// Rotary head dimension for decoupled Q/K.
+    pub qk_rope_dim: u32,
+    /// Value head dimension.
+    pub v_dim: u32,
+}
+
+/// 1D convolution activation function (Spec 1 §4.E).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConvActivation {
+    /// SiLU activation.
+    Silu,
+    /// Identity (linear) activation.
+    Identity,
+}
+
+/// Linear attention / SSM scan architecture kind (Spec 1 §4.E).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LinearAttnKind {
+    /// Gated Delta Net recurrence.
+    GatedDeltaNet,
+    /// Gated Linear Attention scan.
+    GLA,
+    /// Mamba2 structured state-space duality scan.
+    Mamba2,
+}
+
+/// Counter-based pseudo-random number generator algorithm (Spec 1 §4.F).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RngAlgorithm {
+    /// Philox 4x32 10-round counter-based PRNG.
+    Philox4x32,
+}
+
+/// Speculative decoding acceptance verification method (Spec 1 §4.F, Spec 7 §4).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VerifyMethod {
+    /// Standard speculative rejection sampling with probability ratio.
+    Rejection,
+    /// Greedy argmax match verification.
+    Greedy,
+    /// Typical acceptance threshold verification with epsilon and delta parameters (Spec 7 §4).
+    TypicalAcceptance {
+        /// Acceptance probability floor epsilon.
+        eps: f32,
+        /// Entropy scaling factor delta.
+        delta: f32,
+    },
+}
+
+// DECISION(A1.2): GroupId wraps a private u64 field per CONVENTIONS.md §3.1 with as_u64() and as_u32() accessors; rejected bare primitive integers in public collective op signatures.
+/// Communication collective group identifier (Spec 1 §4.G, CONVENTIONS.md §3.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GroupId(u64);
+
+impl GroupId {
+    /// Creates a new communication group identifier.
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the underlying group identifier integer as u64.
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+
+    /// Compatibility accessor returning the group identifier as u32.
+    pub const fn as_u32(&self) -> u32 {
+        self.0 as u32
+    }
+}
+
+impl std::fmt::Display for GroupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Reduction operator for collective operations (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReduceOp {
+    /// Elementwise summation across ranks.
+    Sum,
+}
+
+// DECISION(A1.2): CopyKind defines Contiguize, DeviceToDevice, HostToDevice, and DeviceToHost per Spec 1 §4.A (device↔device, device↔host staging, or contiguization); rejected unconstrained copy because placement-aware validation requires checking transfer boundaries.
+/// Copy boundary kind (Spec 1 §4.A).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CopyKind {
+    /// Contiguization within the same placement.
+    #[default]
+    Contiguize,
+    /// Transfer between distinct devices.
+    DeviceToDevice,
+    /// Host-to-device staging transfer.
+    HostToDevice,
+    /// Device-to-host staging transfer.
+    DeviceToHost,
+}
+
+// DECISION(A1.2): SamplingParams is a typed non-Tensor external structure per Spec 1 §4.F and SI-12; rejected modeling as Tensor because DType is closed and cannot represent sparse bias tuples or heterogeneous float/int hyperparameters.
+/// Sampling parameters per sequence (Spec 1 §4.F, SI-12).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SamplingParams {
+    /// Sampling temperature (>= 0.0, 0.0 means greedy).
+    pub temperature: f32,
+    /// Top-k candidate filtering (0 means disabled).
+    pub top_k: u32,
+    /// Top-p nucleus filtering threshold in (0.0, 1.0].
+    pub top_p: f32,
+    /// Min-p relative probability threshold in [0.0, 1.0].
+    pub min_p: f32,
+    /// Repetition penalty factor (> 0.0, 1.0 means disabled).
+    pub repetition_penalty: f32,
+    /// Additive presence penalty.
+    pub presence_penalty: f32,
+    /// Additive frequency penalty.
+    pub frequency_penalty: f32,
+    /// Sparse logit bias tuples `[(token_id, bias)]`.
+    pub logit_bias: Vec<(u32, f32)>,
+}
+
+impl SamplingParams {
+    /// Validates sampling parameters against Spec 1 §4.F constraints.
+    pub fn validate(&self) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+        if !self.temperature.is_finite() || self.temperature < 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "sampling_params",
+                attribute: "temperature",
+                reason: format!("must be finite and >= 0.0, got {}", self.temperature),
+            });
+        }
+        if !self.top_p.is_finite() || self.top_p <= 0.0 || self.top_p > 1.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "sampling_params",
+                attribute: "top_p",
+                reason: format!("must be finite and in (0.0, 1.0], got {}", self.top_p),
+            });
+        }
+        if !self.min_p.is_finite() || self.min_p < 0.0 || self.min_p > 1.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "sampling_params",
+                attribute: "min_p",
+                reason: format!("must be finite and in [0.0, 1.0], got {}", self.min_p),
+            });
+        }
+        if !self.repetition_penalty.is_finite() || self.repetition_penalty <= 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "sampling_params",
+                attribute: "repetition_penalty",
+                reason: format!("must be finite and > 0.0, got {}", self.repetition_penalty),
+            });
+        }
+        if !self.presence_penalty.is_finite() {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "sampling_params",
+                attribute: "presence_penalty",
+                reason: format!("must be finite, got {}", self.presence_penalty),
+            });
+        }
+        if !self.frequency_penalty.is_finite() {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "sampling_params",
+                attribute: "frequency_penalty",
+                reason: format!("must be finite, got {}", self.frequency_penalty),
+            });
+        }
+        for &(token, bias) in &self.logit_bias {
+            if !bias.is_finite() {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "sampling_params",
+                    attribute: "logit_bias",
+                    reason: format!("token {} has non-finite bias {}", token, bias),
+                });
+            }
+        }
+        IrError::from_problems(problems)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helper validation routines
+// -----------------------------------------------------------------------------
+
+fn check_rank(
+    op: &'static str,
+    tensor_name: &'static str,
+    tensor: &crate::Tensor,
+    expected: usize,
+    problems: &mut Vec<IrError>,
+) {
+    if tensor.rank() != expected {
+        problems.push(IrError::OpRankMismatch {
+            op,
+            tensor: tensor_name,
+            expected,
+            got: tensor.rank(),
+        });
+    }
+}
+
+fn check_dtype_in(
+    op: &'static str,
+    tensor_name: &'static str,
+    tensor: &crate::Tensor,
+    allowed: &[DType],
+    problems: &mut Vec<IrError>,
+) {
+    if !allowed.contains(&tensor.dtype()) {
+        problems.push(IrError::OpDTypeMismatch {
+            op,
+            tensor: tensor_name,
+            expected: allowed.to_vec().into_boxed_slice(),
+            got: tensor.dtype(),
+        });
+    }
+}
+
+fn check_dim_match(
+    op: &'static str,
+    t1_name: &'static str,
+    d1: Dim,
+    t2_name: &'static str,
+    d2: Dim,
+    axis_name: &'static str,
+    problems: &mut Vec<IrError>,
+) {
+    match (d1, d2) {
+        (Dim::Concrete(a), Dim::Concrete(b)) if a != b => {
+            problems.push(IrError::OpShapeMismatch {
+                op,
+                tensor: t1_name,
+                detail: format!(
+                    "axis `{axis_name}` extent {a} does not match `{t2_name}` extent {b}"
+                ),
+            });
+        }
+        (Dim::Symbolic(s1), Dim::Symbolic(s2)) if s1 != s2 => {
+            problems.push(IrError::OpShapeMismatch {
+                op,
+                tensor: t1_name,
+                detail: format!(
+                    "axis `{axis_name}` symbol {s1:?} does not match `{t2_name}` symbol {s2:?}"
+                ),
+            });
+        }
+        (Dim::Concrete(_), Dim::Concrete(_))
+        | (Dim::Concrete(_), Dim::Symbolic(_))
+        | (Dim::Symbolic(_), Dim::Concrete(_))
+        | (Dim::Symbolic(_), Dim::Symbolic(_)) => {}
+    }
+}
+
+fn check_gemm_activation_operand(
+    op: &'static str,
+    name: &'static str,
+    tensor: &crate::Tensor,
+    problems: &mut Vec<IrError>,
+) {
+    check_dtype_in(
+        op,
+        name,
+        tensor,
+        &[DType::F16, DType::Bf16, DType::I8, DType::E4m3],
+        problems,
+    );
+    let quant_valid = match tensor.dtype() {
+        DType::F16 | DType::Bf16 => Some(tensor.quant() == QuantScheme::None),
+        DType::I8 => Some(matches!(
+            tensor.quant(),
+            QuantScheme::PerToken | QuantScheme::PerBlock32
+        )),
+        DType::E4m3 => Some(tensor.quant() == QuantScheme::PerToken),
+        DType::F32 | DType::E5m2 | DType::I4 | DType::I32 | DType::U32 | DType::Bool => None,
+    };
+    if quant_valid == Some(false) {
+        problems.push(IrError::OpQuantMismatch {
+            op,
+            tensor: name,
+            quant: tensor.quant(),
+        });
+    }
+}
+
+fn check_gemm_weight_operand(
+    op: &'static str,
+    name: &'static str,
+    tensor: &crate::Tensor,
+    problems: &mut Vec<IrError>,
+) {
+    check_dtype_in(
+        op,
+        name,
+        tensor,
+        &[DType::I4, DType::I8, DType::E4m3, DType::F16],
+        problems,
+    );
+    let quant_valid = match tensor.dtype() {
+        DType::I4 | DType::I8 | DType::E4m3 => Some(matches!(
+            tensor.quant(),
+            QuantScheme::PerRow | QuantScheme::Scheme(_)
+        )),
+        DType::F16 => Some(tensor.quant() == QuantScheme::None),
+        DType::F32 | DType::Bf16 | DType::E5m2 | DType::I32 | DType::U32 | DType::Bool => None,
+    };
+    if quant_valid == Some(false) {
+        problems.push(IrError::OpQuantMismatch {
+            op,
+            tensor: name,
+            quant: tensor.quant(),
+        });
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.A Data movement and lookup
+// -----------------------------------------------------------------------------
+
+/// Token embedding lookup op (Spec 1 §4.A).
+///
+/// `token_ids [T] u32, table [V, Dm] (i4|i8|f16, Block|PerRow, Device|Tiered) -> x [T, Dm] act_dtype`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EmbedGatherOp {
+    /// Scaling applied to gathered embeddings (e.g. sqrt(Dm) for Gemma).
+    pub scale: f32,
+    /// Destination activation dtype.
+    pub out_dtype: DType,
+}
+
+impl EmbedGatherOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    // DECISION(A1.2): Op validate() records attribute errors and both input and output count mismatches simultaneously into problems before guarding tensor indexing per CONVENTIONS.md §1.4; rejected early return on first count mismatch so that all structural defects are surfaced at once.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !self.scale.is_finite() || self.scale <= 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "embed_gather",
+                attribute: "scale",
+                reason: format!("must be finite and > 0, got {}", self.scale),
+            });
+        }
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "embed_gather",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "embed_gather",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "embed_gather",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let token_ids = &inputs[0];
+            let table = &inputs[1];
+
+            check_rank("embed_gather", "token_ids", token_ids, 1, &mut problems);
+            check_dtype_in(
+                "embed_gather",
+                "token_ids",
+                token_ids,
+                &[DType::U32],
+                &mut problems,
+            );
+            if token_ids.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "embed_gather",
+                    tensor: "token_ids",
+                    expected: Class::Activation,
+                    got: token_ids.class(),
+                });
+            }
+            if !matches!(token_ids.placement(), Placement::Device { .. }) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "embed_gather",
+                    tensor: "token_ids",
+                    placement: token_ids.placement(),
+                });
+            }
+
+            check_rank("embed_gather", "table", table, 2, &mut problems);
+            check_dtype_in(
+                "embed_gather",
+                "table",
+                table,
+                &[DType::I4, DType::I8, DType::F16],
+                &mut problems,
+            );
+            if table.class() != Class::Weight {
+                problems.push(IrError::OpClassMismatch {
+                    op: "embed_gather",
+                    tensor: "table",
+                    expected: Class::Weight,
+                    got: table.class(),
+                });
+            }
+            if !matches!(
+                table.placement(),
+                Placement::Device { .. } | Placement::Tiered
+            ) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "embed_gather",
+                    tensor: "table",
+                    placement: table.placement(),
+                });
+            }
+
+            match table.dtype() {
+                DType::F16 => {
+                    if table.quant() != QuantScheme::None {
+                        problems.push(IrError::OpQuantMismatch {
+                            op: "embed_gather",
+                            tensor: "table",
+                            quant: table.quant(),
+                        });
+                    }
+                }
+                DType::I4 => {
+                    if !matches!(table.quant(), QuantScheme::PerRow | QuantScheme::Scheme(_)) {
+                        problems.push(IrError::OpQuantMismatch {
+                            op: "embed_gather",
+                            tensor: "table",
+                            quant: table.quant(),
+                        });
+                    }
+                }
+                DType::I8 => {
+                    if !matches!(table.quant(), QuantScheme::PerRow | QuantScheme::Scheme(_)) {
+                        problems.push(IrError::OpQuantMismatch {
+                            op: "embed_gather",
+                            tensor: "table",
+                            quant: table.quant(),
+                        });
+                    }
+                }
+                DType::F32
+                | DType::Bf16
+                | DType::E4m3
+                | DType::E5m2
+                | DType::I32
+                | DType::U32
+                | DType::Bool => {}
+            }
+        }
+
+        if output_count_valid {
+            let x = &outputs[0];
+            check_rank("embed_gather", "x", x, 2, &mut problems);
+            if x.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "embed_gather",
+                    tensor: "x",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "embed_gather",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+            if !matches!(x.placement(), Placement::Device { .. }) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "embed_gather",
+                    tensor: "x",
+                    placement: x.placement(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let token_ids = &inputs[0];
+            let table = &inputs[1];
+            let x = &outputs[0];
+
+            if token_ids.rank() == 1 && x.rank() == 2 {
+                check_dim_match(
+                    "embed_gather",
+                    "x",
+                    x.shape()[0],
+                    "token_ids",
+                    token_ids.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+            }
+            if table.rank() == 2 && x.rank() == 2 {
+                check_dim_match(
+                    "embed_gather",
+                    "x",
+                    x.shape()[1],
+                    "table",
+                    table.shape()[1],
+                    "Dm",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::EMBED_GATHER_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::EMBED_GATHER_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::None)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "embed_gather"
+    }
+}
+
+/// N-gram speculative prefix gather op (Spec 1 §4.A, SI-8).
+///
+/// Staged: `gather_staging [T, Np, Dn] (i4|i8, Block), row_scales -> x [T, Np*Dn] act_dtype`
+/// Device: `token_ids [T] u32, table [TotalEntries, Dn] -> x [T, Np*Dn] act_dtype`
+#[derive(Debug, Clone, PartialEq)]
+pub struct NgramGatherOp {
+    /// N-gram source mode: Staged buffer vs Device table.
+    pub source: NgramSource,
+    /// N-gram orders evaluated by the hash heads.
+    pub orders: Box<[u32]>,
+    /// Number of parallel n-gram hash heads `Np`.
+    pub heads: u32,
+    /// Hash function identifier.
+    pub hash: HashId,
+    /// Size of the n-gram table per head.
+    pub table_sizes: Box<[u32]>,
+    /// How gathered head embeddings are combined.
+    pub combine: NgramCombine,
+    /// Destination activation dtype.
+    pub out_dtype: DType,
+}
+
+impl NgramGatherOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if self.heads == 0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "ngram_gather",
+                attribute: "heads",
+                reason: "heads must be > 0".to_string(),
+            });
+        }
+        if self.orders.is_empty() || self.orders.contains(&0) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "ngram_gather",
+                attribute: "orders",
+                reason: "orders must be non-empty with elements > 0".to_string(),
+            });
+        }
+        if self.table_sizes.is_empty() || self.table_sizes.contains(&0) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "ngram_gather",
+                attribute: "table_sizes",
+                reason: "table_sizes must be non-empty with elements > 0".to_string(),
+            });
+        }
+        if self.orders.len() != self.heads as usize {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "ngram_gather",
+                attribute: "orders",
+                reason: format!(
+                    "length {} must equal heads {}",
+                    self.orders.len(),
+                    self.heads
+                ),
+            });
+        }
+        if self.table_sizes.len() != self.heads as usize {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "ngram_gather",
+                attribute: "table_sizes",
+                reason: format!(
+                    "length {} must equal heads {}",
+                    self.table_sizes.len(),
+                    self.heads
+                ),
+            });
+        }
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "ngram_gather",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "ngram_gather",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "ngram_gather",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            match self.source {
+                NgramSource::Staged => {
+                    let staging = &inputs[0];
+                    let scales = &inputs[1];
+
+                    check_rank("ngram_gather", "gather_staging", staging, 3, &mut problems);
+                    check_dtype_in(
+                        "ngram_gather",
+                        "gather_staging",
+                        staging,
+                        &[DType::I4, DType::I8],
+                        &mut problems,
+                    );
+                    if !matches!(staging.quant(), QuantScheme::Scheme(_)) {
+                        problems.push(IrError::OpQuantMismatch {
+                            op: "ngram_gather",
+                            tensor: "gather_staging",
+                            quant: staging.quant(),
+                        });
+                    }
+                    if !matches!(staging.class(), Class::Staging | Class::Weight) {
+                        problems.push(IrError::OpClassMismatch {
+                            op: "ngram_gather",
+                            tensor: "gather_staging",
+                            expected: Class::Staging,
+                            got: staging.class(),
+                        });
+                    }
+                    if !matches!(staging.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "ngram_gather",
+                            tensor: "gather_staging",
+                            placement: staging.placement(),
+                        });
+                    }
+
+                    if scales.rank() != 1 && scales.rank() != 2 {
+                        problems.push(IrError::OpRankMismatch {
+                            op: "ngram_gather",
+                            tensor: "row_scales",
+                            expected: 2,
+                            got: scales.rank(),
+                        });
+                    }
+                    check_dtype_in(
+                        "ngram_gather",
+                        "row_scales",
+                        scales,
+                        &[DType::F32, DType::F16],
+                        &mut problems,
+                    );
+                    if !matches!(scales.class(), Class::Activation | Class::Staging) {
+                        problems.push(IrError::OpClassMismatch {
+                            op: "ngram_gather",
+                            tensor: "row_scales",
+                            expected: Class::Activation,
+                            got: scales.class(),
+                        });
+                    }
+                    if !matches!(scales.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "ngram_gather",
+                            tensor: "row_scales",
+                            placement: scales.placement(),
+                        });
+                    }
+
+                    if staging.rank() == 3 {
+                        if let Dim::Concrete(heads) = staging.shape()[1] {
+                            if heads != self.heads {
+                                problems.push(IrError::OpShapeMismatch {
+                                    op: "ngram_gather",
+                                    tensor: "gather_staging",
+                                    detail: format!(
+                                        "dim 1 heads {heads} != attr heads {}",
+                                        self.heads
+                                    ),
+                                });
+                            }
+                        }
+                    }
+
+                    // Independent input-to-input checks:
+                    if staging.rank() == 3 && (scales.rank() == 1 || scales.rank() == 2) {
+                        check_dim_match(
+                            "ngram_gather",
+                            "row_scales",
+                            scales.shape()[0],
+                            "gather_staging",
+                            staging.shape()[0],
+                            "T",
+                            &mut problems,
+                        );
+                        if scales.rank() == 2 {
+                            if let (Dim::Concrete(sc_h), Dim::Concrete(st_h)) =
+                                (scales.shape()[1], staging.shape()[1])
+                            {
+                                if sc_h != 1 && sc_h != st_h {
+                                    problems.push(IrError::OpShapeMismatch {
+                                        op: "ngram_gather",
+                                        tensor: "row_scales",
+                                        detail: format!(
+                                            "axis 1 heads {sc_h} != gather_staging heads {st_h}"
+                                        ),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                NgramSource::Device => {
+                    let token_ids = &inputs[0];
+                    let table = &inputs[1];
+
+                    check_rank("ngram_gather", "token_ids", token_ids, 1, &mut problems);
+                    check_dtype_in(
+                        "ngram_gather",
+                        "token_ids",
+                        token_ids,
+                        &[DType::U32],
+                        &mut problems,
+                    );
+                    if token_ids.class() != Class::Activation {
+                        problems.push(IrError::OpClassMismatch {
+                            op: "ngram_gather",
+                            tensor: "token_ids",
+                            expected: Class::Activation,
+                            got: token_ids.class(),
+                        });
+                    }
+                    if !matches!(token_ids.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "ngram_gather",
+                            tensor: "token_ids",
+                            placement: token_ids.placement(),
+                        });
+                    }
+
+                    check_rank("ngram_gather", "table", table, 2, &mut problems);
+                    check_dtype_in(
+                        "ngram_gather",
+                        "table",
+                        table,
+                        &[DType::I4, DType::I8, DType::F16, DType::Bf16, DType::F32],
+                        &mut problems,
+                    );
+                    if table.class() != Class::Weight {
+                        problems.push(IrError::OpClassMismatch {
+                            op: "ngram_gather",
+                            tensor: "table",
+                            expected: Class::Weight,
+                            got: table.class(),
+                        });
+                    }
+                    if !matches!(table.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "ngram_gather",
+                            tensor: "table",
+                            placement: table.placement(),
+                        });
+                    }
+                    if table.rank() == 2 {
+                        let expected_entries = self
+                            .table_sizes
+                            .iter()
+                            .try_fold(0u32, |sum, size| sum.checked_add(*size));
+                        match (table.shape()[0], expected_entries) {
+                            (Dim::Concrete(e), Some(expected)) if e != expected => {
+                                problems.push(IrError::OpShapeMismatch {
+                                    op: "ngram_gather",
+                                    tensor: "table",
+                                    detail: format!(
+                                        "table dim 0 extent {e} != sum of table_sizes ({expected})"
+                                    ),
+                                });
+                            }
+                            (_, None) => problems.push(IrError::OpAttributeInvalid {
+                                op: "ngram_gather",
+                                attribute: "table_sizes",
+                                reason: "sum of table_sizes exceeds u32::MAX".to_string(),
+                            }),
+                            (Dim::Concrete(_), Some(_)) | (Dim::Symbolic(_), Some(_)) => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        if output_count_valid {
+            let x = &outputs[0];
+            check_rank("ngram_gather", "x", x, 2, &mut problems);
+            if x.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "ngram_gather",
+                    tensor: "x",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "ngram_gather",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+            if !matches!(x.placement(), Placement::Device { .. }) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "ngram_gather",
+                    tensor: "x",
+                    placement: x.placement(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &outputs[0];
+            match self.source {
+                NgramSource::Staged => {
+                    let staging = &inputs[0];
+                    if staging.rank() == 3 && x.rank() == 2 {
+                        check_dim_match(
+                            "ngram_gather",
+                            "x",
+                            x.shape()[0],
+                            "gather_staging",
+                            staging.shape()[0],
+                            "T",
+                            &mut problems,
+                        );
+                        if let (Dim::Concrete(x_d), Dim::Concrete(st_d)) =
+                            (x.shape()[1], staging.shape()[2])
+                        {
+                            match self.combine {
+                                NgramCombine::Concat => {
+                                    if self.heads.checked_mul(st_d) != Some(x_d) {
+                                        problems.push(IrError::OpShapeMismatch {
+                                            op: "ngram_gather",
+                                            tensor: "x",
+                                            detail: format!(
+                                                "concat dim 1 {x_d} != heads({}) * Dn({})",
+                                                self.heads, st_d
+                                            ),
+                                        });
+                                    }
+                                }
+                                NgramCombine::Sum => {
+                                    if x_d != st_d {
+                                        problems.push(IrError::OpShapeMismatch {
+                                            op: "ngram_gather",
+                                            tensor: "x",
+                                            detail: format!("sum dim 1 {x_d} != Dn({st_d})"),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                NgramSource::Device => {
+                    let token_ids = &inputs[0];
+                    let table = &inputs[1];
+                    if token_ids.rank() == 1 && x.rank() == 2 {
+                        check_dim_match(
+                            "ngram_gather",
+                            "x",
+                            x.shape()[0],
+                            "token_ids",
+                            token_ids.shape()[0],
+                            "T",
+                            &mut problems,
+                        );
+                    }
+                    if table.rank() == 2 && x.rank() == 2 {
+                        if let (Dim::Concrete(x_d), Dim::Concrete(tb_d)) =
+                            (x.shape()[1], table.shape()[1])
+                        {
+                            match self.combine {
+                                NgramCombine::Concat => {
+                                    if self.heads.checked_mul(tb_d) != Some(x_d) {
+                                        problems.push(IrError::OpShapeMismatch {
+                                            op: "ngram_gather",
+                                            tensor: "x",
+                                            detail: format!(
+                                                "concat dim 1 {x_d} != heads({}) * Dn({})",
+                                                self.heads, tb_d
+                                            ),
+                                        });
+                                    }
+                                }
+                                NgramCombine::Sum => {
+                                    if x_d != tb_d {
+                                        problems.push(IrError::OpShapeMismatch {
+                                            op: "ngram_gather",
+                                            tensor: "x",
+                                            detail: format!("sum dim 1 {x_d} != Dn({tb_d})"),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::NGRAM_GATHER_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::NGRAM_GATHER_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        match self.combine {
+            NgramCombine::Concat => Numerics::f32(ReductionOrder::None),
+            NgramCombine::Sum => Numerics::f32(ReductionOrder::AscendingIndex),
+        }
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "ngram_gather"
+    }
+}
+
+// DECISION(A1.2): QuantActOp carries scheme: QuantScheme (PerToken or PerBlock32) and target: DType per Spec 1 §4.A, Spec 2 §3.4, and SI-7; rejected restricting to PerToken because GGUF MMQ models require i8 PerBlock32 with scale [T, N/32] for llama.cpp parity.
+/// Activation quantization op (Spec 1 §4.A, Spec 2 §3.4, SI-7).
+///
+/// `x [T, N] (f16|bf16|f32) -> xq [T, N] (i8|e4m3), scale [T] or [T, N/32] f32`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QuantActOp {
+    /// Activation quantization scheme: PerToken or PerBlock32.
+    pub scheme: QuantScheme,
+    /// Target quantized element dtype (`i8` or `e4m3`).
+    pub target: DType,
+    /// Weight smoothing mode.
+    pub smoothing: Smoothing,
+}
+
+impl QuantActOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !matches!(self.scheme, QuantScheme::PerToken | QuantScheme::PerBlock32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "quant_act",
+                attribute: "scheme",
+                reason: format!("must be PerToken or PerBlock32, got {:?}", self.scheme),
+            });
+        }
+        if self.target != DType::I8 && self.target != DType::E4m3 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "quant_act",
+                attribute: "target",
+                reason: format!("must be i8 or e4m3, got {:?}", self.target),
+            });
+        }
+        if self.scheme == QuantScheme::PerBlock32 && self.target != DType::I8 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "quant_act",
+                attribute: "target",
+                reason: format!(
+                    "PerBlock32 activation quantization is only valid with target i8, got {:?}",
+                    self.target
+                ),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "quant_act",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 2;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "quant_act",
+                expected: 2,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            check_rank("quant_act", "x", x, 2, &mut problems);
+            check_dtype_in(
+                "quant_act",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "quant_act",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+        }
+
+        if output_count_valid {
+            let xq = &outputs[0];
+            let scale = &outputs[1];
+
+            check_rank("quant_act", "xq", xq, 2, &mut problems);
+            if xq.dtype() != self.target {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "quant_act",
+                    tensor: "xq",
+                    expected: vec![self.target].into_boxed_slice(),
+                    got: xq.dtype(),
+                });
+            }
+            if xq.quant() != self.scheme {
+                problems.push(IrError::OpQuantMismatch {
+                    op: "quant_act",
+                    tensor: "xq",
+                    quant: xq.quant(),
+                });
+            }
+            if xq.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "quant_act",
+                    tensor: "xq",
+                    expected: Class::Activation,
+                    got: xq.class(),
+                });
+            }
+            if !matches!(xq.placement(), Placement::Device { .. }) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "quant_act",
+                    tensor: "xq",
+                    placement: xq.placement(),
+                });
+            }
+
+            match self.scheme {
+                QuantScheme::PerToken => {
+                    check_rank("quant_act", "scale", scale, 1, &mut problems);
+                }
+                QuantScheme::PerBlock32 => {
+                    check_rank("quant_act", "scale", scale, 2, &mut problems);
+                }
+                QuantScheme::None | QuantScheme::PerRow | QuantScheme::Scheme(_) => {
+                    check_rank("quant_act", "scale", scale, 1, &mut problems);
+                }
+            }
+            check_dtype_in("quant_act", "scale", scale, &[DType::F32], &mut problems);
+            if scale.quant() != QuantScheme::None {
+                problems.push(IrError::OpQuantMismatch {
+                    op: "quant_act",
+                    tensor: "scale",
+                    quant: scale.quant(),
+                });
+            }
+            if scale.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "quant_act",
+                    tensor: "scale",
+                    expected: Class::Activation,
+                    got: scale.class(),
+                });
+            }
+            if !matches!(scale.placement(), Placement::Device { .. }) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "quant_act",
+                    tensor: "scale",
+                    placement: scale.placement(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let xq = &outputs[0];
+            let scale = &outputs[1];
+
+            if x.rank() == 2 && xq.rank() == 2 {
+                check_dim_match(
+                    "quant_act",
+                    "xq",
+                    xq.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "quant_act",
+                    "xq",
+                    xq.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "N",
+                    &mut problems,
+                );
+            }
+            if x.rank() == 2 {
+                check_dim_match(
+                    "quant_act",
+                    "scale",
+                    scale.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+
+                if self.scheme == QuantScheme::PerBlock32 {
+                    if let Dim::Concrete(n) = x.shape()[1] {
+                        if n % 32 != 0 {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "quant_act",
+                                tensor: "x",
+                                detail: format!(
+                                    "axis 1 extent {n} must be divisible by 32 for PerBlock32"
+                                ),
+                            });
+                        } else if scale.rank() == 2 {
+                            if let Dim::Concrete(scale_blocks) = scale.shape()[1] {
+                                if scale_blocks != n / 32 {
+                                    problems.push(IrError::OpShapeMismatch {
+                                        op: "quant_act",
+                                        tensor: "scale",
+                                        detail: format!(
+                                            "scale axis 1 extent {scale_blocks} != N/32 ({})",
+                                            n / 32
+                                        ),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::QUANT_ACT_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::QUANT_ACT_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingAxis)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "quant_act"
+    }
+}
+
+/// Elementwise precision cast op (Spec 1 §4.A).
+///
+/// `x -> y` with `attrs: dtype`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CastOp {
+    /// Destination element dtype.
+    pub dtype: DType,
+}
+
+impl CastOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "cast",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "cast",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            if y.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "cast",
+                    tensor: "y",
+                    expected: vec![self.dtype].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let y = &outputs[0];
+            if x.rank() != y.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "cast",
+                    tensor: "y",
+                    expected: x.rank(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..x.rank() {
+                    check_dim_match(
+                        "cast",
+                        "y",
+                        y.shape()[i],
+                        "x",
+                        x.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+            if y.layout() != x.layout() {
+                problems.push(IrError::OpLayoutMismatch {
+                    op: "cast",
+                    tensor: "y",
+                    expected: x.layout(),
+                    got: y.layout(),
+                });
+            }
+            if y.quant() != x.quant() {
+                problems.push(IrError::OpQuantMismatch {
+                    op: "cast",
+                    tensor: "y",
+                    quant: y.quant(),
+                });
+            }
+            if y.placement() != x.placement() {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "cast",
+                    tensor: "y",
+                    placement: y.placement(),
+                });
+            }
+            if y.class() != x.class() {
+                problems.push(IrError::OpClassMismatch {
+                    op: "cast",
+                    tensor: "y",
+                    expected: x.class(),
+                    got: y.class(),
+                });
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::PASSTHROUGH_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::PASSTHROUGH_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "cast"
+    }
+}
+
+/// Tensor memory copy and contiguization op (Spec 1 §4.A).
+///
+/// `x -> y`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct CopyOp {
+    /// Copy kind and transfer boundary.
+    pub kind: CopyKind,
+}
+
+impl CopyOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "copy",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "copy",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let y = &outputs[0];
+
+            if y.dtype() != x.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "copy",
+                    tensor: "y",
+                    expected: vec![x.dtype()].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if x.rank() != y.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "copy",
+                    tensor: "y",
+                    expected: x.rank(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..x.rank() {
+                    check_dim_match(
+                        "copy",
+                        "y",
+                        y.shape()[i],
+                        "x",
+                        x.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+            if y.quant() != x.quant() {
+                problems.push(IrError::OpQuantMismatch {
+                    op: "copy",
+                    tensor: "y",
+                    quant: y.quant(),
+                });
+            }
+            if y.class() != x.class() {
+                problems.push(IrError::OpClassMismatch {
+                    op: "copy",
+                    tensor: "y",
+                    expected: x.class(),
+                    got: y.class(),
+                });
+            }
+
+            match self.kind {
+                CopyKind::Contiguize => {
+                    if x.placement() != y.placement() {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            placement: y.placement(),
+                        });
+                    }
+                    if y.layout() != LayoutId::CONTIGUOUS {
+                        problems.push(IrError::OpLayoutMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            expected: LayoutId::CONTIGUOUS,
+                            got: y.layout(),
+                        });
+                    }
+                }
+                CopyKind::DeviceToDevice => {
+                    if !matches!(x.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "x",
+                            placement: x.placement(),
+                        });
+                    }
+                    if !matches!(y.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            placement: y.placement(),
+                        });
+                    }
+                    if matches!(x.placement(), Placement::Device { .. })
+                        && matches!(y.placement(), Placement::Device { .. })
+                        && x.placement() == y.placement()
+                    {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            placement: y.placement(),
+                        });
+                    }
+                    if y.layout() != x.layout() {
+                        problems.push(IrError::OpLayoutMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            expected: x.layout(),
+                            got: y.layout(),
+                        });
+                    }
+                }
+                CopyKind::HostToDevice => {
+                    if !matches!(x.placement(), Placement::Host | Placement::Tiered) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "x",
+                            placement: x.placement(),
+                        });
+                    }
+                    if !matches!(y.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            placement: y.placement(),
+                        });
+                    }
+                    if y.layout() != x.layout() {
+                        problems.push(IrError::OpLayoutMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            expected: x.layout(),
+                            got: y.layout(),
+                        });
+                    }
+                }
+                CopyKind::DeviceToHost => {
+                    if !matches!(x.placement(), Placement::Device { .. }) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "x",
+                            placement: x.placement(),
+                        });
+                    }
+                    if !matches!(y.placement(), Placement::Host | Placement::Tiered) {
+                        problems.push(IrError::OpPlacementMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            placement: y.placement(),
+                        });
+                    }
+                    if y.layout() != x.layout() {
+                        problems.push(IrError::OpLayoutMismatch {
+                            op: "copy",
+                            tensor: "y",
+                            expected: x.layout(),
+                            got: y.layout(),
+                        });
+                    }
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::PASSTHROUGH_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::PASSTHROUGH_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "copy"
+    }
+}
+
+/// Row gather op by integer indices (Spec 1 §4.A, SI-10).
+///
+/// `x [N, D], indices [M] u32 -> y [M, D]`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct GatherRowsOp;
+
+impl GatherRowsOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "gather_rows",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "gather_rows",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            let indices = &inputs[1];
+
+            check_rank("gather_rows", "x", x, 2, &mut problems);
+            check_dtype_in(
+                "gather_rows",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "gather_rows",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+
+            check_rank("gather_rows", "indices", indices, 1, &mut problems);
+            check_dtype_in(
+                "gather_rows",
+                "indices",
+                indices,
+                &[DType::U32],
+                &mut problems,
+            );
+            if indices.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "gather_rows",
+                    tensor: "indices",
+                    expected: Class::Activation,
+                    got: indices.class(),
+                });
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("gather_rows", "y", y, 2, &mut problems);
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "gather_rows",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let indices = &inputs[1];
+            let y = &outputs[0];
+
+            if y.dtype() != x.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "gather_rows",
+                    tensor: "y",
+                    expected: vec![x.dtype()].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+
+            if indices.rank() == 1 && y.rank() == 2 {
+                check_dim_match(
+                    "gather_rows",
+                    "y",
+                    y.shape()[0],
+                    "indices",
+                    indices.shape()[0],
+                    "M",
+                    &mut problems,
+                );
+            }
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "gather_rows",
+                    "y",
+                    y.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "D",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::GATHER_ROWS_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::GATHER_ROWS_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "gather_rows"
+    }
+}
+
+/// Deterministic scatter-add rows op (Spec 1 §4.A, SI-10).
+///
+/// `x [M, D], indices [M] u32, dest? [N, D] -> y [N, D]`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct ScatterAddRowsOp;
+
+impl ScatterAddRowsOp {
+    /// Validates inputs and outputs against Spec 1 §4.A constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 2 || inputs.len() == 3;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountCandidatesMismatch {
+                op: "scatter_add_rows",
+                expected: vec![2, 3].into_boxed_slice(),
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "scatter_add_rows",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            let indices = &inputs[1];
+
+            check_rank("scatter_add_rows", "x", x, 2, &mut problems);
+            check_dtype_in(
+                "scatter_add_rows",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "scatter_add_rows",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+
+            check_rank("scatter_add_rows", "indices", indices, 1, &mut problems);
+            check_dtype_in(
+                "scatter_add_rows",
+                "indices",
+                indices,
+                &[DType::U32],
+                &mut problems,
+            );
+            if indices.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "scatter_add_rows",
+                    tensor: "indices",
+                    expected: Class::Activation,
+                    got: indices.class(),
+                });
+            }
+
+            if inputs.len() == 3 {
+                let dest = &inputs[2];
+                check_rank("scatter_add_rows", "dest", dest, 2, &mut problems);
+                if dest.dtype() != x.dtype() {
+                    problems.push(IrError::OpDTypeMismatch {
+                        op: "scatter_add_rows",
+                        tensor: "dest",
+                        expected: vec![x.dtype()].into_boxed_slice(),
+                        got: dest.dtype(),
+                    });
+                }
+                if dest.class() != Class::Activation {
+                    problems.push(IrError::OpClassMismatch {
+                        op: "scatter_add_rows",
+                        tensor: "dest",
+                        expected: Class::Activation,
+                        got: dest.class(),
+                    });
+                }
+            }
+
+            // Independent input-to-input checks:
+            if x.rank() == 2 && indices.rank() == 1 {
+                check_dim_match(
+                    "scatter_add_rows",
+                    "x",
+                    x.shape()[0],
+                    "indices",
+                    indices.shape()[0],
+                    "M",
+                    &mut problems,
+                );
+            }
+            if inputs.len() == 3 {
+                let dest = &inputs[2];
+                if dest.rank() == 2 && x.rank() == 2 {
+                    check_dim_match(
+                        "scatter_add_rows",
+                        "dest",
+                        dest.shape()[1],
+                        "x",
+                        x.shape()[1],
+                        "D",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("scatter_add_rows", "y", y, 2, &mut problems);
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "scatter_add_rows",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let y = &outputs[0];
+
+            if y.dtype() != x.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "scatter_add_rows",
+                    tensor: "y",
+                    expected: vec![x.dtype()].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "scatter_add_rows",
+                    "y",
+                    y.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "D",
+                    &mut problems,
+                );
+            }
+
+            if inputs.len() == 3 {
+                let dest = &inputs[2];
+                if dest.rank() == 2 && y.rank() == 2 {
+                    check_dim_match(
+                        "scatter_add_rows",
+                        "y",
+                        y.shape()[0],
+                        "dest",
+                        dest.shape()[0],
+                        "N",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.A, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::SCATTER_ADD_ROWS_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::SCATTER_ADD_ROWS_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.A, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "scatter_add_rows"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.B Normalization and elementwise
+// -----------------------------------------------------------------------------
+
+/// Root Mean Square or Layer normalization op (Spec 1 §4.B).
+///
+/// `x [T, N] act_dtype, weight [N] f32, bias? [N] f32 -> y [T, N] out_dtype`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NormOp {
+    /// RMS or Layer norm variant.
+    pub kind: NormKind,
+    /// Epsilon variance floor.
+    pub eps: f32,
+    /// Reduction axis (last dim or per-head).
+    pub axis: NormAxis,
+    /// Weight offset (e.g. 1.0 for Gemma's 1+w parameterization).
+    pub weight_offset: f32,
+    /// Output activation dtype.
+    pub out_dtype: DType,
+}
+
+impl NormOp {
+    /// Validates inputs and outputs against Spec 1 §4.B constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !self.eps.is_finite() || self.eps <= 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "norm",
+                attribute: "eps",
+                reason: format!("must be finite and > 0, got {}", self.eps),
+            });
+        }
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "norm",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+        if !self.weight_offset.is_finite() {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "norm",
+                attribute: "weight_offset",
+                reason: format!("must be finite, got {}", self.weight_offset),
+            });
+        }
+        if let NormAxis::Head(d) = self.axis {
+            if d == 0 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "norm",
+                    attribute: "axis",
+                    reason: "head dimension must be > 0".to_string(),
+                });
+            }
+        }
+
+        let input_count_valid = inputs.len() == 2 || inputs.len() == 3;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountCandidatesMismatch {
+                op: "norm",
+                expected: vec![2, 3].into_boxed_slice(),
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "norm",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            let weight = &inputs[1];
+
+            check_rank("norm", "x", x, 2, &mut problems);
+            check_dtype_in(
+                "norm",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "norm",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+
+            check_rank("norm", "weight", weight, 1, &mut problems);
+            check_dtype_in("norm", "weight", weight, &[DType::F32], &mut problems);
+            if !matches!(weight.class(), Class::Weight | Class::Param) {
+                problems.push(IrError::OpClassMismatch {
+                    op: "norm",
+                    tensor: "weight",
+                    expected: Class::Weight,
+                    got: weight.class(),
+                });
+            }
+
+            if inputs.len() == 3 {
+                let bias = &inputs[2];
+                check_rank("norm", "bias", bias, 1, &mut problems);
+                check_dtype_in("norm", "bias", bias, &[DType::F32], &mut problems);
+                if !matches!(bias.class(), Class::Weight | Class::Param) {
+                    problems.push(IrError::OpClassMismatch {
+                        op: "norm",
+                        tensor: "bias",
+                        expected: Class::Weight,
+                        got: bias.class(),
+                    });
+                }
+            }
+
+            // Independent input-to-input checks:
+            if x.rank() == 2 && weight.rank() == 1 {
+                let last_dim = x.shape()[1];
+                check_dim_match(
+                    "norm",
+                    "weight",
+                    weight.shape()[0],
+                    "x",
+                    last_dim,
+                    "N",
+                    &mut problems,
+                );
+                if let (NormAxis::Head(d), Dim::Concrete(n)) = (self.axis, last_dim) {
+                    if d > 0 && n % d != 0 {
+                        problems.push(IrError::OpShapeMismatch {
+                            op: "norm",
+                            tensor: "x",
+                            detail: format!("feature dim N={n} not divisible by head dim {d}"),
+                        });
+                    }
+                }
+            }
+
+            if inputs.len() == 3 {
+                let bias = &inputs[2];
+                if weight.rank() == 1 && bias.rank() == 1 {
+                    check_dim_match(
+                        "norm",
+                        "bias",
+                        bias.shape()[0],
+                        "weight",
+                        weight.shape()[0],
+                        "N",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("norm", "y", y, 2, &mut problems);
+            if y.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "norm",
+                    tensor: "y",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "norm",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let y = &outputs[0];
+
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "norm",
+                    "y",
+                    y.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "norm",
+                    "y",
+                    y.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "N",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.B, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::NORM_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::NORM_RULES.iter().map(|r| r.as_tuple()).collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.B, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingAxis)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "norm"
+    }
+}
+
+/// Elementwise residual addition op (Spec 1 §4.B).
+///
+/// `a + b in f32 -> y`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ResidualAddOp {
+    /// Output activation dtype.
+    pub out_dtype: DType,
+}
+
+impl ResidualAddOp {
+    /// Validates inputs and outputs against Spec 1 §4.B constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "residual_add",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "residual_add",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "residual_add",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let a = &inputs[0];
+            let b = &inputs[1];
+
+            check_dtype_in(
+                "residual_add",
+                "a",
+                a,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if a.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "residual_add",
+                    tensor: "a",
+                    expected: Class::Activation,
+                    got: a.class(),
+                });
+            }
+            check_dtype_in(
+                "residual_add",
+                "b",
+                b,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if b.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "residual_add",
+                    tensor: "b",
+                    expected: Class::Activation,
+                    got: b.class(),
+                });
+            }
+
+            // Independent input-to-input checks:
+            if a.rank() != b.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "residual_add",
+                    tensor: "b",
+                    expected: a.rank(),
+                    got: b.rank(),
+                });
+            } else {
+                for i in 0..a.rank() {
+                    check_dim_match(
+                        "residual_add",
+                        "b",
+                        b.shape()[i],
+                        "a",
+                        a.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            if y.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "residual_add",
+                    tensor: "y",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "residual_add",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let a = &inputs[0];
+            let y = &outputs[0];
+
+            if y.rank() != a.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "residual_add",
+                    tensor: "y",
+                    expected: a.rank(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..a.rank() {
+                    check_dim_match(
+                        "residual_add",
+                        "y",
+                        y.shape()[i],
+                        "a",
+                        a.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.B, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::RESIDUAL_ADD_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::RESIDUAL_ADD_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.B, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::None)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "residual_add"
+    }
+}
+
+/// Gated activation product op (Spec 1 §4.B).
+///
+/// `gate [T, Dff], up [T, Dff] -> y [T, Dff]`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ActMulOp {
+    /// Activation function applied to the gate tensor.
+    pub act: ActivationKind,
+    /// Optional upper clamp limit.
+    pub clamp: Option<f32>,
+}
+
+impl ActMulOp {
+    /// Validates inputs and outputs against Spec 1 §4.B constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if let Some(c) = self.clamp {
+            if !c.is_finite() || c <= 0.0 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "act_mul",
+                    attribute: "clamp",
+                    reason: format!("must be finite and > 0, got {c}"),
+                });
+            }
+        }
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "act_mul",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "act_mul",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let gate = &inputs[0];
+            let up = &inputs[1];
+
+            check_rank("act_mul", "gate", gate, 2, &mut problems);
+            check_rank("act_mul", "up", up, 2, &mut problems);
+            check_dtype_in(
+                "act_mul",
+                "gate",
+                gate,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            check_dtype_in(
+                "act_mul",
+                "up",
+                up,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if up.dtype() != gate.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "act_mul",
+                    tensor: "up",
+                    expected: vec![gate.dtype()].into_boxed_slice(),
+                    got: up.dtype(),
+                });
+            }
+            if gate.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "act_mul",
+                    tensor: "gate",
+                    expected: Class::Activation,
+                    got: gate.class(),
+                });
+            }
+            if up.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "act_mul",
+                    tensor: "up",
+                    expected: Class::Activation,
+                    got: up.class(),
+                });
+            }
+
+            // Independent input-to-input checks:
+            if gate.rank() == 2 && up.rank() == 2 {
+                check_dim_match(
+                    "act_mul",
+                    "up",
+                    up.shape()[0],
+                    "gate",
+                    gate.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "act_mul",
+                    "up",
+                    up.shape()[1],
+                    "gate",
+                    gate.shape()[1],
+                    "Dff",
+                    &mut problems,
+                );
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("act_mul", "y", y, 2, &mut problems);
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "act_mul",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let gate = &inputs[0];
+            let y = &outputs[0];
+
+            if y.dtype() != gate.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "act_mul",
+                    tensor: "y",
+                    expected: vec![gate.dtype()].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if gate.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "act_mul",
+                    "y",
+                    y.shape()[0],
+                    "gate",
+                    gate.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "act_mul",
+                    "y",
+                    y.shape()[1],
+                    "gate",
+                    gate.shape()[1],
+                    "Dff",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.B, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ACT_MUL_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ACT_MUL_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.B, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::None)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "act_mul"
+    }
+}
+
+/// Standalone non-gated activation function op (Spec 1 §4.B).
+///
+/// `x [T, Dff] -> y [T, Dff]`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ActivationOp {
+    /// Activation function kind.
+    pub act: ActivationKind,
+    /// Optional upper clamp limit.
+    pub clamp: Option<f32>,
+}
+
+impl ActivationOp {
+    /// Validates inputs and outputs against Spec 1 §4.B constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if let Some(c) = self.clamp {
+            if !c.is_finite() || c <= 0.0 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "activation",
+                    attribute: "clamp",
+                    reason: format!("must be finite and > 0, got {c}"),
+                });
+            }
+        }
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "activation",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "activation",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            check_rank("activation", "x", x, 2, &mut problems);
+            check_dtype_in(
+                "activation",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "activation",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("activation", "y", y, 2, &mut problems);
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "activation",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let y = &outputs[0];
+
+            if y.dtype() != x.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "activation",
+                    tensor: "y",
+                    expected: vec![x.dtype()].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "activation",
+                    "y",
+                    y.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "activation",
+                    "y",
+                    y.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "Dff",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.B, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ACTIVATION_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ACTIVATION_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.B, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::None)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "activation"
+    }
+}
+
+/// Rotary Position Embedding application op (Spec 1 §4.B).
+///
+/// `x [T, H, D], positions [T] | [T, 3] -> x' [T, H, D]`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RopeOp {
+    /// Dimension to which rotary embedding is applied.
+    pub rot_dim: u32,
+    /// Base theta frequency.
+    pub theta: f32,
+    /// Interleaved or NeoX style.
+    pub style: RopeStyle,
+    /// Frequency scaling configuration.
+    pub scaling: RopeScaling,
+    /// Multimodal RoPE section dimensions [T, H, W], if applicable.
+    pub mrope_sections: Option<[u32; 3]>,
+    /// Destination activation dtype.
+    pub out_dtype: DType,
+}
+
+impl RopeOp {
+    /// Validates inputs and outputs against Spec 1 §4.B constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if self.rot_dim == 0 || !self.rot_dim.is_multiple_of(2) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "rope",
+                attribute: "rot_dim",
+                reason: format!("rot_dim must be positive and even, got {}", self.rot_dim),
+            });
+        }
+        if !self.theta.is_finite() || self.theta <= 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "rope",
+                attribute: "theta",
+                reason: format!("theta must be finite and > 0, got {}", self.theta),
+            });
+        }
+        if let Some(sections) = self.mrope_sections {
+            if sections.contains(&0) {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "rope",
+                    attribute: "mrope_sections",
+                    reason: "mrope sections must be positive".to_string(),
+                });
+            }
+            if sections.iter().any(|&s| s % 2 != 0) {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "rope",
+                    attribute: "mrope_sections",
+                    reason: "mrope section dimensions must be even".to_string(),
+                });
+            }
+            match sections
+                .iter()
+                .try_fold(0u32, |sum, section| sum.checked_add(*section))
+            {
+                Some(total) if total > self.rot_dim => {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "mrope_sections",
+                        reason: format!(
+                            "sum of mrope sections {total} exceeds rot_dim {}",
+                            self.rot_dim
+                        ),
+                    });
+                }
+                None => problems.push(IrError::OpAttributeInvalid {
+                    op: "rope",
+                    attribute: "mrope_sections",
+                    reason: "sum of mrope sections exceeds u32::MAX".to_string(),
+                }),
+                Some(_) => {}
+            }
+        }
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "rope",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+        match self.scaling {
+            RopeScaling::None | RopeScaling::Dynamic => {}
+            RopeScaling::Linear(factor) => {
+                if !factor.is_finite() || factor <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.factor",
+                        reason: format!("must be finite and > 0, got {factor}"),
+                    });
+                }
+            }
+            RopeScaling::Yarn {
+                factor,
+                beta_fast,
+                beta_slow,
+                orig_ctx,
+                mscale,
+            } => {
+                if !factor.is_finite() || factor <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.factor",
+                        reason: format!("must be finite and > 0, got {factor}"),
+                    });
+                }
+                if !beta_fast.is_finite() || beta_fast <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.beta_fast",
+                        reason: format!("must be finite and > 0, got {beta_fast}"),
+                    });
+                }
+                if !beta_slow.is_finite() || beta_slow <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.beta_slow",
+                        reason: format!("must be finite and > 0, got {beta_slow}"),
+                    });
+                }
+                if beta_slow > beta_fast {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.beta_slow",
+                        reason: format!(
+                            "beta_slow ({beta_slow}) cannot exceed beta_fast ({beta_fast})"
+                        ),
+                    });
+                }
+                if orig_ctx == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.orig_ctx",
+                        reason: "must be > 0".to_string(),
+                    });
+                }
+                if !mscale.is_finite() || mscale <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "rope",
+                        attribute: "scaling.mscale",
+                        reason: format!("must be finite and > 0, got {mscale}"),
+                    });
+                }
+            }
+        }
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "rope",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "rope",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            let positions = &inputs[1];
+
+            check_rank("rope", "x", x, 3, &mut problems);
+            check_dtype_in(
+                "rope",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "rope",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+
+            if self.mrope_sections.is_some() {
+                check_rank("rope", "positions", positions, 2, &mut problems);
+                if positions.rank() == 2 {
+                    if let Dim::Concrete(width) = positions.shape()[1] {
+                        if width != 3 {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "rope",
+                                tensor: "positions",
+                                detail: format!("mrope position width must be 3, got {width}"),
+                            });
+                        }
+                    }
+                }
+            } else {
+                check_rank("rope", "positions", positions, 1, &mut problems);
+            }
+            check_dtype_in("rope", "positions", positions, &[DType::U32], &mut problems);
+            if positions.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "rope",
+                    tensor: "positions",
+                    expected: Class::Activation,
+                    got: positions.class(),
+                });
+            }
+
+            // Independent input-to-input checks:
+            if x.rank() == 3 && (positions.rank() == 1 || positions.rank() == 2) {
+                check_dim_match(
+                    "rope",
+                    "positions",
+                    positions.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+            }
+            if x.rank() == 3 {
+                if let Dim::Concrete(d) = x.shape()[2] {
+                    if self.rot_dim > d {
+                        problems.push(IrError::OpAttributeInvalid {
+                            op: "rope",
+                            attribute: "rot_dim",
+                            reason: format!("rot_dim {} exceeds head dim {}", self.rot_dim, d),
+                        });
+                    }
+                }
+            }
+        }
+
+        if output_count_valid {
+            let x_prime = &outputs[0];
+            check_rank("rope", "x_prime", x_prime, 3, &mut problems);
+            if x_prime.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "rope",
+                    tensor: "x_prime",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: x_prime.dtype(),
+                });
+            }
+            if x_prime.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "rope",
+                    tensor: "x_prime",
+                    expected: Class::Activation,
+                    got: x_prime.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let x_prime = &outputs[0];
+
+            if x.rank() == 3 && x_prime.rank() == 3 {
+                for i in 0..3 {
+                    check_dim_match(
+                        "rope",
+                        "x_prime",
+                        x_prime.shape()[i],
+                        "x",
+                        x.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.B, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ROPE_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ROPE_RULES.iter().map(|r| r.as_tuple()).collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.B, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::None)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "rope"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.C Matmul family
+// -----------------------------------------------------------------------------
+
+/// Matrix multiplication with optional fused epilogue (Spec 1 §4.C).
+///
+/// `x [M, K], w [N, K], bias? [N] f32 -> y [M, N] out_dtype`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MatmulOp {
+    /// Destination activation dtype.
+    pub out_dtype: DType,
+    /// Fused post-GEMM operation.
+    pub epilogue: Epilogue,
+    /// Whether weight matrix `w` is stored transposed `[K, N]` instead of standard `[N, K]`.
+    pub transpose_w: bool,
+}
+
+impl MatmulOp {
+    /// Validates inputs and outputs against Spec 1 §4.C constraints.
+    // DECISION(A1.2): MatmulOp validates inputs conditionally: None/Act require 2 inputs (x, w), Bias requires 3 (x, w, bias [N] f32), Residual requires 3 (x, w, residual [M, N]) per Spec 1 §4.C and SI-9; rejected fixed 2-input signature because fused residual partial sum accumulation requires the residual tensor in the step graph.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "matmul",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+
+        let expected_inputs = match self.epilogue {
+            Epilogue::Bias | Epilogue::Residual => 3,
+            Epilogue::None | Epilogue::Act(_) => 2,
+        };
+
+        let input_count_valid = inputs.len() == expected_inputs;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "matmul",
+                expected: expected_inputs,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "matmul",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            let w = &inputs[1];
+
+            check_rank("matmul", "x", x, 2, &mut problems);
+            check_gemm_activation_operand("matmul", "x", x, &mut problems);
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "matmul",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+
+            check_rank("matmul", "w", w, 2, &mut problems);
+            check_gemm_weight_operand("matmul", "w", w, &mut problems);
+            if w.class() != Class::Weight {
+                problems.push(IrError::OpClassMismatch {
+                    op: "matmul",
+                    tensor: "w",
+                    expected: Class::Weight,
+                    got: w.class(),
+                });
+            }
+            if !matches!(w.placement(), Placement::Device { .. }) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "matmul",
+                    tensor: "w",
+                    placement: w.placement(),
+                });
+            }
+
+            match self.epilogue {
+                Epilogue::Bias => {
+                    let bias = &inputs[2];
+                    check_rank("matmul", "bias", bias, 1, &mut problems);
+                    check_dtype_in("matmul", "bias", bias, &[DType::F32], &mut problems);
+                    if bias.class() != Class::Param {
+                        problems.push(IrError::OpClassMismatch {
+                            op: "matmul",
+                            tensor: "bias",
+                            expected: Class::Param,
+                            got: bias.class(),
+                        });
+                    }
+                }
+                Epilogue::Residual => {
+                    let residual = &inputs[2];
+                    check_rank("matmul", "residual", residual, 2, &mut problems);
+                    check_dtype_in(
+                        "matmul",
+                        "residual",
+                        residual,
+                        &[DType::F16, DType::Bf16, DType::F32],
+                        &mut problems,
+                    );
+                    if residual.class() != Class::Activation {
+                        problems.push(IrError::OpClassMismatch {
+                            op: "matmul",
+                            tensor: "residual",
+                            expected: Class::Activation,
+                            got: residual.class(),
+                        });
+                    }
+                }
+                Epilogue::None | Epilogue::Act(_) => {}
+            }
+
+            // Independent input-to-input checks:
+            if x.rank() == 2 && w.rank() == 2 {
+                let (k_w, n_w) = if self.transpose_w {
+                    (w.shape()[0], w.shape()[1])
+                } else {
+                    (w.shape()[1], w.shape()[0])
+                };
+                check_dim_match("matmul", "w", k_w, "x", x.shape()[1], "K", &mut problems);
+
+                match self.epilogue {
+                    Epilogue::Bias => {
+                        let bias = &inputs[2];
+                        if bias.rank() == 1 {
+                            check_dim_match(
+                                "matmul",
+                                "bias",
+                                bias.shape()[0],
+                                "w",
+                                n_w,
+                                "N",
+                                &mut problems,
+                            );
+                        }
+                    }
+                    Epilogue::Residual => {
+                        let residual = &inputs[2];
+                        if residual.rank() == 2 {
+                            check_dim_match(
+                                "matmul",
+                                "residual",
+                                residual.shape()[0],
+                                "x",
+                                x.shape()[0],
+                                "M",
+                                &mut problems,
+                            );
+                            check_dim_match(
+                                "matmul",
+                                "residual",
+                                residual.shape()[1],
+                                "w",
+                                n_w,
+                                "N",
+                                &mut problems,
+                            );
+                        }
+                    }
+                    Epilogue::None | Epilogue::Act(_) => {}
+                }
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("matmul", "y", y, 2, &mut problems);
+            if y.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "matmul",
+                    tensor: "y",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "matmul",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let w = &inputs[1];
+            let y = &outputs[0];
+
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "matmul",
+                    "y",
+                    y.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "M",
+                    &mut problems,
+                );
+            }
+            if w.rank() == 2 && y.rank() == 2 {
+                let n_w = if self.transpose_w {
+                    w.shape()[1]
+                } else {
+                    w.shape()[0]
+                };
+                check_dim_match("matmul", "y", y.shape()[1], "w", n_w, "N", &mut problems);
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.C, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::MATMUL_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::MATMUL_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    // DECISION(A1.2): numerics_for inspects operand dtype and quant scheme per Spec 1 §6.1 & §6.2 (AscendingBlock for PerBlock32, AscendingK for PerToken / i8 / float); rejected static-only numerics descriptor on MatmulOp because execution contract depends on input activation quantization.
+    /// Returns dynamic input-dependent numerics contract for given activation and weight tensors.
+    pub fn numerics_for(&self, x: &crate::Tensor, w: &crate::Tensor) -> Result<Numerics, IrError> {
+        matmul_numerics(x.dtype(), w.dtype(), x.quant(), w.quant())
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "matmul"
+    }
+}
+
+/// Mixture of Experts routing and top-k gating op (Spec 1 §4.C).
+///
+/// `logits [T, E] f32 -> expert_ids [T, K] u32, weights [T, K] f32`
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MoeRouteOp {
+    /// Number of experts chosen per token `K`.
+    pub top_k: u32,
+    /// Router scoring method.
+    pub scoring: MoeScoring,
+    /// Whether router weights are renormalized to sum to 1.
+    pub renormalize: bool,
+    /// Grouped expert routing constraints, if applicable.
+    pub group: Option<MoeGroup>,
+    /// Router scale factor.
+    pub scale: f32,
+}
+
+impl MoeRouteOp {
+    /// Validates inputs and outputs against Spec 1 §4.C constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if self.top_k == 0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "moe_route",
+                attribute: "top_k",
+                reason: "top_k must be > 0".to_string(),
+            });
+        }
+        if !self.scale.is_finite() || self.scale <= 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "moe_route",
+                attribute: "scale",
+                reason: format!("scale must be finite and > 0, got {}", self.scale),
+            });
+        }
+        if let Some(g) = self.group {
+            if g.n_group == 0 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "moe_route",
+                    attribute: "group.n_group",
+                    reason: "n_group must be > 0".to_string(),
+                });
+            }
+            if g.topk_group == 0 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "moe_route",
+                    attribute: "group.topk_group",
+                    reason: "topk_group must be > 0".to_string(),
+                });
+            }
+            if g.topk_group > self.top_k {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "moe_route",
+                    attribute: "group.topk_group",
+                    reason: format!(
+                        "topk_group {} cannot exceed top_k {}",
+                        g.topk_group, self.top_k
+                    ),
+                });
+            }
+        }
+
+        let input_count_valid = inputs.len() == 1 || inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountCandidatesMismatch {
+                op: "moe_route",
+                expected: vec![1, 2].into_boxed_slice(),
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 2;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "moe_route",
+                expected: 2,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let logits = &inputs[0];
+            check_rank("moe_route", "logits", logits, 2, &mut problems);
+            check_dtype_in("moe_route", "logits", logits, &[DType::F32], &mut problems);
+            if logits.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_route",
+                    tensor: "logits",
+                    expected: Class::Activation,
+                    got: logits.class(),
+                });
+            }
+
+            if inputs.len() == 2 {
+                let bias = &inputs[1];
+                check_rank("moe_route", "bias", bias, 1, &mut problems);
+                check_dtype_in("moe_route", "bias", bias, &[DType::F32], &mut problems);
+                if bias.class() != Class::Param {
+                    problems.push(IrError::OpClassMismatch {
+                        op: "moe_route",
+                        tensor: "bias",
+                        expected: Class::Param,
+                        got: bias.class(),
+                    });
+                }
+            }
+
+            // Independent input-to-input checks:
+            if logits.rank() == 2 {
+                if let Dim::Concrete(e) = logits.shape()[1] {
+                    if self.top_k > e {
+                        problems.push(IrError::OpAttributeInvalid {
+                            op: "moe_route",
+                            attribute: "top_k",
+                            reason: format!(
+                                "top_k {} cannot exceed number of experts E={e}",
+                                self.top_k
+                            ),
+                        });
+                    }
+                    if inputs.len() == 2 && inputs[1].rank() == 1 {
+                        check_dim_match(
+                            "moe_route",
+                            "bias",
+                            inputs[1].shape()[0],
+                            "logits",
+                            logits.shape()[1],
+                            "E",
+                            &mut problems,
+                        );
+                    }
+                    if let Some(g) = self.group {
+                        if g.n_group > 0 {
+                            if e % g.n_group != 0 {
+                                problems.push(IrError::OpShapeMismatch {
+                                    op: "moe_route",
+                                    tensor: "logits",
+                                    detail: format!(
+                                        "experts E={e} must be divisible by n_group={}",
+                                        g.n_group
+                                    ),
+                                });
+                            } else if g.topk_group > e / g.n_group {
+                                problems.push(IrError::OpAttributeInvalid {
+                                    op: "moe_route",
+                                    attribute: "topk_group",
+                                    reason: format!(
+                                        "topk_group {} exceeds experts per group {}",
+                                        g.topk_group,
+                                        e / g.n_group
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if output_count_valid {
+            let expert_ids = &outputs[0];
+            let weights = &outputs[1];
+
+            check_rank("moe_route", "expert_ids", expert_ids, 2, &mut problems);
+            check_dtype_in(
+                "moe_route",
+                "expert_ids",
+                expert_ids,
+                &[DType::U32],
+                &mut problems,
+            );
+            if expert_ids.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_route",
+                    tensor: "expert_ids",
+                    expected: Class::Activation,
+                    got: expert_ids.class(),
+                });
+            }
+
+            check_rank("moe_route", "weights", weights, 2, &mut problems);
+            check_dtype_in(
+                "moe_route",
+                "weights",
+                weights,
+                &[DType::F32],
+                &mut problems,
+            );
+            if weights.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_route",
+                    tensor: "weights",
+                    expected: Class::Activation,
+                    got: weights.class(),
+                });
+            }
+
+            if expert_ids.rank() == 2 && weights.rank() == 2 {
+                check_dim_match(
+                    "moe_route",
+                    "weights",
+                    weights.shape()[0],
+                    "expert_ids",
+                    expert_ids.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "moe_route",
+                    "weights",
+                    weights.shape()[1],
+                    "expert_ids",
+                    expert_ids.shape()[1],
+                    "K",
+                    &mut problems,
+                );
+            }
+
+            if let Dim::Concrete(k) = expert_ids.shape()[1] {
+                if k != self.top_k {
+                    problems.push(IrError::OpShapeMismatch {
+                        op: "moe_route",
+                        tensor: "expert_ids",
+                        detail: format!("axis 1 extent {k} != top_k {}", self.top_k),
+                    });
+                }
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let logits = &inputs[0];
+            let expert_ids = &outputs[0];
+
+            if logits.rank() == 2 && expert_ids.rank() == 2 {
+                check_dim_match(
+                    "moe_route",
+                    "expert_ids",
+                    expert_ids.shape()[0],
+                    "logits",
+                    logits.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.C, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::MOE_ROUTE_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::MOE_ROUTE_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.C, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "moe_route"
+    }
+}
+
+/// Mixture of Experts feed-forward execution op (Spec 1 §4.C).
+///
+/// `x [T, Dm], expert_ids [T, K], weights [T, K], w_gate_up [E, 2*Dff, Dm], w_down [E, Dm, Dff] -> y [T, Dm]`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MoeFfnOp {
+    /// Expert MLP activation function.
+    pub act: ActivationKind,
+    /// Destination activation dtype.
+    pub out_dtype: DType,
+    /// Number of shared experts executed concurrently.
+    pub shared_experts: u32,
+}
+
+impl MoeFfnOp {
+    /// Validates inputs and outputs against Spec 1 §4.C constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !matches!(self.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "moe_ffn",
+                attribute: "out_dtype",
+                reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 5;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "moe_ffn",
+                expected: 5,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "moe_ffn",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if input_count_valid {
+            let x = &inputs[0];
+            let expert_ids = &inputs[1];
+            let weights = &inputs[2];
+            let w_gate_up = &inputs[3];
+            let w_down = &inputs[4];
+
+            check_rank("moe_ffn", "x", x, 2, &mut problems);
+            check_gemm_activation_operand("moe_ffn", "x", x, &mut problems);
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_ffn",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+
+            check_rank("moe_ffn", "expert_ids", expert_ids, 2, &mut problems);
+            check_dtype_in(
+                "moe_ffn",
+                "expert_ids",
+                expert_ids,
+                &[DType::U32],
+                &mut problems,
+            );
+            if expert_ids.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_ffn",
+                    tensor: "expert_ids",
+                    expected: Class::Activation,
+                    got: expert_ids.class(),
+                });
+            }
+
+            check_rank("moe_ffn", "weights", weights, 2, &mut problems);
+            check_dtype_in("moe_ffn", "weights", weights, &[DType::F32], &mut problems);
+            if weights.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_ffn",
+                    tensor: "weights",
+                    expected: Class::Activation,
+                    got: weights.class(),
+                });
+            }
+
+            check_rank("moe_ffn", "w_gate_up", w_gate_up, 3, &mut problems);
+            check_gemm_weight_operand("moe_ffn", "w_gate_up", w_gate_up, &mut problems);
+            if w_gate_up.class() != Class::Weight {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_ffn",
+                    tensor: "w_gate_up",
+                    expected: Class::Weight,
+                    got: w_gate_up.class(),
+                });
+            }
+            if !matches!(
+                w_gate_up.placement(),
+                Placement::Device { .. } | Placement::Tiered
+            ) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "moe_ffn",
+                    tensor: "w_gate_up",
+                    placement: w_gate_up.placement(),
+                });
+            }
+
+            check_rank("moe_ffn", "w_down", w_down, 3, &mut problems);
+            check_gemm_weight_operand("moe_ffn", "w_down", w_down, &mut problems);
+            if w_down.class() != Class::Weight {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_ffn",
+                    tensor: "w_down",
+                    expected: Class::Weight,
+                    got: w_down.class(),
+                });
+            }
+            if !matches!(
+                w_down.placement(),
+                Placement::Device { .. } | Placement::Tiered
+            ) {
+                problems.push(IrError::OpPlacementMismatch {
+                    op: "moe_ffn",
+                    tensor: "w_down",
+                    placement: w_down.placement(),
+                });
+            }
+
+            // Independent input-to-input checks:
+            if expert_ids.rank() == 2 && x.rank() == 2 {
+                check_dim_match(
+                    "moe_ffn",
+                    "expert_ids",
+                    expert_ids.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+            }
+            if weights.rank() == 2 && x.rank() == 2 {
+                check_dim_match(
+                    "moe_ffn",
+                    "weights",
+                    weights.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+            }
+            if expert_ids.rank() == 2 && weights.rank() == 2 {
+                check_dim_match(
+                    "moe_ffn",
+                    "expert_ids",
+                    expert_ids.shape()[1],
+                    "weights",
+                    weights.shape()[1],
+                    "K",
+                    &mut problems,
+                );
+            }
+            if w_gate_up.rank() == 3 && x.rank() == 2 {
+                check_dim_match(
+                    "moe_ffn",
+                    "w_gate_up",
+                    w_gate_up.shape()[2],
+                    "x",
+                    x.shape()[1],
+                    "Dm",
+                    &mut problems,
+                );
+            }
+            if w_down.rank() == 3 && x.rank() == 2 {
+                check_dim_match(
+                    "moe_ffn",
+                    "w_down",
+                    w_down.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "Dm",
+                    &mut problems,
+                );
+            }
+            if w_gate_up.rank() == 3 && w_down.rank() == 3 {
+                check_dim_match(
+                    "moe_ffn",
+                    "w_gate_up",
+                    w_gate_up.shape()[0],
+                    "w_down",
+                    w_down.shape()[0],
+                    "E",
+                    &mut problems,
+                );
+                if let (Dim::Concrete(gu), Dim::Concrete(dff)) =
+                    (w_gate_up.shape()[1], w_down.shape()[2])
+                {
+                    let expected_gate_up = dff.checked_mul(2);
+                    if expected_gate_up != Some(gu) {
+                        let expected = expected_gate_up.map_or_else(
+                            || "overflow (> u32::MAX)".to_string(),
+                            |value| value.to_string(),
+                        );
+                        problems.push(IrError::OpShapeMismatch {
+                            op: "moe_ffn",
+                            tensor: "w_gate_up",
+                            detail: format!(
+                                "w_gate_up dim 1 extent {gu} != 2 * w_down dim 2 ({expected})"
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+
+        if output_count_valid {
+            let y = &outputs[0];
+            check_rank("moe_ffn", "y", y, 2, &mut problems);
+            if y.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "moe_ffn",
+                    tensor: "y",
+                    expected: vec![self.out_dtype].into_boxed_slice(),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "moe_ffn",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if input_count_valid && output_count_valid {
+            let x = &inputs[0];
+            let y = &outputs[0];
+
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "moe_ffn",
+                    "y",
+                    y.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "moe_ffn",
+                    "y",
+                    y.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "Dm",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.C, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::MOE_FFN_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::MOE_FFN_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns dynamic input-dependent numerics contract for given activation and weight tensors.
+    pub fn numerics_for(&self, x: &crate::Tensor, w: &crate::Tensor) -> Result<Numerics, IrError> {
+        moe_ffn_gemm_numerics(x.dtype(), w.dtype(), x.quant(), w.quant())
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.C, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "moe_ffn"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.D Attention
+// -----------------------------------------------------------------------------
+
+/// Attention key/value state cache write op (Spec 1 §4.D).
+///
+/// Tensor operands are `k [T, Hkv, D], v [T, Hkv, Dv] -> ()`.
+/// `slot_map` arrives through the structured `BatchMeta` input (SI-12).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StateWriteKvOp {
+    /// Cache storage element dtype (`f16`, `i8`, or `e4m3`).
+    pub cache_dtype: DType,
+    /// Cache scale quantization granularity.
+    pub scale_granularity: CacheScaleGranularity,
+    /// MLA compressed latent metadata, if applicable.
+    pub latent: Option<MlaLatent>,
+    /// State handle identifying the KV cache buffer.
+    pub handle: StateHandle,
+}
+
+impl StateWriteKvOp {
+    /// Validates inputs and outputs against Spec 1 §4.D constraints.
+    // DECISION(A1.2): StateWriteKvOp validates exactly the tensor operands (k, v); slot_map is carried by the required structured BatchMeta graph input. Rejected a third fake slot_map Tensor because SI-12 keeps BatchMeta outside tensor slices. Spec 1 §4.D, SI-12.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        match self.cache_dtype {
+            DType::F16 | DType::I8 | DType::E4m3 => {}
+            DType::F32
+            | DType::Bf16
+            | DType::E5m2
+            | DType::I4
+            | DType::I32
+            | DType::U32
+            | DType::Bool => {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "state_write_kv",
+                    attribute: "cache_dtype",
+                    reason: format!("must be f16, i8, or e4m3; got {:?}", self.cache_dtype),
+                });
+            }
+        }
+
+        match self.scale_granularity {
+            CacheScaleGranularity::PerTokenHead => {}
+            CacheScaleGranularity::PerBlock => {}
+        }
+
+        match self.latent {
+            Some(ref l) => {
+                if l.kv_lora_rank == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "state_write_kv",
+                        attribute: "latent.kv_lora_rank",
+                        reason: "kv_lora_rank must be > 0".to_string(),
+                    });
+                }
+                if l.rope_dim == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "state_write_kv",
+                        attribute: "latent.rope_dim",
+                        reason: "rope_dim must be > 0".to_string(),
+                    });
+                }
+                match self.handle.kind() {
+                    StateKind::KvLatent => {}
+                    StateKind::KvPaged | StateKind::ConvWindow | StateKind::Recurrent => {
+                        problems.push(IrError::StateHandleKindMismatch {
+                            op: "state_write_kv",
+                            expected: StateKind::KvLatent,
+                            got: self.handle.kind(),
+                        });
+                    }
+                }
+            }
+            None => match self.handle.kind() {
+                StateKind::KvPaged => {}
+                StateKind::KvLatent | StateKind::ConvWindow | StateKind::Recurrent => {
+                    problems.push(IrError::StateHandleKindMismatch {
+                        op: "state_write_kv",
+                        expected: StateKind::KvPaged,
+                        got: self.handle.kind(),
+                    });
+                }
+            },
+        }
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "state_write_kv",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.is_empty();
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "state_write_kv",
+                expected: 0,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(k) = inputs.first() {
+            check_rank("state_write_kv", "k", k, 3, &mut problems);
+            check_dtype_in(
+                "state_write_kv",
+                "k",
+                k,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if k.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "state_write_kv",
+                    tensor: "k",
+                    expected: Class::Activation,
+                    got: k.class(),
+                });
+            }
+        }
+
+        if let Some(v) = inputs.get(1) {
+            check_rank("state_write_kv", "v", v, 3, &mut problems);
+            check_dtype_in(
+                "state_write_kv",
+                "v",
+                v,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if v.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "state_write_kv",
+                    tensor: "v",
+                    expected: Class::Activation,
+                    got: v.class(),
+                });
+            }
+        }
+
+        if let (Some(k), Some(v)) = (inputs.first(), inputs.get(1)) {
+            if v.dtype() != k.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "state_write_kv",
+                    tensor: "v",
+                    expected: Box::new([k.dtype()]),
+                    got: v.dtype(),
+                });
+            }
+            if k.rank() == 3 && v.rank() == 3 {
+                check_dim_match(
+                    "state_write_kv",
+                    "v",
+                    v.shape()[0],
+                    "k",
+                    k.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "state_write_kv",
+                    "v",
+                    v.shape()[1],
+                    "k",
+                    k.shape()[1],
+                    "Hkv",
+                    &mut problems,
+                );
+            }
+            if let Some(ref l) = self.latent {
+                if k.rank() == 3 {
+                    if let Dim::Concrete(d) = k.shape()[2] {
+                        let latent_dim = l.kv_lora_rank.checked_add(l.rope_dim);
+                        if latent_dim != Some(d) && d != l.rope_dim {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "state_write_kv",
+                                tensor: "k",
+                                detail: format!(
+                                    "key dim {d} does not match MLA latent specs (rank {} + rope {})",
+                                    l.kv_lora_rank, l.rope_dim
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.D, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::STATE_WRITE_KV_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::STATE_WRITE_KV_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.D, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "state_write_kv"
+    }
+}
+
+/// Paged attention read and compute op (Spec 1 §4.D).
+///
+/// `q [T, H, D], StateHandle, BatchMeta -> o [T, H, D]`
+#[derive(Debug, Clone, PartialEq)]
+pub struct AttentionOp {
+    /// Softmax scale factor (typically 1 / sqrt(D)).
+    pub softmax_scale: f32,
+    /// Causal, sliding window, or tree verification mask.
+    pub mask: AttentionMask,
+    /// Attention sink token count.
+    pub sinks: u32,
+    /// Logit soft-capping threshold (e.g. 50.0 for Gemma2).
+    pub logit_softcap: Option<f32>,
+    /// MLA configuration, if applicable.
+    pub mla: Option<MlaAttentionSpec>,
+    /// Output activation dtype.
+    pub out_dtype: DType,
+    /// State handle for KV cache reading.
+    pub handle: StateHandle,
+}
+
+impl AttentionOp {
+    /// Validates inputs and outputs against Spec 1 §4.D constraints.
+    // DECISION(A1.2): AttentionOp validates tensor operands q -> o; StateHandle and BatchMeta (with optional TreeMask) are structured external metadata per Spec 1 §4.D and SI-12.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if !self.softmax_scale.is_finite() || self.softmax_scale <= 0.0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "attention",
+                attribute: "softmax_scale",
+                reason: format!("must be finite and > 0, got {}", self.softmax_scale),
+            });
+        }
+        match self.out_dtype {
+            DType::F16 | DType::Bf16 | DType::F32 => {}
+            DType::E4m3
+            | DType::E5m2
+            | DType::I4
+            | DType::I8
+            | DType::I32
+            | DType::U32
+            | DType::Bool => {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "attention",
+                    attribute: "out_dtype",
+                    reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+                });
+            }
+        }
+        match self.mask {
+            AttentionMask::Causal => {}
+            AttentionMask::CausalWindow(w) => {
+                if w == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "attention",
+                        attribute: "mask",
+                        reason: "causal window must be > 0".to_string(),
+                    });
+                }
+            }
+            AttentionMask::Tree => {}
+        }
+        if let Some(c) = self.logit_softcap.filter(|c| !c.is_finite() || *c <= 0.0) {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "attention",
+                attribute: "logit_softcap",
+                reason: format!("must be finite and > 0, got {c}"),
+            });
+        }
+
+        match self.mla {
+            Some(ref m) => {
+                if m.kv_lora_rank == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "attention",
+                        attribute: "mla.kv_lora_rank",
+                        reason: "kv_lora_rank must be > 0".to_string(),
+                    });
+                }
+                if m.qk_nope_dim == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "attention",
+                        attribute: "mla.qk_nope_dim",
+                        reason: "qk_nope_dim must be > 0".to_string(),
+                    });
+                }
+                if m.qk_rope_dim == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "attention",
+                        attribute: "mla.qk_rope_dim",
+                        reason: "qk_rope_dim must be > 0".to_string(),
+                    });
+                }
+                if m.v_dim == 0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "attention",
+                        attribute: "mla.v_dim",
+                        reason: "v_dim must be > 0".to_string(),
+                    });
+                }
+                if m.q_lora_rank == Some(0) {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "attention",
+                        attribute: "mla.q_lora_rank",
+                        reason: "q_lora_rank must be > 0".to_string(),
+                    });
+                }
+                match self.handle.kind() {
+                    StateKind::KvLatent => {}
+                    StateKind::KvPaged | StateKind::ConvWindow | StateKind::Recurrent => {
+                        problems.push(IrError::StateHandleKindMismatch {
+                            op: "attention",
+                            expected: StateKind::KvLatent,
+                            got: self.handle.kind(),
+                        });
+                    }
+                }
+            }
+            None => match self.handle.kind() {
+                StateKind::KvPaged => {}
+                StateKind::KvLatent | StateKind::ConvWindow | StateKind::Recurrent => {
+                    problems.push(IrError::StateHandleKindMismatch {
+                        op: "attention",
+                        expected: StateKind::KvPaged,
+                        got: self.handle.kind(),
+                    });
+                }
+            },
+        }
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "attention",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "attention",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(q) = inputs.first() {
+            check_rank("attention", "q", q, 3, &mut problems);
+            check_dtype_in(
+                "attention",
+                "q",
+                q,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if q.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "attention",
+                    tensor: "q",
+                    expected: Class::Activation,
+                    got: q.class(),
+                });
+            }
+            if let Some(ref m) = self.mla {
+                if q.rank() == 3 {
+                    if let Dim::Concrete(qd) = q.shape()[2] {
+                        if m.qk_nope_dim.checked_add(m.qk_rope_dim) != Some(qd) {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "attention",
+                                tensor: "q",
+                                detail: format!(
+                                    "q head dim {qd} != qk_nope_dim({}) + qk_rope_dim({})",
+                                    m.qk_nope_dim, m.qk_rope_dim
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(o) = outputs.first() {
+            check_rank("attention", "o", o, 3, &mut problems);
+            if o.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "attention",
+                    tensor: "o",
+                    expected: Box::new([self.out_dtype]),
+                    got: o.dtype(),
+                });
+            }
+            if o.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "attention",
+                    tensor: "o",
+                    expected: Class::Activation,
+                    got: o.class(),
+                });
+            }
+            if let Some(ref m) = self.mla {
+                if o.rank() == 3 {
+                    if let Dim::Concrete(od) = o.shape()[2] {
+                        if od != m.v_dim {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "attention",
+                                tensor: "o",
+                                detail: format!("o head dim {od} != v_dim {}", m.v_dim),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        if let (Some(q), Some(o)) = (inputs.first(), outputs.first()) {
+            if q.rank() == 3 && o.rank() == 3 {
+                check_dim_match(
+                    "attention",
+                    "o",
+                    o.shape()[0],
+                    "q",
+                    q.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "attention",
+                    "o",
+                    o.shape()[1],
+                    "q",
+                    q.shape()[1],
+                    "H",
+                    &mut problems,
+                );
+
+                if self.mla.is_none() {
+                    check_dim_match(
+                        "attention",
+                        "o",
+                        o.shape()[2],
+                        "q",
+                        q.shape()[2],
+                        "D",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.D, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ATTENTION_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ATTENTION_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.D, §6.1, §6.3).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingBlock)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "attention"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.E Sequence-state ops beyond attention
+// -----------------------------------------------------------------------------
+
+/// 1D Causal Convolution state op (Spec 1 §4.E).
+///
+/// `x [T, C], w [C, W_k], bias? [C], StateHandle(ConvWindow) -> y [T, C]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CausalConv1dOp {
+    /// Convolution kernel length `W_k`.
+    pub kernel: u32,
+    /// Post-convolution activation function.
+    pub act: ConvActivation,
+    /// State handle managing the convolution window buffer.
+    pub handle: StateHandle,
+}
+
+impl CausalConv1dOp {
+    /// Validates inputs and outputs against Spec 1 §4.E constraints.
+    // DECISION(A1.2): CausalConv1dOp accepts 2 inputs (x, w) or 3 inputs (x, w, bias [C]) per Spec 1 §4.E; candidate count error reported when input count is invalid.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if self.kernel == 0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "causal_conv1d",
+                attribute: "kernel",
+                reason: "kernel must be > 0".to_string(),
+            });
+        }
+        match self.act {
+            ConvActivation::Silu => {}
+            ConvActivation::Identity => {}
+        }
+        match self.handle.kind() {
+            StateKind::ConvWindow => {}
+            StateKind::KvPaged | StateKind::KvLatent | StateKind::Recurrent => {
+                problems.push(IrError::StateHandleKindMismatch {
+                    op: "causal_conv1d",
+                    expected: StateKind::ConvWindow,
+                    got: self.handle.kind(),
+                });
+            }
+        }
+
+        let input_count_valid = inputs.len() == 2 || inputs.len() == 3;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountCandidatesMismatch {
+                op: "causal_conv1d",
+                expected: Box::new([2, 3]),
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "causal_conv1d",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(x) = inputs.first() {
+            check_rank("causal_conv1d", "x", x, 2, &mut problems);
+            check_dtype_in(
+                "causal_conv1d",
+                "x",
+                x,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "causal_conv1d",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+        }
+
+        if let Some(w) = inputs.get(1) {
+            check_rank("causal_conv1d", "w", w, 2, &mut problems);
+            check_dtype_in(
+                "causal_conv1d",
+                "w",
+                w,
+                &[DType::F16, DType::Bf16, DType::F32, DType::I8, DType::I4],
+                &mut problems,
+            );
+            if w.class() != Class::Weight {
+                problems.push(IrError::OpClassMismatch {
+                    op: "causal_conv1d",
+                    tensor: "w",
+                    expected: Class::Weight,
+                    got: w.class(),
+                });
+            }
+            if w.rank() == 2 {
+                if let Dim::Concrete(k) = w.shape()[1] {
+                    if k != self.kernel {
+                        problems.push(IrError::OpShapeMismatch {
+                            op: "causal_conv1d",
+                            tensor: "w",
+                            detail: format!("kernel width {k} != attr kernel {}", self.kernel),
+                        });
+                    }
+                }
+            }
+        }
+
+        if let (Some(x), Some(w)) = (inputs.first(), inputs.get(1)) {
+            if x.rank() == 2 && w.rank() == 2 {
+                check_dim_match(
+                    "causal_conv1d",
+                    "w",
+                    w.shape()[0],
+                    "x",
+                    x.shape()[1],
+                    "C",
+                    &mut problems,
+                );
+            }
+        }
+
+        if let Some(bias) = inputs.get(2) {
+            check_rank("causal_conv1d", "bias", bias, 1, &mut problems);
+            check_dtype_in(
+                "causal_conv1d",
+                "bias",
+                bias,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if bias.class() != Class::Param {
+                problems.push(IrError::OpClassMismatch {
+                    op: "causal_conv1d",
+                    tensor: "bias",
+                    expected: Class::Param,
+                    got: bias.class(),
+                });
+            }
+            if let Some(x) = inputs.first() {
+                if x.rank() == 2 && bias.rank() == 1 {
+                    check_dim_match(
+                        "causal_conv1d",
+                        "bias",
+                        bias.shape()[0],
+                        "x",
+                        x.shape()[1],
+                        "C",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        if let Some(y) = outputs.first() {
+            check_rank("causal_conv1d", "y", y, 2, &mut problems);
+            check_dtype_in(
+                "causal_conv1d",
+                "y",
+                y,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "causal_conv1d",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if let (Some(x), Some(y)) = (inputs.first(), outputs.first()) {
+            if y.dtype() != x.dtype() {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "causal_conv1d",
+                    tensor: "y",
+                    expected: Box::new([x.dtype()]),
+                    got: y.dtype(),
+                });
+            }
+            if x.rank() == 2 && y.rank() == 2 {
+                check_dim_match(
+                    "causal_conv1d",
+                    "y",
+                    y.shape()[0],
+                    "x",
+                    x.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "causal_conv1d",
+                    "y",
+                    y.shape()[1],
+                    "x",
+                    x.shape()[1],
+                    "C",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.E, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::CAUSAL_CONV1D_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::CAUSAL_CONV1D_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.E, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "causal_conv1d"
+    }
+}
+
+/// Linear attention and structured state-space scan op (Spec 1 §4.E).
+///
+/// `q [T, H, D], k [T, H, D], v [T, H, Dv], alpha [T, H] f32, beta [T, H] f32, StateHandle -> o [T, H, Dv]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LinearAttnScanOp {
+    /// Recurrence / scan architecture kind.
+    pub kind: LinearAttnKind,
+    /// Chunk size for chunked parallel scan (default 64).
+    pub chunk: u32,
+    /// Destination activation dtype.
+    pub out_dtype: DType,
+    /// State handle managing the recurrent state matrices.
+    pub handle: StateHandle,
+}
+
+impl LinearAttnScanOp {
+    /// Validates inputs and outputs against Spec 1 §4.E constraints.
+    // DECISION(A1.2): LinearAttnScanOp validates exact tensor operands (q, k, v, alpha, beta) -> o; recurrent state is managed via StateHandle per Spec 1 §4.E.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        if self.chunk == 0 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "linear_attn_scan",
+                attribute: "chunk",
+                reason: "chunk must be > 0".to_string(),
+            });
+        }
+        match self.out_dtype {
+            DType::F16 | DType::Bf16 | DType::F32 => {}
+            DType::E4m3
+            | DType::E5m2
+            | DType::I4
+            | DType::I8
+            | DType::I32
+            | DType::U32
+            | DType::Bool => {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "linear_attn_scan",
+                    attribute: "out_dtype",
+                    reason: format!("must be f16, bf16, or f32, got {:?}", self.out_dtype),
+                });
+            }
+        }
+        match self.kind {
+            LinearAttnKind::GatedDeltaNet => {}
+            LinearAttnKind::GLA => {}
+            LinearAttnKind::Mamba2 => {}
+        }
+        match self.handle.kind() {
+            StateKind::Recurrent => {}
+            StateKind::KvPaged | StateKind::KvLatent | StateKind::ConvWindow => {
+                problems.push(IrError::StateHandleKindMismatch {
+                    op: "linear_attn_scan",
+                    expected: StateKind::Recurrent,
+                    got: self.handle.kind(),
+                });
+            }
+        }
+
+        let input_count_valid = inputs.len() == 5;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "linear_attn_scan",
+                expected: 5,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "linear_attn_scan",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(q) = inputs.first() {
+            check_rank("linear_attn_scan", "q", q, 3, &mut problems);
+            check_dtype_in(
+                "linear_attn_scan",
+                "q",
+                q,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if q.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "q",
+                    expected: Class::Activation,
+                    got: q.class(),
+                });
+            }
+        }
+
+        if let Some(k) = inputs.get(1) {
+            check_rank("linear_attn_scan", "k", k, 3, &mut problems);
+            check_dtype_in(
+                "linear_attn_scan",
+                "k",
+                k,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if k.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "k",
+                    expected: Class::Activation,
+                    got: k.class(),
+                });
+            }
+            if let Some(q) = inputs.first() {
+                if k.dtype() != q.dtype() {
+                    problems.push(IrError::OpDTypeMismatch {
+                        op: "linear_attn_scan",
+                        tensor: "k",
+                        expected: Box::new([q.dtype()]),
+                        got: k.dtype(),
+                    });
+                }
+            }
+        }
+
+        if let Some(v) = inputs.get(2) {
+            check_rank("linear_attn_scan", "v", v, 3, &mut problems);
+            check_dtype_in(
+                "linear_attn_scan",
+                "v",
+                v,
+                &[DType::F16, DType::Bf16, DType::F32],
+                &mut problems,
+            );
+            if v.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "v",
+                    expected: Class::Activation,
+                    got: v.class(),
+                });
+            }
+            if let Some(q) = inputs.first() {
+                if v.dtype() != q.dtype() {
+                    problems.push(IrError::OpDTypeMismatch {
+                        op: "linear_attn_scan",
+                        tensor: "v",
+                        expected: Box::new([q.dtype()]),
+                        got: v.dtype(),
+                    });
+                }
+            }
+        }
+
+        if let Some(alpha) = inputs.get(3) {
+            check_rank("linear_attn_scan", "alpha", alpha, 2, &mut problems);
+            check_dtype_in(
+                "linear_attn_scan",
+                "alpha",
+                alpha,
+                &[DType::F32],
+                &mut problems,
+            );
+            if alpha.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "alpha",
+                    expected: Class::Activation,
+                    got: alpha.class(),
+                });
+            }
+        }
+
+        if let Some(beta) = inputs.get(4) {
+            check_rank("linear_attn_scan", "beta", beta, 2, &mut problems);
+            check_dtype_in(
+                "linear_attn_scan",
+                "beta",
+                beta,
+                &[DType::F32],
+                &mut problems,
+            );
+            if beta.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "beta",
+                    expected: Class::Activation,
+                    got: beta.class(),
+                });
+            }
+        }
+
+        if let (Some(q), Some(k)) = (inputs.first(), inputs.get(1)) {
+            if q.rank() == 3 && k.rank() == 3 {
+                check_dim_match(
+                    "linear_attn_scan",
+                    "k",
+                    k.shape()[0],
+                    "q",
+                    q.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "linear_attn_scan",
+                    "k",
+                    k.shape()[1],
+                    "q",
+                    q.shape()[1],
+                    "H",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "linear_attn_scan",
+                    "k",
+                    k.shape()[2],
+                    "q",
+                    q.shape()[2],
+                    "D",
+                    &mut problems,
+                );
+            }
+        }
+
+        if let (Some(q), Some(v)) = (inputs.first(), inputs.get(2)) {
+            if q.rank() == 3 && v.rank() == 3 {
+                check_dim_match(
+                    "linear_attn_scan",
+                    "v",
+                    v.shape()[0],
+                    "q",
+                    q.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "linear_attn_scan",
+                    "v",
+                    v.shape()[1],
+                    "q",
+                    q.shape()[1],
+                    "H",
+                    &mut problems,
+                );
+            }
+        }
+
+        if let (Some(q), Some(alpha)) = (inputs.first(), inputs.get(3)) {
+            if q.rank() == 3 && alpha.rank() == 2 {
+                check_dim_match(
+                    "linear_attn_scan",
+                    "alpha",
+                    alpha.shape()[0],
+                    "q",
+                    q.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "linear_attn_scan",
+                    "alpha",
+                    alpha.shape()[1],
+                    "q",
+                    q.shape()[1],
+                    "H",
+                    &mut problems,
+                );
+            }
+        }
+
+        if let (Some(q), Some(beta)) = (inputs.first(), inputs.get(4)) {
+            if q.rank() == 3 && beta.rank() == 2 {
+                check_dim_match(
+                    "linear_attn_scan",
+                    "beta",
+                    beta.shape()[0],
+                    "q",
+                    q.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "linear_attn_scan",
+                    "beta",
+                    beta.shape()[1],
+                    "q",
+                    q.shape()[1],
+                    "H",
+                    &mut problems,
+                );
+            }
+        }
+
+        if let Some(o) = outputs.first() {
+            check_rank("linear_attn_scan", "o", o, 3, &mut problems);
+            if o.dtype() != self.out_dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "o",
+                    expected: Box::new([self.out_dtype]),
+                    got: o.dtype(),
+                });
+            }
+            if o.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "linear_attn_scan",
+                    tensor: "o",
+                    expected: Class::Activation,
+                    got: o.class(),
+                });
+            }
+        }
+
+        if let (Some(q), Some(o)) = (inputs.first(), outputs.first()) {
+            if q.rank() == 3 && o.rank() == 3 {
+                check_dim_match(
+                    "linear_attn_scan",
+                    "o",
+                    o.shape()[0],
+                    "q",
+                    q.shape()[0],
+                    "T",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "linear_attn_scan",
+                    "o",
+                    o.shape()[1],
+                    "q",
+                    q.shape()[1],
+                    "H",
+                    &mut problems,
+                );
+            }
+        }
+
+        if let (Some(v), Some(o)) = (inputs.get(2), outputs.first()) {
+            if v.rank() == 3 && o.rank() == 3 {
+                check_dim_match(
+                    "linear_attn_scan",
+                    "o",
+                    o.shape()[2],
+                    "v",
+                    v.shape()[2],
+                    "Dv",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.E, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::LINEAR_ATTN_SCAN_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::LINEAR_ATTN_SCAN_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.E, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "linear_attn_scan"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.F Sampling and verification
+// -----------------------------------------------------------------------------
+
+/// Logit postprocessing, temperature, penalties, and grammar masking op (Spec 1 §4.F).
+///
+/// `logits [S, q, V] f32, params, history_counts?, grammar_mask? -> probs [S, q, V] f32`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct LogitsPostprocessOp;
+
+impl LogitsPostprocessOp {
+    /// Validates inputs and outputs against Spec 1 §4.F constraints.
+    // DECISION(A1.2): LogitsPostprocessOp validates exact rank-3 logits [S, q, V] -> probs [S, q, V], distinguishing optional history_counts [S, V] (U32, rank 2) from grammar_mask [S, q, V] (Bool, rank 3) by dtype and rank; SamplingParams is validated as structured external metadata per Spec 1 §4.F and SI-12; rejected rank-2 logits/probs in op validation because multi-sequence verify steps require explicit query dimension q.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = !inputs.is_empty() && inputs.len() <= 3;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountCandidatesMismatch {
+                op: "logits_postprocess",
+                expected: Box::new([1, 2, 3]),
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "logits_postprocess",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(logits) = inputs.first() {
+            check_rank("logits_postprocess", "logits", logits, 3, &mut problems);
+            check_dtype_in(
+                "logits_postprocess",
+                "logits",
+                logits,
+                &[DType::F32],
+                &mut problems,
+            );
+            if logits.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "logits_postprocess",
+                    tensor: "logits",
+                    expected: Class::Activation,
+                    got: logits.class(),
+                });
+            }
+        }
+
+        if inputs.len() == 2 {
+            let opt = &inputs[1];
+            if opt.dtype() == DType::Bool || opt.rank() == 3 {
+                check_rank("logits_postprocess", "grammar_mask", opt, 3, &mut problems);
+                check_dtype_in(
+                    "logits_postprocess",
+                    "grammar_mask",
+                    opt,
+                    &[DType::Bool],
+                    &mut problems,
+                );
+                if opt.class() != Class::Activation {
+                    problems.push(IrError::OpClassMismatch {
+                        op: "logits_postprocess",
+                        tensor: "grammar_mask",
+                        expected: Class::Activation,
+                        got: opt.class(),
+                    });
+                }
+                if let Some(logits) = inputs.first() {
+                    if logits.rank() == 3 && opt.rank() == 3 {
+                        check_dim_match(
+                            "logits_postprocess",
+                            "grammar_mask",
+                            opt.shape()[0],
+                            "logits",
+                            logits.shape()[0],
+                            "S",
+                            &mut problems,
+                        );
+                        check_dim_match(
+                            "logits_postprocess",
+                            "grammar_mask",
+                            opt.shape()[1],
+                            "logits",
+                            logits.shape()[1],
+                            "q",
+                            &mut problems,
+                        );
+                        check_dim_match(
+                            "logits_postprocess",
+                            "grammar_mask",
+                            opt.shape()[2],
+                            "logits",
+                            logits.shape()[2],
+                            "V",
+                            &mut problems,
+                        );
+                    }
+                }
+            } else {
+                check_rank(
+                    "logits_postprocess",
+                    "history_counts",
+                    opt,
+                    2,
+                    &mut problems,
+                );
+                check_dtype_in(
+                    "logits_postprocess",
+                    "history_counts",
+                    opt,
+                    &[DType::U32],
+                    &mut problems,
+                );
+                if opt.class() != Class::Activation {
+                    problems.push(IrError::OpClassMismatch {
+                        op: "logits_postprocess",
+                        tensor: "history_counts",
+                        expected: Class::Activation,
+                        got: opt.class(),
+                    });
+                }
+                if let Some(logits) = inputs.first() {
+                    if logits.rank() == 3 && opt.rank() == 2 {
+                        check_dim_match(
+                            "logits_postprocess",
+                            "history_counts",
+                            opt.shape()[0],
+                            "logits",
+                            logits.shape()[0],
+                            "S",
+                            &mut problems,
+                        );
+                        check_dim_match(
+                            "logits_postprocess",
+                            "history_counts",
+                            opt.shape()[1],
+                            "logits",
+                            logits.shape()[2],
+                            "V",
+                            &mut problems,
+                        );
+                    }
+                }
+            }
+        } else if inputs.len() == 3 {
+            let history = &inputs[1];
+            let mask = &inputs[2];
+
+            check_rank(
+                "logits_postprocess",
+                "history_counts",
+                history,
+                2,
+                &mut problems,
+            );
+            check_dtype_in(
+                "logits_postprocess",
+                "history_counts",
+                history,
+                &[DType::U32],
+                &mut problems,
+            );
+            if history.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "logits_postprocess",
+                    tensor: "history_counts",
+                    expected: Class::Activation,
+                    got: history.class(),
+                });
+            }
+            if let Some(logits) = inputs.first() {
+                if logits.rank() == 3 && history.rank() == 2 {
+                    check_dim_match(
+                        "logits_postprocess",
+                        "history_counts",
+                        history.shape()[0],
+                        "logits",
+                        logits.shape()[0],
+                        "S",
+                        &mut problems,
+                    );
+                    check_dim_match(
+                        "logits_postprocess",
+                        "history_counts",
+                        history.shape()[1],
+                        "logits",
+                        logits.shape()[2],
+                        "V",
+                        &mut problems,
+                    );
+                }
+            }
+
+            check_rank("logits_postprocess", "grammar_mask", mask, 3, &mut problems);
+            check_dtype_in(
+                "logits_postprocess",
+                "grammar_mask",
+                mask,
+                &[DType::Bool],
+                &mut problems,
+            );
+            if mask.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "logits_postprocess",
+                    tensor: "grammar_mask",
+                    expected: Class::Activation,
+                    got: mask.class(),
+                });
+            }
+            if let Some(logits) = inputs.first() {
+                if logits.rank() == 3 && mask.rank() == 3 {
+                    check_dim_match(
+                        "logits_postprocess",
+                        "grammar_mask",
+                        mask.shape()[0],
+                        "logits",
+                        logits.shape()[0],
+                        "S",
+                        &mut problems,
+                    );
+                    check_dim_match(
+                        "logits_postprocess",
+                        "grammar_mask",
+                        mask.shape()[1],
+                        "logits",
+                        logits.shape()[1],
+                        "q",
+                        &mut problems,
+                    );
+                    check_dim_match(
+                        "logits_postprocess",
+                        "grammar_mask",
+                        mask.shape()[2],
+                        "logits",
+                        logits.shape()[2],
+                        "V",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        if let Some(probs) = outputs.first() {
+            check_rank("logits_postprocess", "probs", probs, 3, &mut problems);
+            check_dtype_in(
+                "logits_postprocess",
+                "probs",
+                probs,
+                &[DType::F32],
+                &mut problems,
+            );
+            if probs.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "logits_postprocess",
+                    tensor: "probs",
+                    expected: Class::Activation,
+                    got: probs.class(),
+                });
+            }
+        }
+
+        if let (Some(logits), Some(probs)) = (inputs.first(), outputs.first()) {
+            if logits.rank() == 3 && probs.rank() == 3 {
+                check_dim_match(
+                    "logits_postprocess",
+                    "probs",
+                    probs.shape()[0],
+                    "logits",
+                    logits.shape()[0],
+                    "S",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "logits_postprocess",
+                    "probs",
+                    probs.shape()[1],
+                    "logits",
+                    logits.shape()[1],
+                    "q",
+                    &mut problems,
+                );
+                check_dim_match(
+                    "logits_postprocess",
+                    "probs",
+                    probs.shape()[2],
+                    "logits",
+                    logits.shape()[2],
+                    "V",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.F, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::LOGITS_POSTPROCESS_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::LOGITS_POSTPROCESS_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.F, §6.1, §6.5).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "logits_postprocess"
+    }
+}
+
+/// Stochastic or greedy token sampling op (Spec 1 §4.F).
+///
+/// `probs [S, V] f32, rng_state [S] -> token [S] u32, rng_state' [S]`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SampleOp {
+    /// PRNG algorithm.
+    pub rng: RngAlgorithm,
+}
+
+impl SampleOp {
+    /// Validates inputs and outputs against Spec 1 §4.F constraints.
+    // DECISION(A1.2): SampleOp validates exactly one probs [S, V] tensor to one token [S] tensor; rng_state is typed external metadata per Spec 1 §4.F and SI-12.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        match self.rng {
+            RngAlgorithm::Philox4x32 => {}
+        }
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "sample",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "sample",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(probs) = inputs.first() {
+            check_rank("sample", "probs", probs, 2, &mut problems);
+            check_dtype_in("sample", "probs", probs, &[DType::F32], &mut problems);
+            if probs.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "sample",
+                    tensor: "probs",
+                    expected: Class::Activation,
+                    got: probs.class(),
+                });
+            }
+        }
+
+        if let Some(token) = outputs.first() {
+            check_rank("sample", "token", token, 1, &mut problems);
+            check_dtype_in("sample", "token", token, &[DType::U32], &mut problems);
+            if token.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "sample",
+                    tensor: "token",
+                    expected: Class::Activation,
+                    got: token.class(),
+                });
+            }
+        }
+
+        if let (Some(probs), Some(token)) = (inputs.first(), outputs.first()) {
+            if probs.rank() == 2 && token.rank() == 1 {
+                check_dim_match(
+                    "sample",
+                    "token",
+                    token.shape()[0],
+                    "probs",
+                    probs.shape()[0],
+                    "S",
+                    &mut problems,
+                );
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.F, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::SAMPLE_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::SAMPLE_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.F, §6.1, §6.5).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "sample"
+    }
+}
+
+/// Speculative decoding verification op (Spec 1 §4.F).
+///
+/// `draft_tokens [S, k] u32, target_probs [S, k+1, V] f32, ... -> accepted [S, k+1] u32, accept_len [S] u32`
+#[derive(Debug, Clone, PartialEq)]
+pub struct VerifyOp {
+    /// Verification and acceptance policy.
+    pub method: VerifyMethod,
+}
+
+impl VerifyOp {
+    /// Validates inputs and outputs against Spec 1 §4.F constraints.
+    // DECISION(A1.2): VerifyOp validates exact tensor operands draft_tokens [S, k], target_probs [S, k+1, V], and optional draft_probs [S, k, V] to accepted [S, k+1] and accept_len [S]; tree mask and rng_state are typed external metadata per Spec 1 §4.F, Spec 7 §4, SI-12.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        match self.method {
+            VerifyMethod::Rejection => {}
+            VerifyMethod::Greedy => {}
+            VerifyMethod::TypicalAcceptance { eps, delta } => {
+                if !eps.is_finite() || eps <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "verify",
+                        attribute: "method.eps",
+                        reason: format!("eps must be finite and > 0, got {eps}"),
+                    });
+                }
+                if !delta.is_finite() || delta <= 0.0 {
+                    problems.push(IrError::OpAttributeInvalid {
+                        op: "verify",
+                        attribute: "method.delta",
+                        reason: format!("delta must be finite and > 0, got {delta}"),
+                    });
+                }
+            }
+        }
+
+        let input_count_valid = inputs.len() == 2 || inputs.len() == 3;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountCandidatesMismatch {
+                op: "verify",
+                expected: Box::new([2, 3]),
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 2;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "verify",
+                expected: 2,
+                got: outputs.len(),
+            });
+        }
+
+        let draft_probs_opt = (inputs.len() == 3).then(|| &inputs[1]);
+        let target_probs_opt = match inputs.len() {
+            2 => inputs.get(1),
+            3 => inputs.get(2),
+            0 | 1 | 4.. => None,
+        };
+
+        if let Some(draft_tokens) = inputs.first() {
+            check_rank("verify", "draft_tokens", draft_tokens, 2, &mut problems);
+            check_dtype_in(
+                "verify",
+                "draft_tokens",
+                draft_tokens,
+                &[DType::U32],
+                &mut problems,
+            );
+            if draft_tokens.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "verify",
+                    tensor: "draft_tokens",
+                    expected: Class::Activation,
+                    got: draft_tokens.class(),
+                });
+            }
+        }
+
+        if let Some(target_probs) = target_probs_opt {
+            check_rank("verify", "target_probs", target_probs, 3, &mut problems);
+            check_dtype_in(
+                "verify",
+                "target_probs",
+                target_probs,
+                &[DType::F32],
+                &mut problems,
+            );
+            if target_probs.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "verify",
+                    tensor: "target_probs",
+                    expected: Class::Activation,
+                    got: target_probs.class(),
+                });
+            }
+            if let Some(draft_tokens) = inputs.first() {
+                if draft_tokens.rank() == 2 && target_probs.rank() == 3 {
+                    check_dim_match(
+                        "verify",
+                        "target_probs",
+                        target_probs.shape()[0],
+                        "draft_tokens",
+                        draft_tokens.shape()[0],
+                        "S",
+                        &mut problems,
+                    );
+                    if let (Dim::Concrete(k), Dim::Concrete(k1)) =
+                        (draft_tokens.shape()[1], target_probs.shape()[1])
+                    {
+                        let expected_k1 = k.checked_add(1);
+                        if expected_k1 != Some(k1) {
+                            let expected = expected_k1.map_or_else(
+                                || "overflow (> u32::MAX)".to_string(),
+                                |value| value.to_string(),
+                            );
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "verify",
+                                tensor: "target_probs",
+                                detail: format!(
+                                    "target_probs axis 1 extent {k1} != draft_tokens axis 1 + 1 ({})",
+                                    expected
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(draft_probs) = draft_probs_opt {
+            check_rank("verify", "draft_probs", draft_probs, 3, &mut problems);
+            check_dtype_in(
+                "verify",
+                "draft_probs",
+                draft_probs,
+                &[DType::F32],
+                &mut problems,
+            );
+            if draft_probs.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "verify",
+                    tensor: "draft_probs",
+                    expected: Class::Activation,
+                    got: draft_probs.class(),
+                });
+            }
+            if let Some(draft_tokens) = inputs.first() {
+                if draft_tokens.rank() == 2 && draft_probs.rank() == 3 {
+                    check_dim_match(
+                        "verify",
+                        "draft_probs",
+                        draft_probs.shape()[0],
+                        "draft_tokens",
+                        draft_tokens.shape()[0],
+                        "S",
+                        &mut problems,
+                    );
+                    check_dim_match(
+                        "verify",
+                        "draft_probs",
+                        draft_probs.shape()[1],
+                        "draft_tokens",
+                        draft_tokens.shape()[1],
+                        "k",
+                        &mut problems,
+                    );
+                }
+            }
+            if let Some(target_probs) = target_probs_opt {
+                if draft_probs.rank() == 3 && target_probs.rank() == 3 {
+                    check_dim_match(
+                        "verify",
+                        "draft_probs",
+                        draft_probs.shape()[2],
+                        "target_probs",
+                        target_probs.shape()[2],
+                        "V",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        if let Some(accepted) = outputs.first() {
+            check_rank("verify", "accepted", accepted, 2, &mut problems);
+            check_dtype_in("verify", "accepted", accepted, &[DType::U32], &mut problems);
+            if accepted.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "verify",
+                    tensor: "accepted",
+                    expected: Class::Activation,
+                    got: accepted.class(),
+                });
+            }
+            if let Some(draft_tokens) = inputs.first() {
+                if draft_tokens.rank() == 2 && accepted.rank() == 2 {
+                    check_dim_match(
+                        "verify",
+                        "accepted",
+                        accepted.shape()[0],
+                        "draft_tokens",
+                        draft_tokens.shape()[0],
+                        "S",
+                        &mut problems,
+                    );
+                    if let (Dim::Concrete(k), Dim::Concrete(ak1)) =
+                        (draft_tokens.shape()[1], accepted.shape()[1])
+                    {
+                        let expected_ak1 = k.checked_add(1);
+                        if expected_ak1 != Some(ak1) {
+                            let expected = expected_ak1.map_or_else(
+                                || "overflow (> u32::MAX)".to_string(),
+                                |value| value.to_string(),
+                            );
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "verify",
+                                tensor: "accepted",
+                                detail: format!(
+                                    "accepted axis 1 extent {ak1} != draft_tokens axis 1 + 1 ({})",
+                                    expected
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(accept_len) = outputs.get(1) {
+            check_rank("verify", "accept_len", accept_len, 1, &mut problems);
+            check_dtype_in(
+                "verify",
+                "accept_len",
+                accept_len,
+                &[DType::U32],
+                &mut problems,
+            );
+            if accept_len.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "verify",
+                    tensor: "accept_len",
+                    expected: Class::Activation,
+                    got: accept_len.class(),
+                });
+            }
+            if let Some(draft_tokens) = inputs.first() {
+                if draft_tokens.rank() == 2 && accept_len.rank() == 1 {
+                    check_dim_match(
+                        "verify",
+                        "accept_len",
+                        accept_len.shape()[0],
+                        "draft_tokens",
+                        draft_tokens.shape()[0],
+                        "S",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.F, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::VERIFY_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::VERIFY_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.F, §6.1, §6.5).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "verify"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.G Collectives
+// -----------------------------------------------------------------------------
+
+/// All-reduce collective op (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AllReduceOp {
+    /// Communication group identifier.
+    pub group: GroupId,
+    /// Reduction operator (e.g. Sum).
+    pub op: ReduceOp,
+    /// Element dtype.
+    pub dtype: DType,
+    /// Internal accumulator dtype (f32 per Spec 1 §4.G).
+    pub reduce_in: DType,
+}
+
+impl AllReduceOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        match self.op {
+            ReduceOp::Sum => {}
+        }
+
+        if self.reduce_in != DType::F32 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "all_reduce",
+                attribute: "reduce_in",
+                reason: format!("must be f32 per Spec 1 §4.G, got {:?}", self.reduce_in),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "all_reduce",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "all_reduce",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(x) = inputs.first() {
+            if x.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "all_reduce",
+                    tensor: "x",
+                    expected: Box::new([self.dtype]),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_reduce",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+        }
+
+        if let Some(y) = outputs.first() {
+            if y.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "all_reduce",
+                    tensor: "y",
+                    expected: Box::new([self.dtype]),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_reduce",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if let (Some(x), Some(y)) = (inputs.first(), outputs.first()) {
+            if y.rank() != x.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "all_reduce",
+                    tensor: "y",
+                    expected: x.rank(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..x.rank() {
+                    check_dim_match(
+                        "all_reduce",
+                        "y",
+                        y.shape()[i],
+                        "x",
+                        x.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ALL_REDUCE_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ALL_REDUCE_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingRank)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "all_reduce"
+    }
+}
+
+/// All-gather collective op (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AllGatherOp {
+    /// Communication group identifier.
+    pub group: GroupId,
+    /// Axis along which tensors are concatenated.
+    pub axis: u32,
+    /// Element dtype.
+    pub dtype: DType,
+}
+
+impl AllGatherOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "all_gather",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "all_gather",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(x) = inputs.first() {
+            if x.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "all_gather",
+                    tensor: "x",
+                    expected: Box::new([self.dtype]),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_gather",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+            if self.axis >= x.rank() as u32 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "all_gather",
+                    attribute: "axis",
+                    reason: format!("axis {} out of bounds for rank {}", self.axis, x.rank()),
+                });
+            }
+        }
+
+        if let Some(y) = outputs.first() {
+            if y.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "all_gather",
+                    tensor: "y",
+                    expected: Box::new([self.dtype]),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_gather",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+            if inputs.is_empty() && self.axis >= y.rank() as u32 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "all_gather",
+                    attribute: "axis",
+                    reason: format!("axis {} out of bounds for rank {}", self.axis, y.rank()),
+                });
+            }
+        }
+
+        if let (Some(x), Some(y)) = (inputs.first(), outputs.first()) {
+            if y.rank() != x.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "all_gather",
+                    tensor: "y",
+                    expected: x.rank(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..x.rank() {
+                    if i as u32 != self.axis {
+                        check_dim_match(
+                            "all_gather",
+                            "y",
+                            y.shape()[i],
+                            "x",
+                            x.shape()[i],
+                            "dim",
+                            &mut problems,
+                        );
+                    } else if let (Dim::Concrete(x_dim), Dim::Concrete(y_dim)) =
+                        (x.shape()[i], y.shape()[i])
+                    {
+                        if x_dim == 0 || y_dim < x_dim || y_dim % x_dim != 0 {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "all_gather",
+                                tensor: "y",
+                                detail: format!(
+                                    "gathered axis {} output extent {y_dim} is not a valid non-zero multiple of input extent {x_dim}",
+                                    self.axis
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ALL_GATHER_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ALL_GATHER_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "all_gather"
+    }
+}
+
+/// Reduce-scatter collective op (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReduceScatterOp {
+    /// Communication group identifier.
+    pub group: GroupId,
+    /// Axis along which reduction partitions are distributed.
+    pub axis: u32,
+    /// Reduction operator.
+    pub op: ReduceOp,
+    /// Element dtype.
+    pub dtype: DType,
+    /// Internal accumulator dtype.
+    pub reduce_in: DType,
+}
+
+impl ReduceScatterOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        match self.op {
+            ReduceOp::Sum => {}
+        }
+
+        if self.reduce_in != DType::F32 {
+            problems.push(IrError::OpAttributeInvalid {
+                op: "reduce_scatter",
+                attribute: "reduce_in",
+                reason: format!("must be f32 per Spec 1 §4.G, got {:?}", self.reduce_in),
+            });
+        }
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "reduce_scatter",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "reduce_scatter",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(x) = inputs.first() {
+            if x.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "reduce_scatter",
+                    tensor: "x",
+                    expected: Box::new([self.dtype]),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "reduce_scatter",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+            if self.axis >= x.rank() as u32 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "reduce_scatter",
+                    attribute: "axis",
+                    reason: format!("axis {} out of bounds for rank {}", self.axis, x.rank()),
+                });
+            }
+        }
+
+        if let Some(y) = outputs.first() {
+            if y.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "reduce_scatter",
+                    tensor: "y",
+                    expected: Box::new([self.dtype]),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "reduce_scatter",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+            if inputs.is_empty() && self.axis >= y.rank() as u32 {
+                problems.push(IrError::OpAttributeInvalid {
+                    op: "reduce_scatter",
+                    attribute: "axis",
+                    reason: format!("axis {} out of bounds for rank {}", self.axis, y.rank()),
+                });
+            }
+        }
+
+        if let (Some(x), Some(y)) = (inputs.first(), outputs.first()) {
+            if y.rank() != x.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "reduce_scatter",
+                    tensor: "y",
+                    expected: x.rank(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..x.rank() {
+                    if i as u32 != self.axis {
+                        check_dim_match(
+                            "reduce_scatter",
+                            "y",
+                            y.shape()[i],
+                            "x",
+                            x.shape()[i],
+                            "dim",
+                            &mut problems,
+                        );
+                    } else if let (Dim::Concrete(x_dim), Dim::Concrete(y_dim)) =
+                        (x.shape()[i], y.shape()[i])
+                    {
+                        if y_dim == 0 || x_dim < y_dim || x_dim % y_dim != 0 {
+                            problems.push(IrError::OpShapeMismatch {
+                                op: "reduce_scatter",
+                                tensor: "y",
+                                detail: format!(
+                                    "scattered axis {} output extent {y_dim} is not a valid non-zero divisor of input extent {x_dim}",
+                                    self.axis
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::REDUCE_SCATTER_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::REDUCE_SCATTER_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::f32(ReductionOrder::AscendingRank)
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "reduce_scatter"
+    }
+}
+
+/// All-to-all collective op for Expert Parallel token dispatch/combine (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AllToAllOp {
+    /// Communication group identifier.
+    pub group: GroupId,
+    /// Element dtype.
+    pub dtype: DType,
+}
+
+impl AllToAllOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    // DECISION(A1.2): AllToAllOp requires exactly two inputs (x, counts [P] u32) and one output y per Spec 1 §4.G and SI-11; rejected optional arities or invented recv_counts output.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 2;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "all_to_all",
+                expected: 2,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "all_to_all",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(x) = inputs.first() {
+            if x.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "all_to_all",
+                    tensor: "x",
+                    expected: Box::new([self.dtype]),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_to_all",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+        }
+
+        if let Some(counts) = inputs.get(1) {
+            check_rank("all_to_all", "counts", counts, 1, &mut problems);
+            check_dtype_in("all_to_all", "counts", counts, &[DType::U32], &mut problems);
+            if counts.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_to_all",
+                    tensor: "counts",
+                    expected: Class::Activation,
+                    got: counts.class(),
+                });
+            }
+        }
+
+        if let Some(y) = outputs.first() {
+            if y.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "all_to_all",
+                    tensor: "y",
+                    expected: Box::new([self.dtype]),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "all_to_all",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+        }
+
+        if let (Some(x), Some(y)) = (inputs.first(), outputs.first()) {
+            if y.rank() != x.rank() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "all_to_all",
+                    tensor: "y",
+                    expected: x.rank(),
+                    got: y.rank(),
+                });
+            } else if x.rank() >= 2 {
+                for i in 1..x.rank() {
+                    check_dim_match(
+                        "all_to_all",
+                        "y",
+                        y.shape()[i],
+                        "x",
+                        x.shape()[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::ALL_TO_ALL_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::ALL_TO_ALL_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "all_to_all"
+    }
+}
+
+/// Point-to-point send collective op (Spec 1 §4.G).
+// DECISION(A1.2): SendOp includes group: GroupId per Spec 1 §4.G and SI-11; rejected peer-only struct because point-to-point operations require communication group context for communicators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SendOp {
+    /// Communication group identifier.
+    pub group: GroupId,
+    /// Destination peer device rank.
+    pub peer: u32,
+    /// Transferred element dtype.
+    pub dtype: DType,
+}
+
+impl SendOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.len() == 1;
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "send",
+                expected: 1,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.is_empty();
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "send",
+                expected: 0,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(x) = inputs.first() {
+            if x.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "send",
+                    tensor: "x",
+                    expected: Box::new([self.dtype]),
+                    got: x.dtype(),
+                });
+            }
+            if x.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "send",
+                    tensor: "x",
+                    expected: Class::Activation,
+                    got: x.class(),
+                });
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::SEND_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::SEND_RULES.iter().map(|r| r.as_tuple()).collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "send"
+    }
+}
+
+/// Point-to-point receive collective op (Spec 1 §4.G).
+// DECISION(A1.2): RecvOp includes group: GroupId per Spec 1 §4.G and SI-11; rejected peer-only struct because point-to-point operations require communication group context for communicators.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RecvOp {
+    /// Communication group identifier.
+    pub group: GroupId,
+    /// Source peer device rank.
+    pub peer: u32,
+    /// Expected received tensor shape.
+    pub shape: Box<[Dim]>,
+    /// Received element dtype.
+    pub dtype: DType,
+}
+
+impl RecvOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+
+        let input_count_valid = inputs.is_empty();
+        if !input_count_valid {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "recv",
+                expected: 0,
+                got: inputs.len(),
+            });
+        }
+
+        let output_count_valid = outputs.len() == 1;
+        if !output_count_valid {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "recv",
+                expected: 1,
+                got: outputs.len(),
+            });
+        }
+
+        if let Some(y) = outputs.first() {
+            if y.dtype() != self.dtype {
+                problems.push(IrError::OpDTypeMismatch {
+                    op: "recv",
+                    tensor: "y",
+                    expected: Box::new([self.dtype]),
+                    got: y.dtype(),
+                });
+            }
+            if y.class() != Class::Activation {
+                problems.push(IrError::OpClassMismatch {
+                    op: "recv",
+                    tensor: "y",
+                    expected: Class::Activation,
+                    got: y.class(),
+                });
+            }
+            if y.rank() != self.shape.len() {
+                problems.push(IrError::OpRankMismatch {
+                    op: "recv",
+                    tensor: "y",
+                    expected: self.shape.len(),
+                    got: y.rank(),
+                });
+            } else {
+                for i in 0..self.shape.len() {
+                    check_dim_match(
+                        "recv",
+                        "y",
+                        y.shape()[i],
+                        "attr.shape",
+                        self.shape[i],
+                        "dim",
+                        &mut problems,
+                    );
+                }
+            }
+        }
+
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::RECV_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::RECV_RULES.iter().map(|r| r.as_tuple()).collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "recv"
+    }
+}
+
+/// Collective cross-device synchronization barrier op (Spec 1 §4.G).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BarrierOp {
+    /// Synchronized communication group identifier.
+    pub group: GroupId,
+}
+
+impl BarrierOp {
+    /// Validates inputs and outputs against Spec 1 §4.G constraints.
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        let mut problems = Vec::new();
+        if !inputs.is_empty() {
+            problems.push(IrError::OpInputCountMismatch {
+                op: "barrier",
+                expected: 0,
+                got: inputs.len(),
+            });
+        }
+        if !outputs.is_empty() {
+            problems.push(IrError::OpOutputCountMismatch {
+                op: "barrier",
+                expected: 0,
+                got: outputs.len(),
+            });
+        }
+        IrError::from_problems(problems)
+    }
+
+    /// Returns legal sharding rules (Spec 1 §4.G, §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::BARRIER_RULES
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::BARRIER_RULES
+            .iter()
+            .map(|r| r.as_tuple())
+            .collect()
+    }
+
+    /// Returns op numerics contract (Spec 1 §4.G, §6.1).
+    pub fn numerics(&self) -> Numerics {
+        Numerics::none()
+    }
+
+    /// Returns op identifier name.
+    pub const fn op_name(&self) -> &'static str {
+        "barrier"
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Closed Op Enum (Spec 1 §4)
+// -----------------------------------------------------------------------------
+
+/// Closed set of operations supported by the Op IR (Spec 1 §4).
+///
+/// Exhaustive matching required per CONVENTIONS.md §3.2.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Op {
+    /// Token embedding lookup (Spec 1 §4.A).
+    EmbedGather(EmbedGatherOp),
+    /// N-gram prefix gather (Spec 1 §4.A).
+    NgramGather(NgramGatherOp),
+    /// Activation quantization (Spec 1 §4.A).
+    QuantAct(QuantActOp),
+    /// Precision casting (Spec 1 §4.A).
+    Cast(CastOp),
+    /// Memory copy and contiguization (Spec 1 §4.A).
+    Copy(CopyOp),
+    /// Row gather (Spec 1 §4.A).
+    GatherRows(GatherRowsOp),
+    /// Deterministic scatter-add rows (Spec 1 §4.A).
+    ScatterAddRows(ScatterAddRowsOp),
+    /// Normalization: RMS or Layer norm (Spec 1 §4.B).
+    Norm(NormOp),
+    /// Residual addition (Spec 1 §4.B).
+    ResidualAdd(ResidualAddOp),
+    /// Gated activation multiplication (Spec 1 §4.B).
+    ActMul(ActMulOp),
+    /// Standalone activation (Spec 1 §4.B).
+    Activation(ActivationOp),
+    /// Rotary Position Embedding (Spec 1 §4.B).
+    Rope(RopeOp),
+    /// Matrix multiplication with epilogue (Spec 1 §4.C).
+    Matmul(MatmulOp),
+    /// Mixture of Experts routing (Spec 1 §4.C).
+    MoeRoute(MoeRouteOp),
+    /// Mixture of Experts feed-forward (Spec 1 §4.C).
+    MoeFfn(MoeFfnOp),
+    /// KV state cache write (Spec 1 §4.D).
+    StateWriteKv(StateWriteKvOp),
+    /// Paged / latent attention (Spec 1 §4.D).
+    Attention(AttentionOp),
+    /// 1D Causal Convolution (Spec 1 §4.E).
+    CausalConv1d(CausalConv1dOp),
+    /// Linear attention scan (Spec 1 §4.E).
+    LinearAttnScan(LinearAttnScanOp),
+    /// Logits postprocessing (Spec 1 §4.F).
+    LogitsPostprocess(LogitsPostprocessOp),
+    /// Stochastic or greedy sampling (Spec 1 §4.F).
+    Sample(SampleOp),
+    /// Speculative verification (Spec 1 §4.F).
+    Verify(VerifyOp),
+    /// All-reduce collective (Spec 1 §4.G).
+    AllReduce(AllReduceOp),
+    /// All-gather collective (Spec 1 §4.G).
+    AllGather(AllGatherOp),
+    /// Reduce-scatter collective (Spec 1 §4.G).
+    ReduceScatter(ReduceScatterOp),
+    /// All-to-all collective (Spec 1 §4.G).
+    AllToAll(AllToAllOp),
+    /// Point-to-point send (Spec 1 §4.G).
+    Send(SendOp),
+    /// Point-to-point receive (Spec 1 §4.G).
+    Recv(RecvOp),
+    /// Device barrier (Spec 1 §4.G).
+    Barrier(BarrierOp),
+}
+
+impl Op {
+    /// Validates inputs and outputs against the constraints for this op (Spec 1 §4).
+    pub fn validate(
+        &self,
+        inputs: &[crate::Tensor],
+        outputs: &[crate::Tensor],
+    ) -> Result<(), IrError> {
+        match self {
+            Op::EmbedGather(op) => op.validate(inputs, outputs),
+            Op::NgramGather(op) => op.validate(inputs, outputs),
+            Op::QuantAct(op) => op.validate(inputs, outputs),
+            Op::Cast(op) => op.validate(inputs, outputs),
+            Op::Copy(op) => op.validate(inputs, outputs),
+            Op::GatherRows(op) => op.validate(inputs, outputs),
+            Op::ScatterAddRows(op) => op.validate(inputs, outputs),
+            Op::Norm(op) => op.validate(inputs, outputs),
+            Op::ResidualAdd(op) => op.validate(inputs, outputs),
+            Op::ActMul(op) => op.validate(inputs, outputs),
+            Op::Activation(op) => op.validate(inputs, outputs),
+            Op::Rope(op) => op.validate(inputs, outputs),
+            Op::Matmul(op) => op.validate(inputs, outputs),
+            Op::MoeRoute(op) => op.validate(inputs, outputs),
+            Op::MoeFfn(op) => op.validate(inputs, outputs),
+            Op::StateWriteKv(op) => op.validate(inputs, outputs),
+            Op::Attention(op) => op.validate(inputs, outputs),
+            Op::CausalConv1d(op) => op.validate(inputs, outputs),
+            Op::LinearAttnScan(op) => op.validate(inputs, outputs),
+            Op::LogitsPostprocess(op) => op.validate(inputs, outputs),
+            Op::Sample(op) => op.validate(inputs, outputs),
+            Op::Verify(op) => op.validate(inputs, outputs),
+            Op::AllReduce(op) => op.validate(inputs, outputs),
+            Op::AllGather(op) => op.validate(inputs, outputs),
+            Op::ReduceScatter(op) => op.validate(inputs, outputs),
+            Op::AllToAll(op) => op.validate(inputs, outputs),
+            Op::Send(op) => op.validate(inputs, outputs),
+            Op::Recv(op) => op.validate(inputs, outputs),
+            Op::Barrier(op) => op.validate(inputs, outputs),
+        }
+    }
+
+    /// Returns legal sharding rules (Spec 1 §5.2).
+    pub fn legal_layouts(&self) -> &'static [ShardingRule] {
+        sharding::legal_layouts(self)
+    }
+
+    /// Returns legal sharding rules as tuples.
+    pub fn legal_layout_tuples(
+        &self,
+    ) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+        sharding::legal_layout_tuples(self)
+    }
+
+    /// Returns the op numerics contract for the supplied tensor inputs (Spec 1 §6.1).
+    pub fn numerics(&self, inputs: &[crate::Tensor]) -> Result<Numerics, IrError> {
+        match self {
+            Op::EmbedGather(op) => Ok(op.numerics()),
+            Op::NgramGather(op) => Ok(op.numerics()),
+            Op::QuantAct(op) => Ok(op.numerics()),
+            Op::Cast(op) => Ok(op.numerics()),
+            Op::Copy(op) => Ok(op.numerics()),
+            Op::GatherRows(op) => Ok(op.numerics()),
+            Op::ScatterAddRows(op) => Ok(op.numerics()),
+            Op::Norm(op) => Ok(op.numerics()),
+            Op::ResidualAdd(op) => Ok(op.numerics()),
+            Op::ActMul(op) => Ok(op.numerics()),
+            Op::Activation(op) => Ok(op.numerics()),
+            Op::Rope(op) => Ok(op.numerics()),
+            Op::Matmul(op) => {
+                if inputs.len() < 2 {
+                    Err(IrError::OpInputCountMismatch {
+                        op: "matmul_numerics",
+                        expected: 2,
+                        got: inputs.len(),
+                    })
+                } else {
+                    op.numerics_for(&inputs[0], &inputs[1])
+                }
+            }
+            Op::MoeRoute(op) => Ok(op.numerics()),
+            Op::MoeFfn(op) => {
+                if inputs.len() < 5 {
+                    Err(IrError::OpInputCountMismatch {
+                        op: "moe_ffn_numerics",
+                        expected: 5,
+                        got: inputs.len(),
+                    })
+                } else {
+                    let n = op.numerics_for(&inputs[0], &inputs[3])?;
+                    let _ = op.numerics_for(&inputs[0], &inputs[4])?;
+                    Ok(n)
+                }
+            }
+            Op::StateWriteKv(op) => Ok(op.numerics()),
+            Op::Attention(op) => Ok(op.numerics()),
+            Op::CausalConv1d(op) => Ok(op.numerics()),
+            Op::LinearAttnScan(op) => Ok(op.numerics()),
+            Op::LogitsPostprocess(op) => Ok(op.numerics()),
+            Op::Sample(op) => Ok(op.numerics()),
+            Op::Verify(op) => Ok(op.numerics()),
+            Op::AllReduce(op) => Ok(op.numerics()),
+            Op::AllGather(op) => Ok(op.numerics()),
+            Op::ReduceScatter(op) => Ok(op.numerics()),
+            Op::AllToAll(op) => Ok(op.numerics()),
+            Op::Send(op) => Ok(op.numerics()),
+            Op::Recv(op) => Ok(op.numerics()),
+            Op::Barrier(op) => Ok(op.numerics()),
+        }
+    }
+
+    /// Returns op identifier name.
+    pub fn op_name(&self) -> &'static str {
+        match self {
+            Op::EmbedGather(op) => op.op_name(),
+            Op::NgramGather(op) => op.op_name(),
+            Op::QuantAct(op) => op.op_name(),
+            Op::Cast(op) => op.op_name(),
+            Op::Copy(op) => op.op_name(),
+            Op::GatherRows(op) => op.op_name(),
+            Op::ScatterAddRows(op) => op.op_name(),
+            Op::Norm(op) => op.op_name(),
+            Op::ResidualAdd(op) => op.op_name(),
+            Op::ActMul(op) => op.op_name(),
+            Op::Activation(op) => op.op_name(),
+            Op::Rope(op) => op.op_name(),
+            Op::Matmul(op) => op.op_name(),
+            Op::MoeRoute(op) => op.op_name(),
+            Op::MoeFfn(op) => op.op_name(),
+            Op::StateWriteKv(op) => op.op_name(),
+            Op::Attention(op) => op.op_name(),
+            Op::CausalConv1d(op) => op.op_name(),
+            Op::LinearAttnScan(op) => op.op_name(),
+            Op::LogitsPostprocess(op) => op.op_name(),
+            Op::Sample(op) => op.op_name(),
+            Op::Verify(op) => op.op_name(),
+            Op::AllReduce(op) => op.op_name(),
+            Op::AllGather(op) => op.op_name(),
+            Op::ReduceScatter(op) => op.op_name(),
+            Op::AllToAll(op) => op.op_name(),
+            Op::Send(op) => op.op_name(),
+            Op::Recv(op) => op.op_name(),
+            Op::Barrier(op) => op.op_name(),
+        }
+    }
+}

--- a/crates/r9v-ir/src/sharding.rs
+++ b/crates/r9v-ir/src/sharding.rs
@@ -1,0 +1,1299 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Declared sharding rules and layout compatibility tables (Spec 1 §5; card A1.2).
+//!
+//! Sharding is declared as data, not discovered (Spec 1 §1 Principle 4).
+//! Every op carries a legal-layouts table. The partitioner only ever applies
+//! this table (Spec 1 §5.2).
+
+use crate::{Op, ShardLayout};
+
+/// Symbolic head count representation in sharding patterns (Spec 1 §5.1; card A1.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HeadCount {
+    /// Concrete number of heads.
+    Concrete(u32),
+    /// Symbolic head count `H` (or `Hkv`), resolved per-model at instantiation.
+    Symbolic,
+}
+
+/// Symbolic expert count representation in sharding patterns (Spec 1 §5.1; card A1.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExpertCount {
+    /// Concrete number of experts.
+    Concrete(u32),
+    /// Symbolic expert count `E`, resolved per-model at instantiation.
+    Symbolic,
+}
+
+/// Sharding layout pattern for static op sharding declarations (Spec 1 §5.1; card A1.2).
+// DECISION(A1.2): Spec 1 §5.1 defines concrete `ShardLayout::HeadShard { heads: u32 }`
+// and `ShardLayout::ExpertShard { experts: u32 }` for materialized tensors, where
+// zero extents are forbidden (CONVENTIONS.md §2.1, SI-5). Rather than using magic
+// zero (`heads: 0` or `experts: 0`) in static op tables, `ShardLayoutPattern` provides
+// typed symbolic variants (`HeadCount::Symbolic`, `ExpertCount::Symbolic`) for static
+// op rules. Rejected: magic zeros in concrete ShardLayout which misrepresent invalid
+// layouts as valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShardLayoutPattern {
+    /// Whole tensor on every rank (Spec 1 §5.1).
+    Replicated,
+    /// Split along output features, Megatron column-parallel (Spec 1 §5.1).
+    ColShard {
+        /// Sharded axis.
+        axis: u32,
+    },
+    /// Split along input features, row-parallel; consumer output is `Partial` (Spec 1 §5.1).
+    RowShard {
+        /// Sharded axis.
+        axis: u32,
+    },
+    /// Attention heads split; KV heads and state split identically (Spec 1 §5.1).
+    HeadShard {
+        /// Head count.
+        heads: HeadCount,
+    },
+    /// Experts distributed across ranks (Spec 1 §5.1).
+    ExpertShard {
+        /// Expert count.
+        experts: ExpertCount,
+    },
+    /// Sum across ranks pending; must be resolved by `all_reduce` before Replicated (Spec 1 §5.1).
+    Partial,
+}
+
+impl ShardLayoutPattern {
+    /// Matches this pattern against a concrete [`ShardLayout`].
+    ///
+    /// Per Spec 1 §5.1 and CONVENTIONS.md §2.1 / SI-5, valid concrete layouts
+    /// never contain magic zeros (`heads == 0` or `experts == 0`). A concrete
+    /// layout with zero extent is rejected and returns `false`.
+    pub fn matches(&self, layout: &ShardLayout) -> bool {
+        self.matches_layout(layout)
+    }
+
+    /// Matches this pattern against a concrete [`ShardLayout`].
+    ///
+    /// Per Spec 1 §5.1 and CONVENTIONS.md §2.1 / SI-5, valid concrete layouts
+    /// never contain magic zeros (`heads == 0` or `experts == 0`). A concrete
+    /// layout with zero extent is rejected and returns `false`.
+    pub fn matches_layout(&self, layout: &ShardLayout) -> bool {
+        match self {
+            Self::Replicated => match layout {
+                ShardLayout::Replicated => true,
+                ShardLayout::ColShard { .. }
+                | ShardLayout::RowShard { .. }
+                | ShardLayout::HeadShard { .. }
+                | ShardLayout::ExpertShard { .. }
+                | ShardLayout::Partial => false,
+            },
+            Self::ColShard { axis: a1 } => match layout {
+                ShardLayout::ColShard { axis: a2 } => a1 == a2,
+                ShardLayout::Replicated
+                | ShardLayout::RowShard { .. }
+                | ShardLayout::HeadShard { .. }
+                | ShardLayout::ExpertShard { .. }
+                | ShardLayout::Partial => false,
+            },
+            Self::RowShard { axis: a1 } => match layout {
+                ShardLayout::RowShard { axis: a2 } => a1 == a2,
+                ShardLayout::Replicated
+                | ShardLayout::ColShard { .. }
+                | ShardLayout::HeadShard { .. }
+                | ShardLayout::ExpertShard { .. }
+                | ShardLayout::Partial => false,
+            },
+            Self::HeadShard { heads } => match layout {
+                ShardLayout::HeadShard { heads: concrete } => match heads {
+                    HeadCount::Concrete(expected) => *concrete > 0 && concrete == expected,
+                    HeadCount::Symbolic => *concrete > 0,
+                },
+                ShardLayout::Replicated
+                | ShardLayout::ColShard { .. }
+                | ShardLayout::RowShard { .. }
+                | ShardLayout::ExpertShard { .. }
+                | ShardLayout::Partial => false,
+            },
+            Self::ExpertShard { experts } => match layout {
+                ShardLayout::ExpertShard { experts: concrete } => match experts {
+                    ExpertCount::Concrete(expected) => *concrete > 0 && concrete == expected,
+                    ExpertCount::Symbolic => *concrete > 0,
+                },
+                ShardLayout::Replicated
+                | ShardLayout::ColShard { .. }
+                | ShardLayout::RowShard { .. }
+                | ShardLayout::HeadShard { .. }
+                | ShardLayout::Partial => false,
+            },
+            Self::Partial => match layout {
+                ShardLayout::Partial => true,
+                ShardLayout::Replicated
+                | ShardLayout::ColShard { .. }
+                | ShardLayout::RowShard { .. }
+                | ShardLayout::HeadShard { .. }
+                | ShardLayout::ExpertShard { .. } => false,
+            },
+        }
+    }
+
+    /// Instantiates a concrete [`ShardLayout`] from this pattern using resolved symbolic dimensions.
+    ///
+    /// Returns `None` if zero heads or zero experts are provided, rejecting magic zero per Spec 1 §5.1.
+    pub fn to_concrete(&self, heads: u32, experts: u32) -> Option<ShardLayout> {
+        match self {
+            Self::Replicated => Some(ShardLayout::Replicated),
+            Self::ColShard { axis } => Some(ShardLayout::ColShard { axis: *axis }),
+            Self::RowShard { axis } => Some(ShardLayout::RowShard { axis: *axis }),
+            Self::HeadShard {
+                heads: HeadCount::Symbolic,
+            } => {
+                if heads > 0 {
+                    Some(ShardLayout::HeadShard { heads })
+                } else {
+                    None
+                }
+            }
+            Self::HeadShard {
+                heads: HeadCount::Concrete(c),
+            } => {
+                if *c > 0 {
+                    Some(ShardLayout::HeadShard { heads: *c })
+                } else {
+                    None
+                }
+            }
+            Self::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            } => {
+                if experts > 0 {
+                    Some(ShardLayout::ExpertShard { experts })
+                } else {
+                    None
+                }
+            }
+            Self::ExpertShard {
+                experts: ExpertCount::Concrete(c),
+            } => {
+                if *c > 0 {
+                    Some(ShardLayout::ExpertShard { experts: *c })
+                } else {
+                    None
+                }
+            }
+            Self::Partial => Some(ShardLayout::Partial),
+        }
+    }
+}
+
+/// A legal sharding rule: input layouts and corresponding output layout(s) (Spec 1 §5.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ShardingRule {
+    /// Required sharding layout for each input tensor in signature order.
+    pub inputs: &'static [ShardLayoutPattern],
+    /// Resulting sharding layout for each output tensor in signature order.
+    pub outputs: &'static [ShardLayoutPattern],
+}
+
+impl ShardingRule {
+    /// Creates a new sharding rule with the given input and output layout slices.
+    pub const fn new(
+        inputs: &'static [ShardLayoutPattern],
+        outputs: &'static [ShardLayoutPattern],
+    ) -> Self {
+        Self { inputs, outputs }
+    }
+
+    /// Input layout requirements.
+    pub const fn inputs(&self) -> &'static [ShardLayoutPattern] {
+        self.inputs
+    }
+
+    /// Output layout results.
+    pub const fn outputs(&self) -> &'static [ShardLayoutPattern] {
+        self.outputs
+    }
+
+    /// Primary output layout, or `None` if the op has no output tensors.
+    pub const fn output(&self) -> Option<ShardLayoutPattern> {
+        if self.outputs.is_empty() {
+            None
+        } else {
+            Some(self.outputs[0])
+        }
+    }
+
+    /// Returns the rule as an `(inputs, outputs)` tuple.
+    pub const fn as_tuple(&self) -> (&'static [ShardLayoutPattern], &'static [ShardLayoutPattern]) {
+        (self.inputs, self.outputs)
+    }
+
+    /// Returns whether the provided concrete input and output layouts match this rule.
+    ///
+    /// Validates exact input/output arity and binds symbolic head and expert
+    /// cardinalities consistently across all inputs and outputs (Spec 1 §5.1–§5.2).
+    pub fn matches(&self, inputs: &[ShardLayout], outputs: &[ShardLayout]) -> bool {
+        if self.inputs.len() != inputs.len() || self.outputs.len() != outputs.len() {
+            return false;
+        }
+        let mut bound_heads: Option<u32> = None;
+        let mut bound_experts: Option<u32> = None;
+
+        for (pat, layout) in self.inputs.iter().zip(inputs) {
+            if !match_pattern_with_bindings(pat, layout, &mut bound_heads, &mut bound_experts) {
+                return false;
+            }
+        }
+        for (pat, layout) in self.outputs.iter().zip(outputs) {
+            if !match_pattern_with_bindings(pat, layout, &mut bound_heads, &mut bound_experts) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Returns whether the provided input and output tensors match this rule's layouts.
+    ///
+    /// Validates exact arity, verifies that actual tensor sharding is structurally valid
+    /// (sharded axis within tensor rank, non-zero head/expert counts), and ensures that
+    /// symbolic head and expert cardinalities match consistently across all tensors (Spec 1 §5.1–§5.2).
+    // DECISION(A1.2): matches_tensors validates exact rule arity, concrete sharded axis within tensor rank, non-zero head/expert extents, and binds symbolic head and expert cardinalities consistently across all rule tensors per Spec 1 §5.1-§5.2; rejected independent unverified wildcard matching across tensors.
+    pub fn matches_tensors(&self, inputs: &[crate::Tensor], outputs: &[crate::Tensor]) -> bool {
+        if self.inputs.len() != inputs.len() || self.outputs.len() != outputs.len() {
+            return false;
+        }
+        for t in inputs.iter().chain(outputs.iter()) {
+            match t.sharding() {
+                ShardLayout::ColShard { axis } | ShardLayout::RowShard { axis } => {
+                    if axis as usize >= t.rank() {
+                        return false;
+                    }
+                }
+                ShardLayout::HeadShard { heads } => {
+                    if heads == 0 {
+                        return false;
+                    }
+                }
+                ShardLayout::ExpertShard { experts } => {
+                    if experts == 0 {
+                        return false;
+                    }
+                }
+                ShardLayout::Replicated | ShardLayout::Partial => {}
+            }
+        }
+        let mut bound_heads: Option<u32> = None;
+        let mut bound_experts: Option<u32> = None;
+
+        for (pat, t) in self.inputs.iter().zip(inputs) {
+            if !match_pattern_with_bindings(
+                pat,
+                &t.sharding(),
+                &mut bound_heads,
+                &mut bound_experts,
+            ) {
+                return false;
+            }
+        }
+        for (pat, t) in self.outputs.iter().zip(outputs) {
+            if !match_pattern_with_bindings(
+                pat,
+                &t.sharding(),
+                &mut bound_heads,
+                &mut bound_experts,
+            ) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Helper matching a layout pattern against a concrete layout, binding symbolic counts.
+///
+/// Exhaustive matching over all variants without wildcards (CONVENTIONS.md §3.2).
+fn match_pattern_with_bindings(
+    pattern: &ShardLayoutPattern,
+    layout: &ShardLayout,
+    bound_heads: &mut Option<u32>,
+    bound_experts: &mut Option<u32>,
+) -> bool {
+    match pattern {
+        ShardLayoutPattern::Replicated => match layout {
+            ShardLayout::Replicated => true,
+            ShardLayout::ColShard { .. }
+            | ShardLayout::RowShard { .. }
+            | ShardLayout::HeadShard { .. }
+            | ShardLayout::ExpertShard { .. }
+            | ShardLayout::Partial => false,
+        },
+        ShardLayoutPattern::ColShard { axis: a1 } => match layout {
+            ShardLayout::ColShard { axis: a2 } => a1 == a2,
+            ShardLayout::Replicated
+            | ShardLayout::RowShard { .. }
+            | ShardLayout::HeadShard { .. }
+            | ShardLayout::ExpertShard { .. }
+            | ShardLayout::Partial => false,
+        },
+        ShardLayoutPattern::RowShard { axis: a1 } => match layout {
+            ShardLayout::RowShard { axis: a2 } => a1 == a2,
+            ShardLayout::Replicated
+            | ShardLayout::ColShard { .. }
+            | ShardLayout::HeadShard { .. }
+            | ShardLayout::ExpertShard { .. }
+            | ShardLayout::Partial => false,
+        },
+        ShardLayoutPattern::HeadShard { heads } => match layout {
+            ShardLayout::HeadShard { heads: concrete } => {
+                if *concrete == 0 {
+                    return false;
+                }
+                match heads {
+                    HeadCount::Concrete(expected) => concrete == expected,
+                    HeadCount::Symbolic => match bound_heads {
+                        Some(existing) => *existing == *concrete,
+                        None => {
+                            *bound_heads = Some(*concrete);
+                            true
+                        }
+                    },
+                }
+            }
+            ShardLayout::Replicated
+            | ShardLayout::ColShard { .. }
+            | ShardLayout::RowShard { .. }
+            | ShardLayout::ExpertShard { .. }
+            | ShardLayout::Partial => false,
+        },
+        ShardLayoutPattern::ExpertShard { experts } => match layout {
+            ShardLayout::ExpertShard { experts: concrete } => {
+                if *concrete == 0 {
+                    return false;
+                }
+                match experts {
+                    ExpertCount::Concrete(expected) => concrete == expected,
+                    ExpertCount::Symbolic => match bound_experts {
+                        Some(existing) => *existing == *concrete,
+                        None => {
+                            *bound_experts = Some(*concrete);
+                            true
+                        }
+                    },
+                }
+            }
+            ShardLayout::Replicated
+            | ShardLayout::ColShard { .. }
+            | ShardLayout::RowShard { .. }
+            | ShardLayout::HeadShard { .. }
+            | ShardLayout::Partial => false,
+        },
+        ShardLayoutPattern::Partial => match layout {
+            ShardLayout::Partial => true,
+            ShardLayout::Replicated
+            | ShardLayout::ColShard { .. }
+            | ShardLayout::RowShard { .. }
+            | ShardLayout::HeadShard { .. }
+            | ShardLayout::ExpertShard { .. } => false,
+        },
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Static layout rules per op (Spec 1 §4, §5)
+// -----------------------------------------------------------------------------
+
+// DECISION(A1.2): EMBED_GATHER_RULES covers Replicated and RowShard(0) vocab sharding per Spec 1 §4.A; rejected invented ColShard(1) embed rule which has no spec basis.
+pub static EMBED_GATHER_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::RowShard { axis: 0 },
+        ],
+        &[ShardLayoutPattern::Partial],
+    ),
+];
+
+// DECISION(A1.2): NGRAM_GATHER_RULES matches op tensor validation arity (2 inputs: staging/token_ids, row_scales/table; 1 output: x) per Spec 1 §4.A & SI-8; rejected stale 1-input rules.
+pub static NGRAM_GATHER_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::RowShard { axis: 1 },
+            ShardLayoutPattern::RowShard { axis: 1 },
+        ],
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::RowShard { axis: 1 },
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+    ),
+];
+
+// DECISION(A1.2): QUANT_ACT_RULES matches op tensor validation arity (1 input: x; 2 outputs: xq, scale) per Spec 1 §4.A & SI-7; rejected RowShard(0) batch-axis invention.
+pub static QUANT_ACT_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated],
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::Replicated,
+        ],
+    ),
+];
+
+// DECISION(A1.2): PASSTHROUGH_RULES excludes Partial per Spec 1 §5.2 (Partial may flow only through residual_add and matmul epilogues); rejected generic passthrough of unresolved partial sums.
+pub static PASSTHROUGH_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 0 }],
+        &[ShardLayoutPattern::ColShard { axis: 0 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::RowShard { axis: 0 }],
+        &[ShardLayoutPattern::RowShard { axis: 0 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        }],
+        &[ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        }],
+    ),
+];
+
+pub static GATHER_ROWS_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+];
+
+pub static SCATTER_ADD_ROWS_RULES: &[ShardingRule] = &[
+    // x, indices -> y
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+    // x, indices, dest -> y
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::ColShard { axis: 1 },
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+];
+
+// DECISION(A1.2): NORM_RULES enforces replicated normalized axis per Spec 1 §4.B; rejected RowShard(0) batch-axis invention.
+pub static NORM_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+];
+
+// DECISION(A1.2): RESIDUAL_ADD_RULES covers Spec 1 §5.2 Partial sum flow and feature sharding; rejected RowShard(0) batch-axis invention.
+pub static RESIDUAL_ADD_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::Partial, ShardLayoutPattern::Replicated],
+        &[ShardLayoutPattern::Partial],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated, ShardLayoutPattern::Partial],
+        &[ShardLayoutPattern::Partial],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::Partial, ShardLayoutPattern::Partial],
+        &[ShardLayoutPattern::Partial],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::ColShard { axis: 1 },
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::RowShard { axis: 1 },
+            ShardLayoutPattern::RowShard { axis: 1 },
+        ],
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+        ],
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+    ),
+];
+
+// DECISION(A1.2): ACT_MUL_RULES matches feature-axis sharding per Spec 1 §4.B; rejected RowShard(0) batch-axis invention.
+pub static ACT_MUL_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::ColShard { axis: 1 },
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+];
+
+// DECISION(A1.2): ACTIVATION_RULES matches elementwise feature-axis sharding per Spec 1 §4.B; rejected RowShard(0) batch-axis invention.
+pub static ACTIVATION_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+];
+
+// DECISION(A1.2): ROPE_RULES covers Replicated and HeadShard per Spec 1 §4.B; rejected RowShard(0) batch-axis invention.
+pub static ROPE_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+    ),
+];
+
+// DECISION(A1.2): MATMUL_RULES contains exactly the three §4.C principal x/w/y rows; rejected invented data-parallel RowShard(0), bias 3-input rules, and residual 3-input variants.
+pub static MATMUL_RULES: &[ShardingRule] = &[
+    // 1. Column parallel: x: Replicated, w: ColShard(0) -> y: ColShard(1)
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::ColShard { axis: 0 },
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+    // 2. Row parallel: x: ColShard(1), w: RowShard(1) -> y: Partial
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::RowShard { axis: 1 },
+        ],
+        &[ShardLayoutPattern::Partial],
+    ),
+    // 3. Fully replicated
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+];
+
+pub static MOE_ROUTE_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated],
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+    ),
+];
+
+pub static MOE_FFN_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            },
+            ShardLayoutPattern::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            },
+        ],
+        &[ShardLayoutPattern::Partial],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+];
+
+pub static STATE_WRITE_KV_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+        ],
+        &[],
+    ),
+];
+
+pub static ATTENTION_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+    ),
+];
+
+pub static CAUSAL_CONV1D_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::ColShard { axis: 0 },
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::ColShard { axis: 0 },
+            ShardLayoutPattern::ColShard { axis: 0 },
+        ],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+];
+
+pub static LINEAR_ATTN_SCAN_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+            ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            },
+        ],
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+    ),
+];
+
+pub static LOGITS_POSTPROCESS_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Replicated],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+];
+
+// DECISION(A1.2): SAMPLE_RULES matches op tensor validation arity (1 input: probs; 1 output: token) per Spec 1 §4.F & SI-12; rejected stale 2/2 rule.
+pub static SAMPLE_RULES: &[ShardingRule] = &[ShardingRule::new(
+    &[ShardLayoutPattern::Replicated],
+    &[ShardLayoutPattern::Replicated],
+)];
+
+// DECISION(A1.2): VERIFY_RULES matches op tensor validation arity (2 or 3 inputs; 2 outputs: accepted, accept_len) per Spec 1 §4.F & SI-12; rejected stale 4/3 rule.
+pub static VERIFY_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+    ),
+];
+
+pub static ALL_REDUCE_RULES: &[ShardingRule] = &[ShardingRule::new(
+    &[ShardLayoutPattern::Partial],
+    &[ShardLayoutPattern::Replicated],
+)];
+
+pub static ALL_GATHER_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 0 }],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::RowShard { axis: 0 }],
+        &[ShardLayoutPattern::Replicated],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+        &[ShardLayoutPattern::Replicated],
+    ),
+];
+
+pub static REDUCE_SCATTER_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[ShardLayoutPattern::Partial],
+        &[ShardLayoutPattern::RowShard { axis: 0 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::Partial],
+        &[ShardLayoutPattern::RowShard { axis: 1 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::Partial],
+        &[ShardLayoutPattern::ColShard { axis: 0 }],
+    ),
+    ShardingRule::new(
+        &[ShardLayoutPattern::Partial],
+        &[ShardLayoutPattern::ColShard { axis: 1 }],
+    ),
+];
+
+// DECISION(A1.2): ALL_TO_ALL_RULES covers exactly inputs (x, counts) to y per Spec 1 §4.G and SI-11; rejected stale 1-input or 2-output rows.
+pub static ALL_TO_ALL_RULES: &[ShardingRule] = &[
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            },
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        }],
+    ),
+    ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    ),
+];
+
+// DECISION(A1.2): SEND_RULES and RECV_RULES exclude Partial per Spec 1 §5.2 (Partial resolved before pipeline boundaries); rejected sending unresolved partial sums across stages.
+pub static SEND_RULES: &[ShardingRule] = &[
+    ShardingRule::new(&[ShardLayoutPattern::Replicated], &[]),
+    ShardingRule::new(&[ShardLayoutPattern::ColShard { axis: 0 }], &[]),
+    ShardingRule::new(&[ShardLayoutPattern::ColShard { axis: 1 }], &[]),
+];
+
+pub static RECV_RULES: &[ShardingRule] = &[
+    ShardingRule::new(&[], &[ShardLayoutPattern::Replicated]),
+    ShardingRule::new(&[], &[ShardLayoutPattern::ColShard { axis: 0 }]),
+    ShardingRule::new(&[], &[ShardLayoutPattern::ColShard { axis: 1 }]),
+];
+
+pub static BARRIER_RULES: &[ShardingRule] = &[ShardingRule::new(&[], &[])];
+
+/// Returns the legal input/output sharding layout rules for the given op (Spec 1 §5.2).
+///
+/// Exhaustive matching over all 29 closed ops without wildcards (CONVENTIONS.md §3.2).
+pub fn legal_layouts(op: &Op) -> &'static [ShardingRule] {
+    match op {
+        Op::EmbedGather(_) => EMBED_GATHER_RULES,
+        Op::NgramGather(_) => NGRAM_GATHER_RULES,
+        Op::QuantAct(_) => QUANT_ACT_RULES,
+        Op::Cast(_) => PASSTHROUGH_RULES,
+        Op::Copy(_) => PASSTHROUGH_RULES,
+        Op::GatherRows(_) => GATHER_ROWS_RULES,
+        Op::ScatterAddRows(_) => SCATTER_ADD_ROWS_RULES,
+        Op::Norm(_) => NORM_RULES,
+        Op::ResidualAdd(_) => RESIDUAL_ADD_RULES,
+        Op::ActMul(_) => ACT_MUL_RULES,
+        Op::Activation(_) => ACTIVATION_RULES,
+        Op::Rope(_) => ROPE_RULES,
+        Op::Matmul(_) => MATMUL_RULES,
+        Op::MoeRoute(_) => MOE_ROUTE_RULES,
+        Op::MoeFfn(_) => MOE_FFN_RULES,
+        Op::StateWriteKv(_) => STATE_WRITE_KV_RULES,
+        Op::Attention(_) => ATTENTION_RULES,
+        Op::CausalConv1d(_) => CAUSAL_CONV1D_RULES,
+        Op::LinearAttnScan(_) => LINEAR_ATTN_SCAN_RULES,
+        Op::LogitsPostprocess(_) => LOGITS_POSTPROCESS_RULES,
+        Op::Sample(_) => SAMPLE_RULES,
+        Op::Verify(_) => VERIFY_RULES,
+        Op::AllReduce(_) => ALL_REDUCE_RULES,
+        Op::AllGather(_) => ALL_GATHER_RULES,
+        Op::ReduceScatter(_) => REDUCE_SCATTER_RULES,
+        Op::AllToAll(_) => ALL_TO_ALL_RULES,
+        Op::Send(_) => SEND_RULES,
+        Op::Recv(_) => RECV_RULES,
+        Op::Barrier(_) => BARRIER_RULES,
+    }
+}
+
+/// Returns legal sharding rules formatted as tuples `(inputs, outputs)`.
+pub fn legal_layout_tuples(
+    op: &Op,
+) -> Vec<(&'static [ShardLayoutPattern], &'static [ShardLayoutPattern])> {
+    legal_layouts(op).iter().map(|r| r.as_tuple()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pattern_matches_concrete_without_magic_zero() {
+        // Replicated
+        assert!(ShardLayoutPattern::Replicated.matches(&ShardLayout::Replicated));
+        assert!(!ShardLayoutPattern::Replicated.matches(&ShardLayout::Partial));
+
+        // ColShard
+        let pat_col = ShardLayoutPattern::ColShard { axis: 1 };
+        assert!(pat_col.matches(&ShardLayout::ColShard { axis: 1 }));
+        assert!(!pat_col.matches(&ShardLayout::ColShard { axis: 0 }));
+
+        // RowShard
+        let pat_row = ShardLayoutPattern::RowShard { axis: 0 };
+        assert!(pat_row.matches(&ShardLayout::RowShard { axis: 0 }));
+        assert!(!pat_row.matches(&ShardLayout::RowShard { axis: 1 }));
+
+        // HeadShard concrete
+        let pat_head_c = ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Concrete(8),
+        };
+        assert!(pat_head_c.matches(&ShardLayout::HeadShard { heads: 8 }));
+        assert!(!pat_head_c.matches(&ShardLayout::HeadShard { heads: 4 }));
+        // Magic zero rejected
+        assert!(!pat_head_c.matches(&ShardLayout::HeadShard { heads: 0 }));
+
+        // HeadShard symbolic
+        let pat_head_s = ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        };
+        assert!(pat_head_s.matches(&ShardLayout::HeadShard { heads: 8 }));
+        assert!(pat_head_s.matches(&ShardLayout::HeadShard { heads: 32 }));
+        // Magic zero rejected
+        assert!(!pat_head_s.matches(&ShardLayout::HeadShard { heads: 0 }));
+
+        // ExpertShard concrete
+        let pat_exp_c = ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Concrete(16),
+        };
+        assert!(pat_exp_c.matches(&ShardLayout::ExpertShard { experts: 16 }));
+        assert!(!pat_exp_c.matches(&ShardLayout::ExpertShard { experts: 8 }));
+        // Magic zero rejected
+        assert!(!pat_exp_c.matches(&ShardLayout::ExpertShard { experts: 0 }));
+
+        // ExpertShard symbolic
+        let pat_exp_s = ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        };
+        assert!(pat_exp_s.matches(&ShardLayout::ExpertShard { experts: 16 }));
+        assert!(pat_exp_s.matches(&ShardLayout::ExpertShard { experts: 64 }));
+        // Magic zero rejected
+        assert!(!pat_exp_s.matches(&ShardLayout::ExpertShard { experts: 0 }));
+
+        // Partial
+        assert!(ShardLayoutPattern::Partial.matches(&ShardLayout::Partial));
+        assert!(!ShardLayoutPattern::Partial.matches(&ShardLayout::Replicated));
+    }
+
+    #[test]
+    fn pattern_to_concrete_instantiation_rejects_zero() {
+        let pat_head_s = ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        };
+        assert_eq!(
+            pat_head_s.to_concrete(8, 16),
+            Some(ShardLayout::HeadShard { heads: 8 })
+        );
+        assert_eq!(pat_head_s.to_concrete(0, 16), None);
+
+        let pat_exp_s = ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        };
+        assert_eq!(
+            pat_exp_s.to_concrete(8, 16),
+            Some(ShardLayout::ExpertShard { experts: 16 })
+        );
+        assert_eq!(pat_exp_s.to_concrete(8, 0), None);
+    }
+
+    #[test]
+    fn matmul_rules_has_exactly_three_principal_rows() {
+        assert_eq!(MATMUL_RULES.len(), 3);
+        assert_eq!(
+            MATMUL_RULES[0].inputs,
+            &[
+                ShardLayoutPattern::Replicated,
+                ShardLayoutPattern::ColShard { axis: 0 }
+            ]
+        );
+        assert_eq!(
+            MATMUL_RULES[0].outputs,
+            &[ShardLayoutPattern::ColShard { axis: 1 }]
+        );
+
+        assert_eq!(
+            MATMUL_RULES[1].inputs,
+            &[
+                ShardLayoutPattern::ColShard { axis: 1 },
+                ShardLayoutPattern::RowShard { axis: 1 }
+            ]
+        );
+        assert_eq!(MATMUL_RULES[1].outputs, &[ShardLayoutPattern::Partial]);
+
+        assert_eq!(
+            MATMUL_RULES[2].inputs,
+            &[
+                ShardLayoutPattern::Replicated,
+                ShardLayoutPattern::Replicated
+            ]
+        );
+        assert_eq!(MATMUL_RULES[2].outputs, &[ShardLayoutPattern::Replicated]);
+    }
+
+    #[test]
+    fn embed_gather_rules_has_no_invented_colshard() {
+        assert_eq!(EMBED_GATHER_RULES.len(), 2);
+        assert!(!EMBED_GATHER_RULES.iter().any(|r| {
+            r.inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::ColShard { .. }))
+        }));
+    }
+
+    #[test]
+    fn ngram_gather_rules_has_no_one_input_rules() {
+        assert_eq!(NGRAM_GATHER_RULES.len(), 3);
+        for rule in NGRAM_GATHER_RULES {
+            assert_eq!(rule.inputs.len(), 2);
+            assert_eq!(rule.outputs.len(), 1);
+        }
+    }
+
+    #[test]
+    fn quant_act_rules_has_no_batch_axis_rowshard() {
+        assert_eq!(QUANT_ACT_RULES.len(), 2);
+        for rule in QUANT_ACT_RULES {
+            assert!(!rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::RowShard { axis: 0 })));
+            assert_eq!(rule.inputs.len(), 1);
+            assert_eq!(rule.outputs.len(), 2);
+        }
+    }
+
+    #[test]
+    fn sample_rules_matches_op_tensor_arity() {
+        assert_eq!(SAMPLE_RULES.len(), 1);
+        assert_eq!(SAMPLE_RULES[0].inputs.len(), 1);
+        assert_eq!(SAMPLE_RULES[0].outputs.len(), 1);
+    }
+
+    #[test]
+    fn verify_rules_has_no_stale_four_input_rules() {
+        assert_eq!(VERIFY_RULES.len(), 2);
+        for rule in VERIFY_RULES {
+            assert!(rule.inputs.len() == 2 || rule.inputs.len() == 3);
+            assert_eq!(rule.outputs.len(), 2);
+        }
+    }
+
+    #[test]
+    fn all_to_all_rules_has_exact_two_inputs_one_output() {
+        assert_eq!(ALL_TO_ALL_RULES.len(), 2);
+        for rule in ALL_TO_ALL_RULES {
+            assert_eq!(rule.inputs.len(), 2);
+            assert_eq!(rule.outputs.len(), 1);
+        }
+        assert_eq!(
+            ALL_TO_ALL_RULES[0].inputs,
+            &[
+                ShardLayoutPattern::ExpertShard {
+                    experts: ExpertCount::Symbolic,
+                },
+                ShardLayoutPattern::Replicated,
+            ]
+        );
+        assert_eq!(
+            ALL_TO_ALL_RULES[0].outputs,
+            &[ShardLayoutPattern::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            }]
+        );
+        assert_eq!(
+            ALL_TO_ALL_RULES[1].inputs,
+            &[
+                ShardLayoutPattern::Replicated,
+                ShardLayoutPattern::Replicated,
+            ]
+        );
+        assert_eq!(
+            ALL_TO_ALL_RULES[1].outputs,
+            &[ShardLayoutPattern::Replicated]
+        );
+    }
+
+    #[test]
+    fn passthrough_and_send_recv_rules_exclude_partial() {
+        for rule in PASSTHROUGH_RULES {
+            assert!(!rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)));
+            assert!(!rule
+                .outputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)));
+        }
+        for rule in SEND_RULES {
+            assert!(!rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)));
+        }
+        for rule in RECV_RULES {
+            assert!(!rule
+                .outputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)));
+        }
+    }
+
+    #[test]
+    fn rule_matches_binds_symbolic_head_and_expert_cardinalities() {
+        // HeadShard symbolic binding
+        let head_rule = ShardingRule::new(
+            &[ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            }],
+            &[ShardLayoutPattern::HeadShard {
+                heads: HeadCount::Symbolic,
+            }],
+        );
+        // Matching head counts: 8 -> 8 matches
+        assert!(head_rule.matches(
+            &[ShardLayout::HeadShard { heads: 8 }],
+            &[ShardLayout::HeadShard { heads: 8 }]
+        ));
+        // Mismatched head counts: 8 -> 4 rejected
+        assert!(!head_rule.matches(
+            &[ShardLayout::HeadShard { heads: 8 }],
+            &[ShardLayout::HeadShard { heads: 4 }]
+        ));
+
+        // ExpertShard symbolic binding
+        let exp_rule = ALL_TO_ALL_RULES[0];
+        // Matching expert counts: 16 -> 16 matches
+        assert!(exp_rule.matches(
+            &[
+                ShardLayout::ExpertShard { experts: 16 },
+                ShardLayout::Replicated
+            ],
+            &[ShardLayout::ExpertShard { experts: 16 }]
+        ));
+        // Mismatched expert counts: 16 -> 8 rejected
+        assert!(!exp_rule.matches(
+            &[
+                ShardLayout::ExpertShard { experts: 16 },
+                ShardLayout::Replicated
+            ],
+            &[ShardLayout::ExpertShard { experts: 8 }]
+        ));
+    }
+}

--- a/crates/r9v-ir/tests/api_shape.rs
+++ b/crates/r9v-ir/tests/api_shape.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! API-shape tests for r9v-ir (Spec 1 §2, App. A; r9v-card-work §6).
+//! API-shape tests for r9v-ir (Spec 1 §2, §3, §4, §5, §6; App. A; r9v-card-work §6; card A1.2).
 //!
 //! Asserts compilation, visibility boundaries and the `Send`/`Sync` markers
 //! downstream crates rely on. Closed-set enums are additionally matched
@@ -9,10 +9,24 @@
 use std::hash::Hash;
 
 use r9v_ir::{
-    ArchDescriptor, ArchFamily, BatchMeta, BatchMetaBuilder, Class, DType, Dim, GraphCapture,
-    IrError, IrVersion, LayoutId, MatrixOp, Measured, P2pLink, P2pTransport, Placement, Positions,
-    QuantScheme, RelRate, SchemeId, ShapeSymbol, ShardLayout, StateHandle, StateKind, Tensor,
-    TreeMask, ValuDot, BLOCK_TABLE_SENTINEL,
+    bucket_s, bucket_step, bucket_t_dec, bucket_t_pre, compute_contiguous_strides, fusion_table,
+    is_permitted_fusion, is_permitted_pair, legal_layout_tuples, legal_layouts, match_chain,
+    match_gated_pair, matmul_numerics, moe_ffn_gemm_numerics, ActMulOp, ActivationKind,
+    ActivationOp, AllGatherOp, AllReduceOp, AllToAllOp, ArchDescriptor, ArchFamily, AttentionMask,
+    AttentionOp, BarrierOp, BatchMeta, BatchMetaBuilder, CacheScaleGranularity, CastOp,
+    CausalConv1dOp, Class, ConvActivation, CopyKind, CopyOp, DType, Dim, EdgeId, EmbedGatherOp,
+    Epilogue, ExpertCount, ExternalInput, ExternalInputKind, ExternalOutput, ExternalOutputKind,
+    FusionEntry, FusionPattern, GatherRowsOp, Graph, GraphCapture, GraphEdge, GraphNode,
+    GraphSummary, GroupId, HashId, HeadCount, InsertedCopy, IrError, IrVersion, LayoutId,
+    LinearAttnKind, LinearAttnScanOp, LogitsPostprocessOp, MatmulOp, MatrixOp, Measured,
+    MlaAttentionSpec, MlaLatent, MoeFfnOp, MoeGroup, MoeRouteOp, MoeScoring, NgramCombine,
+    NgramGatherOp, NgramSource, NodeId, NormAxis, NormKind, NormOp, Numerics, Op, P2pLink,
+    P2pTransport, Placement, PlanId, Positions, QuantActOp, QuantScheme, RecvOp, ReduceOp,
+    ReduceScatterOp, ReductionOrder, RelRate, ResidualAddOp, RngAlgorithm, RopeOp, RopeScaling,
+    RopeStyle, SampleOp, SamplingParams, ScatterAddRowsOp, SchemeId, SendOp, ShapeSymbol,
+    ShardLayout, ShardLayoutPattern, ShardingRule, Smoothing, StateHandle, StateKind,
+    StateWriteKvOp, StepGraphKey, StrideRequirement, Tensor, TreeMask, ValuDot, VerifyMethod,
+    VerifyOp, BLOCK_TABLE_SENTINEL, BUCKET_SIZES, FUSION_TABLE,
 };
 
 fn assert_send<T: Send>() {}
@@ -104,6 +118,126 @@ fn api_shape_markers_and_errors() {
     assert_send_sync::<P2pLink>();
     assert_send_sync::<Measured>();
 
+    // A1.2 markers
+    assert_send_sync::<PlanId>();
+    assert_copy::<PlanId>();
+    assert_hash::<PlanId>();
+    assert_ord::<PlanId>();
+
+    assert_send_sync::<StepGraphKey>();
+    assert_copy::<StepGraphKey>();
+    assert_hash::<StepGraphKey>();
+    assert_ord::<StepGraphKey>();
+
+    assert_send_sync::<Numerics>();
+    assert_copy::<Numerics>();
+    assert_hash::<Numerics>();
+
+    assert_send_sync::<ReductionOrder>();
+    assert_copy::<ReductionOrder>();
+    assert_hash::<ReductionOrder>();
+
+    assert_send_sync::<FusionPattern>();
+    assert_copy::<FusionPattern>();
+    assert_hash::<FusionPattern>();
+
+    assert_send_sync::<FusionEntry>();
+    assert_copy::<FusionEntry>();
+
+    assert_send_sync::<ShardingRule>();
+    assert_copy::<ShardingRule>();
+
+    assert_send_sync::<ExternalInputKind>();
+    assert_copy::<ExternalInputKind>();
+    assert_hash::<ExternalInputKind>();
+
+    assert_send_sync::<ExternalOutputKind>();
+    assert_copy::<ExternalOutputKind>();
+    assert_hash::<ExternalOutputKind>();
+
+    assert_send_sync::<NodeId>();
+    assert_copy::<NodeId>();
+    assert_hash::<NodeId>();
+
+    assert_send_sync::<EdgeId>();
+    assert_copy::<EdgeId>();
+    assert_hash::<EdgeId>();
+
+    assert_send_sync::<ExternalInput>();
+    assert_clone::<ExternalInput>();
+
+    assert_send_sync::<ExternalOutput>();
+    assert_copy::<ExternalOutput>();
+    assert_hash::<ExternalOutput>();
+
+    assert_send_sync::<StrideRequirement>();
+    assert_copy::<StrideRequirement>();
+    assert_hash::<StrideRequirement>();
+
+    assert_send_sync::<NgramSource>();
+    assert_copy::<NgramSource>();
+    assert_hash::<NgramSource>();
+
+    assert_send_sync::<CopyKind>();
+    assert_copy::<CopyKind>();
+    assert_hash::<CopyKind>();
+
+    assert_send_sync::<SamplingParams>();
+    assert_clone::<SamplingParams>();
+
+    assert_send_sync::<HeadCount>();
+    assert_copy::<HeadCount>();
+    assert_hash::<HeadCount>();
+
+    assert_send_sync::<ExpertCount>();
+    assert_copy::<ExpertCount>();
+    assert_hash::<ExpertCount>();
+
+    assert_send_sync::<ShardLayoutPattern>();
+    assert_copy::<ShardLayoutPattern>();
+    assert_hash::<ShardLayoutPattern>();
+
+    assert_send_sync::<GraphEdge>();
+    assert_send_sync::<GraphNode>();
+    assert_send_sync::<InsertedCopy>();
+    assert_send_sync::<GraphSummary>();
+    assert_send_sync::<Graph>();
+
+    // Closed ops
+    assert_send_sync::<Op>();
+    assert_send_sync::<EmbedGatherOp>();
+    assert_send_sync::<NgramGatherOp>();
+    assert_send_sync::<QuantActOp>();
+    assert_send_sync::<CastOp>();
+    assert_send_sync::<CopyOp>();
+    assert_send_sync::<GatherRowsOp>();
+    assert_send_sync::<ScatterAddRowsOp>();
+    assert_send_sync::<NormOp>();
+    assert_send_sync::<ResidualAddOp>();
+    assert_send_sync::<ActMulOp>();
+    assert_send_sync::<ActivationOp>();
+    assert_send_sync::<RopeOp>();
+    assert_send_sync::<MatmulOp>();
+    assert_send_sync::<MoeRouteOp>();
+    assert_send_sync::<MoeFfnOp>();
+    assert_send_sync::<StateWriteKvOp>();
+    assert_send_sync::<AttentionOp>();
+    assert_send_sync::<CausalConv1dOp>();
+    assert_send_sync::<LinearAttnScanOp>();
+    assert_send_sync::<LogitsPostprocessOp>();
+    assert_send_sync::<SampleOp>();
+    assert_send_sync::<VerifyOp>();
+    assert_send_sync::<AllReduceOp>();
+    assert_send_sync::<AllGatherOp>();
+    assert_send_sync::<ReduceScatterOp>();
+    assert_send_sync::<AllToAllOp>();
+    assert_send_sync::<SendOp>();
+    assert_send_sync::<RecvOp>();
+    assert_send_sync::<BarrierOp>();
+    assert_send_sync::<MlaAttentionSpec>();
+    assert_send_sync::<MlaLatent>();
+    assert_send_sync::<MoeGroup>();
+
     let _ = BLOCK_TABLE_SENTINEL;
 }
 
@@ -145,16 +279,16 @@ fn api_shape_closed_sets_match_exhaustively() {
     let sharding = ShardLayout::Replicated;
     let _ = match sharding {
         ShardLayout::Replicated => 0,
-        ShardLayout::ColShard { .. } => 1,
-        ShardLayout::RowShard { .. } => 2,
-        ShardLayout::HeadShard { .. } => 3,
-        ShardLayout::ExpertShard { .. } => 4,
+        ShardLayout::ColShard { axis: _ } => 1,
+        ShardLayout::RowShard { axis: _ } => 2,
+        ShardLayout::HeadShard { heads: _ } => 3,
+        ShardLayout::ExpertShard { experts: _ } => 4,
         ShardLayout::Partial => 5,
     };
 
     let placement = Placement::Host;
     let _ = match placement {
-        Placement::Device { .. } => 0,
+        Placement::Device { rank: _ } => 0,
         Placement::Host => 1,
         Placement::Tiered => 2,
     };
@@ -223,6 +357,250 @@ fn api_shape_closed_sets_match_exhaustively() {
         Positions::PerToken(_) => 0,
         Positions::Mrope(_) => 1,
     };
+
+    // A1.2 closed sets exhaustive matching
+    let red_order = ReductionOrder::None;
+    let _ = match red_order {
+        ReductionOrder::None => 0,
+        ReductionOrder::AscendingK => 1,
+        ReductionOrder::AscendingBlock => 2,
+        ReductionOrder::AscendingAxis => 3,
+        ReductionOrder::AscendingRank => 4,
+        ReductionOrder::AscendingIndex => 5,
+    };
+
+    let fusion_pat = FusionPattern::ResidualAddNorm;
+    let _ = match fusion_pat {
+        FusionPattern::ResidualAddNorm => 0,
+        FusionPattern::NormQuantAct => 1,
+        FusionPattern::MatmulEpilogue => 2,
+        FusionPattern::GatedMatmulActMul => 3,
+        FusionPattern::RopeStateWriteKv => 4,
+        FusionPattern::RopeAttentionPrefill => 5,
+        FusionPattern::StateWriteKvAttentionDecode => 6,
+        FusionPattern::LogitsPostprocessSample => 7,
+        FusionPattern::QuantActAllToAll => 8,
+    };
+
+    let ext_in = ExternalInputKind::TokenIds;
+    let _ = match ext_in {
+        ExternalInputKind::TokenIds => 0,
+        ExternalInputKind::BatchMeta => 1,
+        ExternalInputKind::RngState => 2,
+        ExternalInputKind::GatherStaging => 3,
+        ExternalInputKind::GrammarMask => 4,
+        ExternalInputKind::SamplingParams => 5,
+        ExternalInputKind::EmbedOverride => 6,
+        ExternalInputKind::EmbedMask => 7,
+    };
+
+    let ext_out = ExternalOutputKind::Sampled;
+    let _ = match ext_out {
+        ExternalOutputKind::Sampled => 0,
+        ExternalOutputKind::AcceptLen => 1,
+        ExternalOutputKind::Logits => 2,
+        ExternalOutputKind::Hidden => 3,
+        ExternalOutputKind::UpdatedRngState => 4,
+    };
+
+    let norm_kind = NormKind::Rms;
+    let _ = match norm_kind {
+        NormKind::Rms => 0,
+        NormKind::Layer => 1,
+    };
+
+    let norm_axis = NormAxis::Last;
+    let _ = match norm_axis {
+        NormAxis::Last => 0,
+        NormAxis::Head(_) => 1,
+    };
+
+    let act_kind = ActivationKind::Silu;
+    let _ = match act_kind {
+        ActivationKind::Silu => 0,
+        ActivationKind::Gelu => 1,
+        ActivationKind::GeluTanh => 2,
+        ActivationKind::Relu2 => 3,
+        ActivationKind::Identity => 4,
+    };
+
+    let rope_style = RopeStyle::Neox;
+    let _ = match rope_style {
+        RopeStyle::Neox => 0,
+        RopeStyle::Interleaved => 1,
+    };
+
+    let rope_scale = RopeScaling::None;
+    let _ = match rope_scale {
+        RopeScaling::None => 0,
+        RopeScaling::Linear(_) => 1,
+        RopeScaling::Yarn {
+            factor: _,
+            beta_fast: _,
+            beta_slow: _,
+            orig_ctx: _,
+            mscale: _,
+        } => 2,
+        RopeScaling::Dynamic => 3,
+    };
+
+    let epilogue = Epilogue::None;
+    let _ = match epilogue {
+        Epilogue::None => 0,
+        Epilogue::Bias => 1,
+        Epilogue::Residual => 2,
+        Epilogue::Act(_) => 3,
+    };
+
+    let moe_scoring = MoeScoring::Softmax;
+    let _ = match moe_scoring {
+        MoeScoring::Softmax => 0,
+        MoeScoring::Sigmoid => 1,
+    };
+
+    let cache_scale = CacheScaleGranularity::PerTokenHead;
+    let _ = match cache_scale {
+        CacheScaleGranularity::PerTokenHead => 0,
+        CacheScaleGranularity::PerBlock => 1,
+    };
+
+    let attn_mask = AttentionMask::Causal;
+    let _ = match attn_mask {
+        AttentionMask::Causal => 0,
+        AttentionMask::CausalWindow(_) => 1,
+        AttentionMask::Tree => 2,
+    };
+
+    let conv_act = ConvActivation::Silu;
+    let _ = match conv_act {
+        ConvActivation::Silu => 0,
+        ConvActivation::Identity => 1,
+    };
+
+    let lin_attn = LinearAttnKind::GLA;
+    let _ = match lin_attn {
+        LinearAttnKind::GatedDeltaNet => 0,
+        LinearAttnKind::GLA => 1,
+        LinearAttnKind::Mamba2 => 2,
+    };
+
+    let rng = RngAlgorithm::Philox4x32;
+    let _ = match rng {
+        RngAlgorithm::Philox4x32 => 0,
+    };
+
+    let verify = VerifyMethod::Greedy;
+    let _ = match verify {
+        VerifyMethod::Rejection => 0,
+        VerifyMethod::Greedy => 1,
+        VerifyMethod::TypicalAcceptance { eps: _, delta: _ } => 2,
+    };
+
+    let ext_input = ExternalInput::BatchMeta;
+    let _ = match ext_input {
+        ExternalInput::Tensor { kind: _, edge: _ } => 0,
+        ExternalInput::BatchMeta => 1,
+        ExternalInput::SamplingParams => 2,
+        ExternalInput::RngState => 3,
+    };
+
+    let ext_output = ExternalOutput::UpdatedRngState;
+    let _ = match ext_output {
+        ExternalOutput::Tensor { kind: _, edge: _ } => 0,
+        ExternalOutput::UpdatedRngState => 1,
+    };
+
+    let stride_req = StrideRequirement::Contiguous;
+    let _ = match stride_req {
+        StrideRequirement::Any => 0,
+        StrideRequirement::Contiguous => 1,
+    };
+
+    let ngram_src = NgramSource::Staged;
+    let _ = match ngram_src {
+        NgramSource::Staged => 0,
+        NgramSource::Device => 1,
+    };
+
+    let copy_k = CopyKind::Contiguize;
+    let _ = match copy_k {
+        CopyKind::Contiguize => 0,
+        CopyKind::DeviceToDevice => 1,
+        CopyKind::HostToDevice => 2,
+        CopyKind::DeviceToHost => 3,
+    };
+
+    let head_c = HeadCount::Symbolic;
+    let _ = match head_c {
+        HeadCount::Concrete(_) => 0,
+        HeadCount::Symbolic => 1,
+    };
+
+    let expert_c = ExpertCount::Symbolic;
+    let _ = match expert_c {
+        ExpertCount::Concrete(_) => 0,
+        ExpertCount::Symbolic => 1,
+    };
+
+    let shard_pat = ShardLayoutPattern::Replicated;
+    let _ = match shard_pat {
+        ShardLayoutPattern::Replicated => 0,
+        ShardLayoutPattern::ColShard { axis: _ } => 1,
+        ShardLayoutPattern::RowShard { axis: _ } => 2,
+        ShardLayoutPattern::HeadShard { heads: _ } => 3,
+        ShardLayoutPattern::ExpertShard { experts: _ } => 4,
+        ShardLayoutPattern::Partial => 5,
+    };
+
+    let reduce_op = ReduceOp::Sum;
+    let _ = match reduce_op {
+        ReduceOp::Sum => 0,
+    };
+
+    let ngram_comb = NgramCombine::Concat;
+    let _ = match ngram_comb {
+        NgramCombine::Concat => 0,
+        NgramCombine::Sum => 1,
+    };
+
+    let smoothing = Smoothing::None;
+    let _ = match smoothing {
+        Smoothing::None => 0,
+        Smoothing::Folded => 1,
+    };
+
+    let dummy_op = Op::Copy(CopyOp::default());
+    let _ = match dummy_op {
+        Op::EmbedGather(_) => 0,
+        Op::NgramGather(_) => 1,
+        Op::QuantAct(_) => 2,
+        Op::Cast(_) => 3,
+        Op::Copy(_) => 4,
+        Op::GatherRows(_) => 5,
+        Op::ScatterAddRows(_) => 6,
+        Op::Norm(_) => 7,
+        Op::ResidualAdd(_) => 8,
+        Op::ActMul(_) => 9,
+        Op::Activation(_) => 10,
+        Op::Rope(_) => 11,
+        Op::Matmul(_) => 12,
+        Op::MoeRoute(_) => 13,
+        Op::MoeFfn(_) => 14,
+        Op::StateWriteKv(_) => 15,
+        Op::Attention(_) => 16,
+        Op::CausalConv1d(_) => 17,
+        Op::LinearAttnScan(_) => 18,
+        Op::LogitsPostprocess(_) => 19,
+        Op::Sample(_) => 20,
+        Op::Verify(_) => 21,
+        Op::AllReduce(_) => 22,
+        Op::AllGather(_) => 23,
+        Op::ReduceScatter(_) => 24,
+        Op::AllToAll(_) => 25,
+        Op::Send(_) => 26,
+        Op::Recv(_) => 27,
+        Op::Barrier(_) => 28,
+    };
 }
 
 #[test]
@@ -274,4 +652,112 @@ fn api_shape_constructors_are_reachable() {
 
     assert_eq!(IrVersion::CURRENT, IrVersion::new(0, 1, 0));
     assert_eq!(IrVersion::CURRENT.to_string(), "0.1.0");
+
+    let plan = PlanId::new(42);
+    assert_eq!(plan.as_u64(), 42);
+
+    let key = StepGraphKey::new(plan, 0, 16, 16, 0, 0).expect("valid key builds");
+    assert_eq!(key.s, 16);
+    let mut graph = Graph::new(key);
+    let source = Tensor::new(
+        vec![Dim::Concrete(4), Dim::Symbolic(ShapeSymbol::Dm)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .expect("graph-owned weight source builds");
+    let source_edge = graph.add_tensor(source).expect("weight source registers");
+    assert_eq!(source_edge, EdgeId(0));
+    let reshaped_edge = graph
+        .reshape_edge(
+            source_edge,
+            vec![Dim::Concrete(4), Dim::Symbolic(ShapeSymbol::Dm)],
+        )
+        .expect("metadata reshape API is reachable");
+    assert_eq!(reshaped_edge, EdgeId(1));
+    assert!(graph.topological_order().unwrap().is_empty());
+
+    let hash = HashId::new(101);
+    assert_eq!(hash.as_u64(), 101);
+
+    let group = GroupId::new(3);
+    assert_eq!(group.as_u64(), 3);
+    assert_eq!(group.as_u32(), 3);
+    assert_eq!(group.to_string(), "3");
+
+    let num = Numerics::f32(ReductionOrder::AscendingK);
+    assert_eq!(num.accumulator, Some(DType::F32));
+    assert_eq!(num.reduction_order, ReductionOrder::AscendingK);
+
+    let num_matmul = matmul_numerics(
+        DType::I8,
+        DType::I8,
+        QuantScheme::PerToken,
+        QuantScheme::PerRow,
+    )
+    .unwrap();
+    assert_eq!(num_matmul.accumulator, Some(DType::I32));
+    assert_eq!(num_matmul.reduction_order, ReductionOrder::AscendingK);
+
+    let num_moe = moe_ffn_gemm_numerics(
+        DType::I8,
+        DType::I8,
+        QuantScheme::PerBlock32,
+        QuantScheme::PerRow,
+    )
+    .unwrap();
+    assert_eq!(num_moe.accumulator, Some(DType::I32));
+    assert_eq!(num_moe.reduction_order, ReductionOrder::AscendingBlock);
+
+    assert!(is_permitted_fusion(FusionPattern::ResidualAddNorm));
+    let residual = Op::ResidualAdd(ResidualAddOp {
+        out_dtype: DType::F16,
+    });
+    let norm = Op::Norm(NormOp {
+        kind: NormKind::Rms,
+        eps: 1.0e-5,
+        axis: NormAxis::Last,
+        weight_offset: 0.0,
+        out_dtype: DType::F16,
+    });
+    assert_eq!(
+        is_permitted_pair(&residual, &norm),
+        Some(FusionPattern::ResidualAddNorm)
+    );
+    assert_eq!(
+        match_chain(&[&residual, &norm]),
+        Some(FusionPattern::ResidualAddNorm)
+    );
+    let _gated_matcher: fn(&Op, &Op, &Op) -> Option<FusionPattern> = match_gated_pair;
+
+    let sp = SamplingParams {
+        temperature: 0.7,
+        top_k: 50,
+        top_p: 0.9,
+        min_p: 0.05,
+        repetition_penalty: 1.1,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        logit_bias: vec![(10, 1.5)],
+    };
+    assert!(sp.validate().is_ok());
+
+    assert_eq!(CopyKind::default(), CopyKind::Contiguize);
+    assert_eq!(StrideRequirement::default(), StrideRequirement::Any);
+
+    let _ = BUCKET_SIZES;
+    let _ = FUSION_TABLE;
+    let _ = fusion_table();
+    let _ = compute_contiguous_strides(&[Dim::Concrete(4), Dim::Concrete(8)]);
+    let _ = bucket_s(4);
+    let _ = bucket_t_dec(4);
+    let _ = bucket_t_pre(0);
+    let _ = bucket_step(4, 4, 0);
+
+    let op_sample = Op::Copy(CopyOp::default());
+    let _ = legal_layouts(&op_sample);
+    let _ = legal_layout_tuples(&op_sample);
 }

--- a/crates/r9v-ir/tests/fusion_table.rs
+++ b/crates/r9v-ir/tests/fusion_table.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for the closed kernel fusion table (Spec 1 §3.4; card A1.2).
+
+use r9v_ir::{
+    fusion_table, is_permitted_fusion, is_permitted_pair, match_chain, match_gated_pair, ActMulOp,
+    ActivationKind, ActivationOp, AllToAllOp, AttentionMask, AttentionOp, CacheScaleGranularity,
+    DType, Epilogue, FusionPattern, GroupId, LogitsPostprocessOp, MatmulOp, NormAxis, NormKind,
+    NormOp, Op, QuantActOp, QuantScheme, ResidualAddOp, RngAlgorithm, RopeOp, RopeScaling,
+    RopeStyle, SampleOp, Smoothing, StateHandle, StateKind, StateWriteKvOp, FUSION_TABLE,
+};
+
+fn fusion_ops() -> (Op, Op, Op, Op, Op, Op, Op, Op, Op, Op, Op) {
+    let residual = Op::ResidualAdd(ResidualAddOp {
+        out_dtype: DType::F16,
+    });
+    let norm = Op::Norm(NormOp {
+        kind: NormKind::Rms,
+        eps: 1.0e-5,
+        axis: NormAxis::Last,
+        weight_offset: 0.0,
+        out_dtype: DType::F16,
+    });
+    let quant = Op::QuantAct(QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    });
+    let matmul = Op::Matmul(MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    });
+    let activation = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    let act_mul = Op::ActMul(ActMulOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    let rope = Op::Rope(RopeOp {
+        rot_dim: 64,
+        theta: 10_000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+        out_dtype: DType::F16,
+    });
+    let state_write = Op::StateWriteKv(StateWriteKvOp {
+        cache_dtype: DType::F16,
+        scale_granularity: CacheScaleGranularity::PerTokenHead,
+        latent: None,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    });
+    let attention = Op::Attention(AttentionOp {
+        softmax_scale: 0.125,
+        mask: AttentionMask::Causal,
+        sinks: 0,
+        logit_softcap: None,
+        mla: None,
+        out_dtype: DType::F16,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    });
+    let logits = Op::LogitsPostprocess(LogitsPostprocessOp);
+    let sample = Op::Sample(SampleOp {
+        rng: RngAlgorithm::Philox4x32,
+    });
+    (
+        residual,
+        norm,
+        quant,
+        matmul,
+        activation,
+        act_mul,
+        rope,
+        state_write,
+        attention,
+        logits,
+        sample,
+    )
+}
+
+#[test]
+fn fusion_table_has_exactly_nine_patterns() {
+    assert_eq!(
+        FUSION_TABLE.len(),
+        9,
+        "Spec 1 §3.4 defines exactly 9 fusion patterns"
+    );
+    let table = fusion_table();
+    assert_eq!(table.len(), 9);
+
+    let patterns = [
+        FusionPattern::ResidualAddNorm,
+        FusionPattern::NormQuantAct,
+        FusionPattern::MatmulEpilogue,
+        FusionPattern::GatedMatmulActMul,
+        FusionPattern::RopeStateWriteKv,
+        FusionPattern::RopeAttentionPrefill,
+        FusionPattern::StateWriteKvAttentionDecode,
+        FusionPattern::LogitsPostprocessSample,
+        FusionPattern::QuantActAllToAll,
+    ];
+
+    for p in patterns {
+        let entry = table.iter().find(|e| e.pattern == p);
+        assert!(
+            entry.is_some(),
+            "Pattern {:?} must exist in FUSION_TABLE",
+            p
+        );
+        let entry = entry.unwrap();
+        assert!(!entry.description.is_empty());
+        assert!(is_permitted_fusion(p));
+    }
+}
+
+#[test]
+fn typed_pair_matching_accepts_only_spec_transitions() {
+    let (
+        residual,
+        norm,
+        quant,
+        matmul,
+        activation,
+        act_mul,
+        rope,
+        state_write,
+        attention,
+        logits,
+        sample,
+    ) = fusion_ops();
+    let all_to_all = Op::AllToAll(AllToAllOp {
+        group: GroupId::new(0),
+        dtype: DType::I8,
+    });
+
+    assert_eq!(
+        is_permitted_pair(&residual, &norm),
+        Some(FusionPattern::ResidualAddNorm)
+    );
+    assert_eq!(
+        is_permitted_pair(&norm, &quant),
+        Some(FusionPattern::NormQuantAct)
+    );
+    assert_eq!(
+        is_permitted_pair(&matmul, &residual),
+        Some(FusionPattern::MatmulEpilogue)
+    );
+    assert_eq!(
+        is_permitted_pair(&matmul, &activation),
+        Some(FusionPattern::MatmulEpilogue)
+    );
+    assert_eq!(
+        is_permitted_pair(&rope, &state_write),
+        Some(FusionPattern::RopeStateWriteKv)
+    );
+    assert_eq!(
+        is_permitted_pair(&rope, &attention),
+        Some(FusionPattern::RopeAttentionPrefill)
+    );
+    assert_eq!(
+        is_permitted_pair(&state_write, &attention),
+        Some(FusionPattern::StateWriteKvAttentionDecode)
+    );
+    assert_eq!(
+        is_permitted_pair(&logits, &sample),
+        Some(FusionPattern::LogitsPostprocessSample)
+    );
+    assert_eq!(
+        is_permitted_pair(&quant, &all_to_all),
+        Some(FusionPattern::QuantActAllToAll)
+    );
+
+    assert_eq!(is_permitted_pair(&norm, &matmul), None);
+    assert_eq!(is_permitted_pair(&attention, &norm), None);
+    assert_eq!(is_permitted_pair(&sample, &logits), None);
+    assert_eq!(is_permitted_pair(&all_to_all, &quant), None);
+    assert_eq!(is_permitted_pair(&matmul, &act_mul), None);
+}
+
+#[test]
+fn gated_parallel_matmuls_require_two_unfused_producers() {
+    let (_, _, _, matmul, _, act_mul, _, _, _, _, _) = fusion_ops();
+    assert_eq!(
+        match_gated_pair(&matmul, &matmul, &act_mul),
+        Some(FusionPattern::GatedMatmulActMul)
+    );
+    let fused_matmul = Op::Matmul(MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::Act(ActivationKind::Silu),
+        transpose_w: false,
+    });
+    assert_eq!(match_gated_pair(&fused_matmul, &matmul, &act_mul), None);
+}
+
+#[test]
+fn chain_matching_rejects_invented_multi_op_fusions() {
+    let (residual, norm, quant, matmul, activation, _, _, _, _, _, _) = fusion_ops();
+    assert_eq!(
+        match_chain(&[&residual, &norm]),
+        Some(FusionPattern::ResidualAddNorm)
+    );
+    assert_eq!(match_chain(&[]), None);
+    assert_eq!(match_chain(&[&matmul]), None);
+    assert_eq!(match_chain(&[&matmul, &residual, &activation]), None);
+    assert_eq!(match_chain(&[&residual, &norm, &quant]), None);
+}

--- a/crates/r9v-ir/tests/graph_and_buckets.rs
+++ b/crates/r9v-ir/tests/graph_and_buckets.rs
@@ -1,0 +1,842 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for step-graph keys, bucket functions, and copy insertion on stride mismatch (Spec 1 §3; card A1.2).
+
+use r9v_ir::{
+    bucket_s, bucket_step, bucket_t_dec, bucket_t_pre, ActivationKind, ActivationOp, CastOp, Class,
+    DType, Dim, EdgeId, ExternalInput, ExternalInputKind, ExternalOutput, ExternalOutputKind,
+    Graph, IrError, LayoutId, NodeId, NormAxis, NormKind, NormOp, Op, Placement, PlanId,
+    QuantScheme, ShardLayout, StepGraphKey, StrideRequirement, Tensor, BUCKET_SIZES,
+};
+
+#[test]
+fn bucket_functions_exact_edges_and_rounding() {
+    // 1. Exact bucket edges map to themselves
+    for &b in &BUCKET_SIZES {
+        assert_eq!(bucket_s(b).unwrap(), b);
+        assert_eq!(bucket_t_dec(b).unwrap(), b);
+        assert_eq!(bucket_t_pre(b).unwrap(), b);
+    }
+
+    // 2. Intermediate values round up to next discrete power-of-two bucket
+    assert_eq!(bucket_s(3).unwrap(), 4);
+    assert_eq!(bucket_s(5).unwrap(), 8);
+    assert_eq!(bucket_s(33).unwrap(), 64);
+    assert_eq!(bucket_s(1025).unwrap(), 2048);
+    assert_eq!(bucket_s(2049).unwrap(), 4096);
+
+    // 3. T_pre = 0 is legal (decode-only step)
+    assert_eq!(bucket_t_pre(0).unwrap(), 0);
+
+    // 4. Values exceeding 4096 fail with BucketExceeded
+    assert!(matches!(
+        bucket_s(4097),
+        Err(IrError::BucketExceeded {
+            axis: "S",
+            value: 4097,
+            max: 4096
+        })
+    ));
+    assert!(matches!(
+        bucket_t_dec(4097),
+        Err(IrError::BucketExceeded {
+            axis: "T_dec",
+            value: 4097,
+            max: 4096
+        })
+    ));
+    assert!(matches!(
+        bucket_t_pre(4097),
+        Err(IrError::BucketExceeded {
+            axis: "T_pre",
+            value: 4097,
+            max: 4096
+        })
+    ));
+
+    // 5. Zero S or T_dec report the actual invalid bucket axis/value.
+    assert!(matches!(
+        bucket_s(0),
+        Err(IrError::InvalidBucket {
+            axis: "S",
+            value: 0
+        })
+    ));
+    assert!(matches!(
+        bucket_t_dec(0),
+        Err(IrError::InvalidBucket {
+            axis: "T_dec",
+            value: 0
+        })
+    ));
+}
+
+#[test]
+fn bucket_step_collects_errors() {
+    // Both s=0 and t_dec=0 are invalid
+    let res = bucket_step(0, 0, 0);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, IrError::Multiple { .. }));
+}
+
+#[test]
+fn step_graph_key_validation() {
+    let plan = PlanId::new(1);
+    // Exact bucket sizes build cleanly
+    let key = StepGraphKey::new(plan, 0, 16, 32, 0, 0).expect("valid buckets build");
+    assert_eq!(key.s, 16);
+    assert_eq!(key.t_dec, 32);
+    assert_eq!(key.t_pre, 0);
+
+    // Unbucketed values fail with InvalidBucket
+    let bad_key = StepGraphKey::new(plan, 0, 15, 32, 0, 0);
+    assert!(matches!(
+        bad_key,
+        Err(IrError::InvalidBucket {
+            axis: "S",
+            value: 15
+        })
+    ));
+
+    assert!(matches!(
+        StepGraphKey::new(plan, 0, 4097, 32, 0, 0),
+        Err(IrError::BucketExceeded {
+            axis: "S",
+            value: 4097,
+            max: 4096
+        })
+    ));
+
+    // from_unbucketed automatically rounds up
+    let unbucketed = StepGraphKey::from_unbucketed(plan, 0, 15, 20, 100, 0).unwrap();
+    assert_eq!(unbucketed.s, 16);
+    assert_eq!(unbucketed.t_dec, 32);
+    assert_eq!(unbucketed.t_pre, 128);
+}
+
+#[test]
+fn graph_dag_cycle_detection() {
+    let plan = PlanId::new(1);
+    let key = StepGraphKey::new(plan, 0, 1, 1, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    let t = Tensor::new(
+        vec![Dim::Concrete(1), Dim::Concrete(16)],
+        DType::F32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    let e0 = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, t.clone())
+        .unwrap();
+
+    let act_op = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+
+    // Add node 0: in=[e0], out=[e1]
+    let n0 = graph
+        .add_op(act_op.clone(), &[e0], std::slice::from_ref(&t))
+        .unwrap();
+    let e1 = graph.nodes()[n0.0].outputs[0];
+
+    // Add node 1: in=[e1], out=[e2]
+    let n1 = graph
+        .add_op(act_op.clone(), &[e1], std::slice::from_ref(&t))
+        .unwrap();
+    let e2 = graph.nodes()[n1.0].outputs[0];
+
+    // Graph is a linear chain, no cycles
+    assert!(graph.validate().is_ok());
+
+    // Create a cycle by rewiring n0's input to n1's output e2
+    let mut cyclic_graph = graph.clone();
+    cyclic_graph.rewire_node_input(n0, 0, e2).unwrap();
+    let val_res = cyclic_graph.validate();
+    assert!(val_res.is_err());
+    assert!(matches!(val_res.unwrap_err(), IrError::GraphCycle { .. }));
+}
+
+#[test]
+fn graph_detects_cycle_through_metadata_view() {
+    let key = StepGraphKey::new(PlanId::new(1), 0, 1, 1, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+    let input = Tensor::new(
+        vec![Dim::Concrete(1), Dim::Concrete(2)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let input_edge = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, input.clone())
+        .unwrap();
+    let activation = Op::Activation(ActivationOp {
+        act: ActivationKind::Identity,
+        clamp: None,
+    });
+    let first = graph
+        .add_op(activation.clone(), &[input_edge], &[input])
+        .unwrap();
+    let first_output = graph.nodes()[first.0].outputs[0];
+    let view = graph.transpose_edge(first_output, &[1, 0]).unwrap();
+    let view_tensor = graph.edges()[view.0].tensor.clone();
+    let second = graph.add_op(activation, &[view], &[view_tensor]).unwrap();
+    let second_output = graph.nodes()[second.0].outputs[0];
+    graph.rewire_node_input(first, 0, second_output).unwrap();
+
+    assert!(matches!(
+        graph.topological_order(),
+        Err(IrError::GraphCycle { .. })
+    ));
+}
+
+#[test]
+fn stride_mismatch_materializes_exactly_one_copy() {
+    let plan = PlanId::new(1);
+    let key = StepGraphKey::new(plan, 0, 1, 16, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    // Initial activation tensor [16, 64]
+    let t_in = Tensor::new(
+        vec![Dim::Concrete(16), Dim::Concrete(64)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    let e_in = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, t_in)
+        .unwrap();
+
+    // Node 0: Activation produces [16, 64]
+    let act_op = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    let t_act = Tensor::new(
+        vec![Dim::Concrete(16), Dim::Concrete(64)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let n0 = graph.add_op(act_op.clone(), &[e_in], &[t_act]).unwrap();
+    let e_act = graph.nodes()[n0.0].outputs[0];
+
+    // Transpose view permuting [16, 64] -> [64, 16]
+    // Strides become [1, 64] instead of contiguous [16, 1]
+    let e_transposed = graph.transpose_edge(e_act, &[1, 0]).unwrap();
+    assert!(!graph.edges()[e_transposed.0].is_contiguous());
+    assert_eq!(graph.edges()[e_transposed.0].strides, vec![1, 64]);
+
+    // Weight tensor for NormOp [16]
+    let t_weight = Tensor::new(
+        vec![Dim::Concrete(16)],
+        DType::F32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap();
+    let e_weight = graph.add_tensor(t_weight).unwrap();
+
+    // Node 1: NormOp consumes the transposed edge [64, 16] and weight [16]
+    let norm_op = Op::Norm(NormOp {
+        kind: NormKind::Rms,
+        eps: 1e-5,
+        axis: NormAxis::Last,
+        weight_offset: 0.0,
+        out_dtype: DType::F16,
+    });
+    let t_norm_out = Tensor::new(
+        vec![Dim::Concrete(64), Dim::Concrete(16)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    let n1 = graph
+        .add_op_with_requirements(
+            norm_op,
+            &[e_transposed, e_weight],
+            &[StrideRequirement::Contiguous, StrideRequirement::Contiguous],
+            &[t_norm_out],
+        )
+        .unwrap();
+    // Before materialize_copies: consumer input has stride mismatch
+    assert_eq!(graph.nodes()[n1.0].inputs[0], e_transposed);
+    assert_eq!(graph.inserted_copies().len(), 0);
+
+    // Call materialize_copies(): must detect stride mismatch and insert EXACTLY ONE CopyOp
+    let inserted_count = graph
+        .materialize_copies()
+        .expect("copy materialization succeeds");
+    assert_eq!(
+        inserted_count, 1,
+        "Exactly one copy must be inserted for the stride mismatch"
+    );
+
+    // Inspect GraphSummary
+    let summary = graph.summary();
+    assert_eq!(summary.inserted_copy_count(), 1);
+    assert_eq!(summary.inserted_copies.len(), 1);
+
+    let copy_record = &summary.inserted_copies[0];
+    assert_eq!(copy_record.source_edge, e_transposed);
+    assert_eq!(copy_record.consumer_nodes, vec![n1]);
+    assert_eq!(copy_record.actual_strides, vec![1, 64]);
+    assert_eq!(copy_record.expected_strides, vec![16, 1]);
+
+    // Consumer input was rewired to the contiguous copy output
+    let copy_out_edge = copy_record.dest_edge;
+    assert_eq!(graph.nodes()[n1.0].inputs[0], copy_out_edge);
+    assert!(graph.edges()[copy_out_edge.0].is_contiguous());
+    let execution_order = graph.topological_order().unwrap();
+    let copy_position = execution_order
+        .iter()
+        .position(|&node| node == copy_record.copy_node)
+        .unwrap();
+    let consumer_position = execution_order.iter().position(|&node| node == n1).unwrap();
+    assert!(copy_position < consumer_position);
+
+    // Second call to materialize_copies is idempotent (0 new copies inserted)
+    let second_run = graph.materialize_copies().expect("second run succeeds");
+    assert_eq!(second_run, 0, "Second run must not insert duplicate copies");
+
+    // Validating the contiguized graph succeeds
+    assert!(graph.validate().is_ok());
+}
+
+#[test]
+fn noncontiguous_any_requirement_inserts_no_copy() {
+    let plan = PlanId::new(1);
+    let key = StepGraphKey::new(plan, 0, 1, 16, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    let t_in = Tensor::new(
+        vec![Dim::Concrete(16), Dim::Concrete(64)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    let e_in = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, t_in)
+        .unwrap();
+
+    let act_op = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    let t_act = Tensor::new(
+        vec![Dim::Concrete(16), Dim::Concrete(64)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap();
+    let n0 = graph.add_op(act_op.clone(), &[e_in], &[t_act]).unwrap();
+    let e_act = graph.nodes()[n0.0].outputs[0];
+
+    // Transpose view: [16, 64] -> [64, 16] with non-contiguous strides [1, 64]
+    let e_transposed = graph.transpose_edge(e_act, &[1, 0]).unwrap();
+    assert!(!graph.edges()[e_transposed.0].is_contiguous());
+
+    let t_out = Tensor::new(
+        vec![Dim::Concrete(64), Dim::Concrete(16)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    // Consumer op added with explicit StrideRequirement::Any
+    let n1 = graph
+        .add_op_with_requirements(act_op, &[e_transposed], &[StrideRequirement::Any], &[t_out])
+        .unwrap();
+
+    // Verify requirement on node
+    assert_eq!(
+        graph.nodes()[n1.0].input_requirements,
+        vec![StrideRequirement::Any]
+    );
+
+    // materialize_copies must NOT insert a copy because requirement is Any
+    let inserted = graph
+        .materialize_copies()
+        .expect("materialize copies succeeds");
+    assert_eq!(
+        inserted, 0,
+        "materialize_copies must not insert copies for StrideRequirement::Any"
+    );
+    assert_eq!(graph.summary().inserted_copy_count(), 0);
+    assert_eq!(graph.inserted_copies().len(), 0);
+    assert_eq!(
+        graph.nodes()[n1.0].inputs[0],
+        e_transposed,
+        "Consumer input must not be rewired"
+    );
+}
+
+#[test]
+fn transpose_edge_rejects_duplicate_and_missing_axes() {
+    let plan = PlanId::new(1);
+    let key = StepGraphKey::new(plan, 0, 1, 1, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    let t = Tensor::new(
+        vec![Dim::Concrete(4), Dim::Concrete(8), Dim::Concrete(16)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap();
+
+    let e = graph.add_tensor(t).unwrap();
+
+    // Valid permutation: [2, 0, 1] succeeds
+    let e_trans = graph.transpose_edge(e, &[2, 0, 1]).unwrap();
+    assert_eq!(
+        graph.edges()[e_trans.0].tensor.shape(),
+        &[Dim::Concrete(16), Dim::Concrete(4), Dim::Concrete(8)]
+    );
+
+    // Duplicate axis [0, 0, 1] rejected
+    let res_dup = graph.transpose_edge(e, &[0, 0, 1]);
+    assert!(res_dup.is_err());
+    assert!(matches!(
+        res_dup.unwrap_err(),
+        IrError::OpAttributeInvalid {
+            attribute: "perm",
+            ..
+        }
+    ));
+
+    // Missing axis and out-of-bounds axis [0, 1, 5] rejected
+    let res_oob = graph.transpose_edge(e, &[0, 1, 5]);
+    assert!(res_oob.is_err());
+    assert!(matches!(
+        res_oob.unwrap_err(),
+        IrError::OpAttributeInvalid {
+            attribute: "perm",
+            ..
+        }
+    ));
+
+    // Rank mismatch (len 2 vs rank 3) rejected
+    let res_rank = graph.transpose_edge(e, &[0, 1]);
+    assert!(res_rank.is_err());
+    assert!(matches!(
+        res_rank.unwrap_err(),
+        IrError::OpRankMismatch {
+            expected: 3,
+            got: 2,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn reshape_edge_preserves_storage_size_and_rejects_noncontiguous_sources() {
+    let key = StepGraphKey::new(PlanId::new(1), 0, 1, 4, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+    let source = Tensor::new(
+        vec![Dim::Concrete(4), Dim::Concrete(8)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let source_edge = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, source)
+        .unwrap();
+
+    let reshaped = graph
+        .reshape_edge(
+            source_edge,
+            vec![Dim::Concrete(2), Dim::Concrete(4), Dim::Concrete(4)],
+        )
+        .expect("equal-size contiguous reshape is a view");
+    assert_eq!(
+        graph.edges()[reshaped.0].tensor.shape(),
+        &[Dim::Concrete(2), Dim::Concrete(4), Dim::Concrete(4)]
+    );
+    assert!(graph.edges()[reshaped.0].is_contiguous());
+
+    assert!(matches!(
+        graph.reshape_edge(source_edge, vec![Dim::Concrete(31)]),
+        Err(IrError::OpShapeMismatch { .. })
+    ));
+
+    let transposed = graph.transpose_edge(source_edge, &[1, 0]).unwrap();
+    assert!(matches!(
+        graph.reshape_edge(transposed, vec![Dim::Concrete(32)]),
+        Err(IrError::StrideMismatch { .. })
+    ));
+}
+
+#[test]
+fn external_inputs_distinguish_tensor_and_non_tensor() {
+    let plan = PlanId::new(1);
+    let key = StepGraphKey::new(plan, 0, 1, 1, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    let t = Tensor::new(
+        vec![Dim::Concrete(1)],
+        DType::U32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    // Tensor-backed input succeeds
+    let e_tok = graph
+        .add_external_input(ExternalInputKind::TokenIds, t.clone())
+        .unwrap();
+    assert_eq!(e_tok.0, 0);
+
+    // Non-tensor inputs cannot be added via add_external_input with fake Tensor
+    let bad_bm = graph.add_external_input(ExternalInputKind::BatchMeta, t.clone());
+    assert!(bad_bm.is_err());
+    assert!(matches!(
+        bad_bm.unwrap_err(),
+        IrError::OpAttributeInvalid {
+            attribute: "kind",
+            ..
+        }
+    ));
+
+    let bad_sp = graph.add_external_input(ExternalInputKind::SamplingParams, t.clone());
+    assert!(bad_sp.is_err());
+    assert!(matches!(
+        bad_sp.unwrap_err(),
+        IrError::OpAttributeInvalid {
+            attribute: "kind",
+            ..
+        }
+    ));
+
+    // Non-tensor inputs registered cleanly without fake Tensor descriptors
+    graph.add_batch_meta_input().expect("batch meta registers");
+    graph
+        .add_sampling_params_input()
+        .expect("sampling params registers");
+
+    // Duplicate non-tensor inputs are rejected
+    assert!(graph.add_batch_meta_input().is_err());
+    assert!(graph.add_sampling_params_input().is_err());
+
+    // Registering tensor-backed input as non-tensor is rejected
+    let bad_non_tensor = graph.add_external_non_tensor(ExternalInputKind::TokenIds);
+    assert!(bad_non_tensor.is_err());
+    assert!(matches!(
+        bad_non_tensor.unwrap_err(),
+        IrError::OpAttributeInvalid {
+            attribute: "kind",
+            ..
+        }
+    ));
+
+    // Verify external inputs list and exact ExternalInput bindings
+    assert_eq!(graph.external_inputs().len(), 3);
+    assert_eq!(
+        graph.external_inputs()[0],
+        ExternalInput::Tensor {
+            kind: ExternalInputKind::TokenIds,
+            edge: e_tok,
+        }
+    );
+    assert_eq!(
+        graph.external_inputs()[0].kind(),
+        ExternalInputKind::TokenIds
+    );
+    assert_eq!(graph.external_inputs()[0].edge_id(), Some(e_tok));
+    assert_eq!(graph.external_inputs()[1], ExternalInput::BatchMeta);
+    assert_eq!(
+        graph.external_inputs()[1].kind(),
+        ExternalInputKind::BatchMeta
+    );
+    assert_eq!(graph.external_inputs()[1].edge_id(), None);
+    assert_eq!(graph.external_inputs()[2], ExternalInput::SamplingParams);
+    assert_eq!(
+        graph.external_inputs()[2].kind(),
+        ExternalInputKind::SamplingParams
+    );
+    assert_eq!(graph.external_inputs()[2].edge_id(), None);
+
+    // Summary correctly reflects all external inputs
+    let summary = graph.summary();
+    assert_eq!(
+        summary.external_inputs,
+        vec![
+            ExternalInputKind::TokenIds,
+            ExternalInputKind::BatchMeta,
+            ExternalInputKind::SamplingParams,
+        ]
+    );
+
+    // External outputs are typed and bound only to semantically matching edges.
+    let hidden = Tensor::new(
+        vec![Dim::Concrete(1), Dim::Concrete(16)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let e_hidden_input = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, hidden.clone())
+        .unwrap();
+    let act_op = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    let n0 = graph.add_op(act_op, &[e_hidden_input], &[hidden]).unwrap();
+    let e_hidden = graph.nodes()[n0.0].outputs[0];
+    let out_res = graph.add_external_output(ExternalOutputKind::Hidden, e_hidden);
+    assert!(out_res.is_ok());
+    assert_eq!(graph.external_outputs().len(), 1);
+    assert_eq!(
+        graph.external_outputs()[0],
+        ExternalOutput::Tensor {
+            kind: ExternalOutputKind::Hidden,
+            edge: e_hidden,
+        }
+    );
+
+    // Nonexistent edge rejected
+    let bad_out = graph.add_external_output(ExternalOutputKind::Hidden, EdgeId(999));
+    assert!(bad_out.is_err());
+    assert!(matches!(
+        bad_out.unwrap_err(),
+        IrError::GraphEdgeNotFound { edge: 999 }
+    ));
+
+    // Stride requirement mutation on node
+    assert_eq!(
+        graph.nodes()[n0.0].input_requirements[0],
+        StrideRequirement::Any
+    );
+    graph
+        .set_node_input_requirement(n0, 0, StrideRequirement::Contiguous)
+        .expect("set requirement succeeds");
+    assert_eq!(
+        graph.nodes()[n0.0].input_requirements[0],
+        StrideRequirement::Contiguous
+    );
+}
+
+#[test]
+fn external_tensor_bindings_enforce_bucket_shape_dtype_and_role() {
+    let key = StepGraphKey::new(PlanId::new(2), 0, 4, 4, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    let token_ids = Tensor::new(
+        vec![Dim::Concrete(4)],
+        DType::U32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let token_edge = graph
+        .add_external_input(ExternalInputKind::TokenIds, token_ids)
+        .expect("bucket-matched token IDs register");
+    assert!(graph
+        .add_external_input(
+            ExternalInputKind::TokenIds,
+            Tensor::new(
+                vec![Dim::Concrete(4)],
+                DType::U32,
+                QuantScheme::None,
+                LayoutId::CONTIGUOUS,
+                Placement::Device { rank: 0 },
+                ShardLayout::Replicated,
+                Class::Activation,
+            )
+            .unwrap(),
+        )
+        .is_err());
+
+    let wrong_token_shape = Tensor::new(
+        vec![Dim::Concrete(2)],
+        DType::U32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let mut other_graph = Graph::new(key);
+    assert!(matches!(
+        other_graph.add_external_input(ExternalInputKind::TokenIds, wrong_token_shape),
+        Err(IrError::OpShapeMismatch { .. })
+    ));
+
+    let hidden = Tensor::new(
+        vec![Dim::Concrete(4), Dim::Concrete(32)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let hidden_input = graph
+        .add_external_input(ExternalInputKind::EmbedOverride, hidden.clone())
+        .unwrap();
+    let hidden_node = graph
+        .add_op(
+            Op::Activation(ActivationOp {
+                act: ActivationKind::Identity,
+                clamp: None,
+            }),
+            &[hidden_input],
+            &[hidden],
+        )
+        .unwrap();
+    let hidden_edge = graph.nodes()[hidden_node.0].outputs[0];
+    graph
+        .add_external_output(ExternalOutputKind::Hidden, hidden_edge)
+        .expect("bucket-matched hidden output registers");
+
+    let sampled_token = Tensor::new(
+        vec![Dim::Concrete(4)],
+        DType::U32,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let sampled_node = graph
+        .add_op(
+            Op::Cast(CastOp { dtype: DType::U32 }),
+            &[token_edge],
+            &[sampled_token],
+        )
+        .unwrap();
+    let sampled_token_edge = graph.nodes()[sampled_node.0].outputs[0];
+    let sampled_matrix_edge = graph
+        .reshape_edge(sampled_token_edge, vec![Dim::Concrete(4), Dim::Concrete(1)])
+        .unwrap();
+    graph
+        .add_external_output(ExternalOutputKind::Sampled, sampled_matrix_edge)
+        .expect("sample token view satisfies the external sampled matrix contract");
+    assert!(matches!(
+        graph.add_external_output(ExternalOutputKind::AcceptLen, token_edge),
+        Err(IrError::GraphExternalOutputUnproduced { .. })
+    ));
+
+    let weight = Tensor::new(
+        vec![Dim::Concrete(32), Dim::Concrete(32)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap();
+    let _weight_edge = graph.add_tensor(weight).unwrap();
+    let invalid_source = Tensor::new(
+        vec![Dim::Concrete(4), Dim::Concrete(8)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    assert!(matches!(
+        graph.add_tensor(invalid_source),
+        Err(IrError::GraphSourceClassInvalid {
+            class: Class::Activation
+        })
+    ));
+    assert_eq!(graph.external_inputs().len(), 2);
+}
+
+#[test]
+fn public_mutations_validate_and_collect_multiple_errors() {
+    let plan = PlanId::new(1);
+    let key = StepGraphKey::new(plan, 0, 1, 1, 0, 0).unwrap();
+    let mut graph = Graph::new(key);
+
+    let act_op = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    let t = Tensor::new(
+        vec![Dim::Concrete(16)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    // add_op with multiple nonexistent edges collects multiple errors
+    let bad_edges = [EdgeId(10), EdgeId(20)];
+    let res_edges = graph.add_op(act_op.clone(), &bad_edges, std::slice::from_ref(&t));
+    assert!(res_edges.is_err());
+    let err = res_edges.unwrap_err();
+    assert!(matches!(err, IrError::Multiple { .. }));
+
+    // rewire_node_input with bad node and bad edge collects multiple errors
+    let res_rewire = graph.rewire_node_input(NodeId(50), 0, EdgeId(50));
+    assert!(res_rewire.is_err());
+    assert!(matches!(res_rewire.unwrap_err(), IrError::Multiple { .. }));
+}

--- a/crates/r9v-ir/tests/op_validation.rs
+++ b/crates/r9v-ir/tests/op_validation.rs
@@ -1,0 +1,4183 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exhaustive acceptance and rejection validation tests for all 29 ops in Spec 1 §4 (card A1.2).
+//!
+//! Tests verify structural shape, dtype, class, placement, and attribute rules,
+//! checking that errors are strictly typed and that collect-all behavior surfaces
+//! every independent problem when multiple violations coexist (CONVENTIONS.md §1.4).
+
+use r9v_ir::{
+    ActMulOp, ActivationKind, ActivationOp, AllGatherOp, AllReduceOp, AllToAllOp, AttentionMask,
+    AttentionOp, BarrierOp, CacheScaleGranularity, CastOp, CausalConv1dOp, Class, ConvActivation,
+    CopyKind, CopyOp, DType, Dim, EmbedGatherOp, Epilogue, GatherRowsOp, GroupId, HashId, IrError,
+    LayoutId, LinearAttnKind, LinearAttnScanOp, LogitsPostprocessOp, MatmulOp, MlaAttentionSpec,
+    MlaLatent, MoeFfnOp, MoeGroup, MoeRouteOp, MoeScoring, NgramCombine, NgramGatherOp,
+    NgramSource, NormAxis, NormKind, NormOp, Numerics, Op, Placement, QuantActOp, QuantScheme,
+    RecvOp, ReduceOp, ReduceScatterOp, ReductionOrder, ResidualAddOp, RngAlgorithm, RopeOp,
+    RopeScaling, RopeStyle, SampleOp, ScatterAddRowsOp, SchemeId, SendOp, ShardLayout, Smoothing,
+    StateHandle, StateKind, StateWriteKvOp, Tensor, VerifyMethod, VerifyOp,
+};
+
+fn act_tensor(shape: Vec<u32>, dtype: DType) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap()
+}
+
+fn weight_tensor(shape: Vec<u32>, dtype: DType) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap()
+}
+
+fn quant_weight_tensor(shape: Vec<u32>, dtype: DType, quant: QuantScheme) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        quant,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap()
+}
+
+fn device_weight_tensor(shape: Vec<u32>, dtype: DType, rank: u32) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank },
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap()
+}
+
+fn staging_tensor(shape: Vec<u32>, dtype: DType) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        QuantScheme::Scheme(SchemeId::new(1)),
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Staging,
+    )
+    .unwrap()
+}
+
+fn host_tensor(shape: Vec<u32>, dtype: DType) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Host,
+        ShardLayout::Replicated,
+        Class::Weight,
+    )
+    .unwrap()
+}
+
+fn param_tensor(shape: Vec<u32>, dtype: DType) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Param,
+    )
+    .unwrap()
+}
+
+fn bool_tensor(shape: Vec<u32>) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        DType::Bool,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap()
+}
+
+fn quant_act_tensor(shape: Vec<u32>, dtype: DType, quant: QuantScheme) -> Tensor {
+    Tensor::new(
+        shape.into_iter().map(Dim::Concrete).collect(),
+        dtype,
+        quant,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap()
+}
+
+fn assert_multiple_problems(err: IrError, min_count: usize) -> Box<[IrError]> {
+    match err {
+        IrError::Multiple { problems } => {
+            assert!(
+                problems.len() >= min_count,
+                "expected at least {min_count} problems, got {}",
+                problems.len()
+            );
+            problems
+        }
+        other => panic!("expected IrError::Multiple, got {other:?}"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// §4.A Data movement and lookup
+// -----------------------------------------------------------------------------
+
+#[test]
+fn embed_gather_accepts_valid_dimensions_and_dtypes() {
+    let op = EmbedGatherOp {
+        scale: 1.0,
+        out_dtype: DType::F16,
+    };
+
+    let token_ids = act_tensor(vec![128], DType::U32);
+    let table = quant_weight_tensor(vec![32000, 4096], DType::I8, QuantScheme::PerRow);
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[token_ids, table], &[x]).is_ok());
+}
+
+#[test]
+fn embed_gather_rejects_malformed_ranks_classes_and_attributes() {
+    let op = EmbedGatherOp {
+        scale: 1.0,
+        out_dtype: DType::F16,
+    };
+
+    let token_ids = act_tensor(vec![128], DType::U32);
+    let table = quant_weight_tensor(vec![32000, 4096], DType::I8, QuantScheme::PerRow);
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. token_ids wrong dtype
+    let bad_token_ids = act_tensor(vec![128], DType::F32);
+    let err = op
+        .validate(&[bad_token_ids, table.clone()], std::slice::from_ref(&x))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "embed_gather",
+                tensor: "token_ids",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. table wrong rank
+    let bad_table_rank = weight_tensor(vec![4096], DType::F16);
+    let err = op
+        .validate(
+            &[token_ids.clone(), bad_table_rank],
+            std::slice::from_ref(&x),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "embed_gather",
+                tensor: "table",
+                expected: 2,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. table wrong class (Activation instead of Weight)
+    let bad_table_class = act_tensor(vec![32000, 4096], DType::F16);
+    let err = op
+        .validate(
+            &[token_ids.clone(), bad_table_class],
+            std::slice::from_ref(&x),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpClassMismatch {
+                op: "embed_gather",
+                tensor: "table",
+                expected: Class::Weight,
+                got: Class::Activation
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 4. scale <= 0
+    let bad_scale_op = EmbedGatherOp {
+        scale: 0.0,
+        out_dtype: DType::F16,
+    };
+    let err = bad_scale_op
+        .validate(&[token_ids, table], &[x])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "embed_gather",
+                attribute: "scale",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn embed_gather_exposes_collect_all_on_coexisting_violations() {
+    let op = EmbedGatherOp {
+        scale: -1.0,
+        out_dtype: DType::I32,
+    };
+
+    let bad_token_ids = act_tensor(vec![128], DType::F32);
+    let bad_table = act_tensor(vec![32000], DType::F32);
+    let bad_x = act_tensor(vec![128, 4096], DType::F16);
+
+    let err = op
+        .validate(&[bad_token_ids, bad_table], &[bad_x])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "scale",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "out_dtype",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "token_ids",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "table",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn ngram_gather_staged_accepts_one_dimensional_and_two_dimensional_scales() {
+    let op = NgramGatherOp {
+        source: NgramSource::Staged,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(42),
+        table_sizes: vec![1024, 1024].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+
+    let staging = staging_tensor(vec![128, 2, 64], DType::I8);
+    let row_scales_2d = act_tensor(vec![128, 2], DType::F32);
+    let row_scales_1d = act_tensor(vec![128], DType::F32);
+    let x = act_tensor(vec![128, 128], DType::F16);
+
+    assert!(op
+        .validate(&[staging.clone(), row_scales_2d], std::slice::from_ref(&x))
+        .is_ok());
+    assert!(op.validate(&[staging, row_scales_1d], &[x]).is_ok());
+}
+
+#[test]
+fn ngram_gather_device_accepts_direct_table_and_token_ids() {
+    let op = NgramGatherOp {
+        source: NgramSource::Device,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(42),
+        table_sizes: vec![1024, 1024].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+
+    let token_ids = act_tensor(vec![128], DType::U32);
+    let table = weight_tensor(vec![2048, 64], DType::F16);
+    let x = act_tensor(vec![128, 128], DType::F16);
+
+    assert!(op.validate(&[token_ids, table], &[x]).is_ok());
+}
+
+#[test]
+fn ngram_gather_staged_rejects_rank_head_dtype_and_quant_mismatches() {
+    let op = NgramGatherOp {
+        source: NgramSource::Staged,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(42),
+        table_sizes: vec![1024, 1024].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+
+    let staging = staging_tensor(vec![128, 2, 64], DType::I8);
+    let row_scales = act_tensor(vec![128, 2], DType::F32);
+    let x = act_tensor(vec![128, 128], DType::F16);
+
+    // 1. staging rank mismatch
+    let bad_staging_rank = staging_tensor(vec![128, 128], DType::I8);
+    let err = op
+        .validate(
+            &[bad_staging_rank, row_scales.clone()],
+            std::slice::from_ref(&x),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "ngram_gather",
+                tensor: "gather_staging",
+                expected: 3,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. staging bytes must carry a block quantization scheme.
+    let unquantized_staging = Tensor::new(
+        vec![Dim::Concrete(128), Dim::Concrete(2), Dim::Concrete(64)],
+        DType::I8,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        ShardLayout::Replicated,
+        Class::Staging,
+    )
+    .unwrap();
+    let row_scales = act_tensor(vec![128, 2], DType::F32);
+    let x = act_tensor(vec![128, 128], DType::F16);
+    let err = op
+        .validate(&[unquantized_staging, row_scales], std::slice::from_ref(&x))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        IrError::OpQuantMismatch {
+            op: "ngram_gather",
+            tensor: "gather_staging",
+            ..
+        }
+    ));
+
+    // 3. staging heads mismatch (row_scales also matching 4 heads to isolate staging heads violation)
+    let bad_staging_heads = staging_tensor(vec![128, 4, 64], DType::I8);
+    let row_scales_4 = act_tensor(vec![128, 4], DType::F32);
+    let err = op
+        .validate(&[bad_staging_heads, row_scales_4], std::slice::from_ref(&x))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "ngram_gather",
+                tensor: "gather_staging",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 4. row_scales wrong dtype
+    let bad_scales_dtype = act_tensor(vec![128, 2], DType::I32);
+    let err = op.validate(&[staging, bad_scales_dtype], &[x]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "ngram_gather",
+                tensor: "row_scales",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn ngram_gather_device_rejects_rank_class_and_placement_mismatches() {
+    let op = NgramGatherOp {
+        source: NgramSource::Device,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(42),
+        table_sizes: vec![1024, 1024].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+
+    let token_ids = act_tensor(vec![128], DType::U32);
+    let table = weight_tensor(vec![2048, 64], DType::F16);
+    let x = act_tensor(vec![128, 128], DType::F16);
+
+    // 1. token_ids wrong rank
+    let bad_token_ids = act_tensor(vec![128, 1], DType::U32);
+    let err = op
+        .validate(&[bad_token_ids, table.clone()], std::slice::from_ref(&x))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "ngram_gather",
+                tensor: "token_ids",
+                expected: 1,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. table wrong class (Activation instead of Weight)
+    let bad_table_class = act_tensor(vec![2048, 64], DType::F16);
+    let err = op
+        .validate(&[token_ids, bad_table_class], &[x])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpClassMismatch {
+                op: "ngram_gather",
+                tensor: "table",
+                expected: Class::Weight,
+                got: Class::Activation
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn ngram_gather_exposes_collect_all_on_coexisting_violations() {
+    let op = NgramGatherOp {
+        source: NgramSource::Staged,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(42),
+        table_sizes: vec![1024, 1024].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+
+    let bad_staging = act_tensor(vec![128, 4, 64], DType::F32);
+    let bad_scales = act_tensor(vec![128, 2, 1], DType::I32);
+    let bad_x = act_tensor(vec![128, 128], DType::F32);
+
+    let err = op
+        .validate(&[bad_staging, bad_scales], &[bad_x])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "gather_staging",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpClassMismatch {
+            tensor: "gather_staging",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "row_scales",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+}
+
+#[test]
+fn quant_act_accepts_per_token_i8_fp8_and_per_block32_i8() {
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. PerToken with I8 target
+    let op_token_i8 = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+    let xq_i8 = quant_act_tensor(vec![128, 4096], DType::I8, QuantScheme::PerToken);
+    let scale_1d = act_tensor(vec![128], DType::F32);
+    assert!(op_token_i8
+        .validate(std::slice::from_ref(&x), &[xq_i8, scale_1d.clone()])
+        .is_ok());
+
+    // 2. PerToken with E4m3 target
+    let op_token_fp8 = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::E4m3,
+        smoothing: Smoothing::Folded,
+    };
+    let xq_fp8 = quant_act_tensor(vec![128, 4096], DType::E4m3, QuantScheme::PerToken);
+    assert!(op_token_fp8
+        .validate(std::slice::from_ref(&x), &[xq_fp8, scale_1d])
+        .is_ok());
+
+    // 3. PerBlock32 with I8 target
+    let op_block_i8 = QuantActOp {
+        scheme: QuantScheme::PerBlock32,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+    let xq_block_i8 = quant_act_tensor(vec![128, 4096], DType::I8, QuantScheme::PerBlock32);
+    let scale_2d = act_tensor(vec![128, 128], DType::F32);
+    assert!(op_block_i8.validate(&[x], &[xq_block_i8, scale_2d]).is_ok());
+}
+
+#[test]
+fn quant_act_rejects_per_block32_fp8_and_target_scale_mismatches() {
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let xq_i8 = quant_act_tensor(vec![128, 4096], DType::I8, QuantScheme::PerToken);
+    let scale_1d = act_tensor(vec![128], DType::F32);
+
+    // 1. PerBlock32 with E4m3 target rejected
+    let bad_block_fp8 = QuantActOp {
+        scheme: QuantScheme::PerBlock32,
+        target: DType::E4m3,
+        smoothing: Smoothing::None,
+    };
+    let xq_fp8 = quant_act_tensor(vec![128, 4096], DType::E4m3, QuantScheme::PerToken);
+    let scale_2d = act_tensor(vec![128, 128], DType::F32);
+    let err = bad_block_fp8
+        .validate(std::slice::from_ref(&x), &[xq_fp8, scale_2d])
+        .unwrap_err();
+    let problems = match err {
+        IrError::Multiple { problems } => problems,
+        single => vec![single].into_boxed_slice(),
+    };
+    assert!(
+        problems.iter().any(|p| matches!(
+            p,
+            IrError::OpAttributeInvalid {
+                op: "quant_act",
+                attribute: "target",
+                ..
+            }
+        )),
+        "got: {problems:?}"
+    );
+
+    // 2. Invalid target dtype (F32)
+    let bad_target = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::F32,
+        smoothing: Smoothing::None,
+    };
+    let err = bad_target
+        .validate(std::slice::from_ref(&x), &[xq_i8.clone(), scale_1d.clone()])
+        .unwrap_err();
+    let problems = match err {
+        IrError::Multiple { problems } => problems,
+        single => vec![single].into_boxed_slice(),
+    };
+    assert!(
+        problems.iter().any(|p| matches!(
+            p,
+            IrError::OpAttributeInvalid {
+                op: "quant_act",
+                attribute: "target",
+                ..
+            }
+        )),
+        "got: {problems:?}"
+    );
+
+    // 3. Scale rank mismatch for PerToken (2D instead of 1D)
+    let op_token_i8 = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+    let bad_scale_rank = act_tensor(vec![128, 1], DType::F32);
+    let err = op_token_i8
+        .validate(&[x], &[xq_i8, bad_scale_rank])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "quant_act",
+                tensor: "scale",
+                expected: 1,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn quant_act_exposes_collect_all_on_coexisting_violations() {
+    let op = QuantActOp {
+        scheme: QuantScheme::PerRow,
+        target: DType::F32,
+        smoothing: Smoothing::None,
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let bad_xq = act_tensor(vec![128, 4096], DType::F16);
+    let bad_scale = act_tensor(vec![128, 1], DType::I32);
+
+    let err = op.validate(&[x], &[bad_xq, bad_scale]).unwrap_err();
+    let problems = assert_multiple_problems(err, 3);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "scheme",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "target",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "scale",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "scale",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn cast_accepts_matching_shapes_with_target_dtype() {
+    let op = CastOp { dtype: DType::Bf16 };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::Bf16);
+
+    assert!(op.validate(&[x], &[y]).is_ok());
+
+    for shape in [vec![8], vec![2, 3, 4], vec![2, 3, 4, 5]] {
+        let x = act_tensor(shape.clone(), DType::F16);
+        let y = act_tensor(shape, DType::Bf16);
+        assert!(op.validate(&[x], &[y]).is_ok());
+    }
+}
+
+#[test]
+fn cast_rejects_dtype_and_shape_mismatches() {
+    let op = CastOp { dtype: DType::Bf16 };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. Output dtype mismatch
+    let bad_y_dtype = act_tensor(vec![128, 4096], DType::F32);
+    let err = op
+        .validate(std::slice::from_ref(&x), &[bad_y_dtype])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "cast",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Shape mismatch
+    let bad_y_shape = act_tensor(vec![128, 2048], DType::Bf16);
+    let err = op
+        .validate(std::slice::from_ref(&x), &[bad_y_shape])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "cast",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Input count mismatch
+    let err = op.validate(&[x.clone(), x], &[]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::Multiple { .. } | IrError::OpInputCountMismatch { .. }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn cast_exposes_collect_all_on_coexisting_violations() {
+    let op = CastOp { dtype: DType::Bf16 };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let bad_y = device_weight_tensor(vec![128, 2048, 1], DType::F32, 1);
+
+    let err = op.validate(&[x], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpRankMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpPlacementMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn copy_accepts_contiguize_d2d_h2d_and_d2h_boundaries() {
+    let x_dev0 = act_tensor(vec![128, 4096], DType::F16);
+    let y_dev0 = act_tensor(vec![128, 4096], DType::F16);
+    let y_dev1 = Tensor::new(
+        vec![Dim::Concrete(128), Dim::Concrete(4096)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 1 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+
+    let x_host = host_tensor(vec![128, 4096], DType::F16);
+    let y_host_dev = device_weight_tensor(vec![128, 4096], DType::F16, 0);
+
+    // 1. Contiguize
+    let op_contig = CopyOp {
+        kind: CopyKind::Contiguize,
+    };
+    assert!(op_contig
+        .validate(std::slice::from_ref(&x_dev0), &[y_dev0])
+        .is_ok());
+
+    // 2. DeviceToDevice
+    let op_d2d = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    assert!(op_d2d
+        .validate(std::slice::from_ref(&x_dev0), &[y_dev1])
+        .is_ok());
+
+    // 3. HostToDevice
+    let op_h2d = CopyOp {
+        kind: CopyKind::HostToDevice,
+    };
+    assert!(op_h2d
+        .validate(
+            std::slice::from_ref(&x_host),
+            std::slice::from_ref(&y_host_dev)
+        )
+        .is_ok());
+
+    // 4. DeviceToHost
+    let op_d2h = CopyOp {
+        kind: CopyKind::DeviceToHost,
+    };
+    assert!(op_d2h.validate(&[y_host_dev], &[x_host]).is_ok());
+}
+
+#[test]
+fn copy_rejects_placement_class_and_dtype_mismatches() {
+    let x_dev0 = act_tensor(vec![128, 4096], DType::F16);
+    let x_host = host_tensor(vec![128, 4096], DType::F16);
+
+    // 1. Contiguize across placements
+    let op_contig = CopyOp {
+        kind: CopyKind::Contiguize,
+    };
+    let y_dev1 = Tensor::new(
+        vec![Dim::Concrete(128), Dim::Concrete(4096)],
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 1 },
+        ShardLayout::Replicated,
+        Class::Activation,
+    )
+    .unwrap();
+    let err = op_contig
+        .validate(std::slice::from_ref(&x_dev0), &[y_dev1])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpPlacementMismatch {
+                op: "copy",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. DeviceToDevice with same rank
+    let op_d2d = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    let err = op_d2d
+        .validate(std::slice::from_ref(&x_dev0), std::slice::from_ref(&x_dev0))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpPlacementMismatch {
+                op: "copy",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Class mismatch (Weight host to Activation device)
+    let op_h2d = CopyOp {
+        kind: CopyKind::HostToDevice,
+    };
+    let err = op_h2d
+        .validate(std::slice::from_ref(&x_host), std::slice::from_ref(&x_dev0))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpClassMismatch {
+                op: "copy",
+                tensor: "y",
+                expected: Class::Weight,
+                got: Class::Activation
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 4. Output dtype mismatch
+    let bad_dtype_dev0 = act_tensor(vec![128, 4096], DType::F32);
+    let err = op_contig
+        .validate(&[x_dev0], &[bad_dtype_dev0])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "copy",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn copy_exposes_collect_all_on_coexisting_violations() {
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    let x_host = host_tensor(vec![128, 4096], DType::F16);
+    let bad_y = act_tensor(vec![128, 2048], DType::F32);
+
+    let err = op.validate(&[x_host], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpPlacementMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn gather_rows_accepts_valid_indices_and_activation_table() {
+    let op = GatherRowsOp;
+    let x = act_tensor(vec![1000, 128], DType::F16);
+    let indices = act_tensor(vec![50], DType::U32);
+    let y = act_tensor(vec![50, 128], DType::F16);
+
+    assert!(op.validate(&[x, indices], &[y]).is_ok());
+}
+
+#[test]
+fn gather_rows_rejects_dtype_rank_and_shape_mismatches() {
+    let op = GatherRowsOp;
+    let x = act_tensor(vec![1000, 128], DType::F16);
+    let indices = act_tensor(vec![50], DType::U32);
+    let y = act_tensor(vec![50, 128], DType::F16);
+
+    // 1. indices not U32
+    let bad_indices = act_tensor(vec![50], DType::F32);
+    let err = op
+        .validate(&[x.clone(), bad_indices], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "gather_rows",
+                tensor: "indices",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. y shape mismatch
+    let bad_y = act_tensor(vec![60, 128], DType::F16);
+    let err = op
+        .validate(&[x.clone(), indices.clone()], &[bad_y])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "gather_rows",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. x class != Activation
+    let bad_x_class = weight_tensor(vec![1000, 128], DType::F16);
+    let err = op.validate(&[bad_x_class, indices], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpClassMismatch {
+                op: "gather_rows",
+                tensor: "x",
+                expected: Class::Activation,
+                got: Class::Weight
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn gather_rows_exposes_collect_all_on_coexisting_violations() {
+    let op = GatherRowsOp;
+    let bad_x = weight_tensor(vec![1000, 128], DType::I32);
+    let bad_indices = act_tensor(vec![50, 1], DType::F32);
+    let bad_y = act_tensor(vec![60, 128], DType::F32);
+
+    let err = op.validate(&[bad_x, bad_indices], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "x", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "indices",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "indices",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn scatter_add_rows_accepts_two_and_three_input_arities() {
+    let op = ScatterAddRowsOp;
+    let x = act_tensor(vec![50, 128], DType::F16);
+    let indices = act_tensor(vec![50], DType::U32);
+    let dest = act_tensor(vec![1000, 128], DType::F16);
+    let y = act_tensor(vec![1000, 128], DType::F16);
+
+    // 1. Two inputs (without dest)
+    assert!(op
+        .validate(&[x.clone(), indices.clone()], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 2. Three inputs (with dest)
+    assert!(op.validate(&[x, indices, dest], &[y]).is_ok());
+}
+
+#[test]
+fn scatter_add_rows_rejects_input_count_shape_and_dtype_violations() {
+    let op = ScatterAddRowsOp;
+    let x = act_tensor(vec![50, 128], DType::F16);
+    let indices = act_tensor(vec![50], DType::U32);
+    let dest = act_tensor(vec![1000, 128], DType::F16);
+    let y = act_tensor(vec![1000, 128], DType::F16);
+
+    // 1. Input count candidates mismatch (1 input)
+    let err = op
+        .validate(std::slice::from_ref(&x), std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountCandidatesMismatch {
+                op: "scatter_add_rows",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. indices length mismatch with x
+    let bad_indices = act_tensor(vec![40], DType::U32);
+    let err = op
+        .validate(
+            &[x.clone(), bad_indices, dest.clone()],
+            std::slice::from_ref(&y),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "scatter_add_rows",
+                tensor: "x",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. dest shape mismatch with y
+    let bad_dest = act_tensor(vec![900, 128], DType::F16);
+    let err = op
+        .validate(&[x.clone(), indices, bad_dest], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "scatter_add_rows",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 4. y dtype mismatch with x
+    let bad_y_dtype = act_tensor(vec![1000, 128], DType::F32);
+    let err = op.validate(&[x.clone(), dest], &[bad_y_dtype]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::Multiple { .. } | IrError::OpDTypeMismatch { .. }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn scatter_add_rows_exposes_collect_all_on_coexisting_violations() {
+    let op = ScatterAddRowsOp;
+    let x = act_tensor(vec![50, 128], DType::F16);
+    let bad_indices = act_tensor(vec![40], DType::F32);
+    let bad_dest = act_tensor(vec![900, 64], DType::F32);
+    let bad_y = act_tensor(vec![1000, 128], DType::F32);
+
+    let err = op
+        .validate(&[x, bad_indices, bad_dest], &[bad_y])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "indices",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "dest", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "x", .. })));
+}
+
+// -----------------------------------------------------------------------------
+// §4.B Normalization and elementwise
+// -----------------------------------------------------------------------------
+
+#[test]
+fn norm_accepts_two_and_three_input_arities_and_head_axis() {
+    let op_last = NormOp {
+        kind: NormKind::Rms,
+        eps: 1e-5,
+        axis: NormAxis::Last,
+        weight_offset: 0.0,
+        out_dtype: DType::F16,
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let weight = weight_tensor(vec![4096], DType::F32);
+    let bias = param_tensor(vec![4096], DType::F32);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. Two inputs (without bias)
+    assert!(op_last
+        .validate(&[x.clone(), weight.clone()], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 2. Three inputs (with bias)
+    assert!(op_last
+        .validate(&[x.clone(), weight.clone(), bias], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 3. Head axis where 4096 is divisible by 64
+    let op_head = NormOp {
+        axis: NormAxis::Head(64),
+        ..op_last
+    };
+    assert!(op_head.validate(&[x, weight], &[y]).is_ok());
+}
+
+#[test]
+fn norm_rejects_eps_weight_rank_and_head_divisibility_violations() {
+    let op = NormOp {
+        kind: NormKind::Layer,
+        eps: 1e-5,
+        axis: NormAxis::Last,
+        weight_offset: 0.0,
+        out_dtype: DType::F16,
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let weight = weight_tensor(vec![4096], DType::F32);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. eps <= 0
+    let bad_eps = NormOp { eps: 0.0, ..op };
+    let err = bad_eps
+        .validate(&[x.clone(), weight.clone()], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "norm",
+                attribute: "eps",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. weight rank != 1
+    let bad_weight = weight_tensor(vec![4096, 1], DType::F32);
+    let err = op
+        .validate(&[x.clone(), bad_weight], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "norm",
+                tensor: "weight",
+                expected: 1,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Head axis indivisible: 4096 not divisible by 50
+    let bad_head_op = NormOp {
+        axis: NormAxis::Head(50),
+        ..op
+    };
+    let err = bad_head_op
+        .validate(&[x.clone(), weight], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "norm",
+                tensor: "x",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 4. A zero head dimension is rejected without reaching modulo arithmetic.
+    let zero_head_op = NormOp {
+        axis: NormAxis::Head(0),
+        ..op
+    };
+    let err = zero_head_op
+        .validate(
+            &[x.clone(), weight_tensor(vec![4096], DType::F32)],
+            std::slice::from_ref(&y),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        IrError::OpAttributeInvalid {
+            op: "norm",
+            attribute: "axis",
+            ..
+        }
+    ));
+
+    // 5. Output dtype mismatch
+    let bad_y_dtype = act_tensor(vec![128, 4096], DType::F32);
+    let err = op.validate(&[x], &[bad_y_dtype]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::Multiple { .. } | IrError::OpDTypeMismatch { .. }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn norm_exposes_collect_all_on_coexisting_violations() {
+    let op = NormOp {
+        kind: NormKind::Rms,
+        eps: -1.0,
+        axis: NormAxis::Head(0),
+        weight_offset: f32::NAN,
+        out_dtype: DType::U32,
+    };
+
+    let bad_x = act_tensor(vec![128, 4096], DType::I32);
+    let bad_weight = act_tensor(vec![4096, 1], DType::F16);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    let err = op.validate(&[bad_x, bad_weight], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 5);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "eps",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "axis",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "weight_offset",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "out_dtype",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+}
+
+#[test]
+fn residual_add_accepts_matching_activation_operands() {
+    let op = ResidualAddOp {
+        out_dtype: DType::F16,
+    };
+    let a = act_tensor(vec![128, 4096], DType::F16);
+    let b = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[a, b], &[y]).is_ok());
+}
+
+#[test]
+fn residual_add_rejects_shape_dtype_and_class_mismatches() {
+    let op = ResidualAddOp {
+        out_dtype: DType::F16,
+    };
+    let a = act_tensor(vec![128, 4096], DType::F16);
+    let b = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. Shape mismatch
+    let bad_b_shape = act_tensor(vec![128, 2048], DType::F16);
+    let err = op
+        .validate(&[a.clone(), bad_b_shape], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "residual_add",
+                tensor: "b",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Class mismatch
+    let bad_b_class = weight_tensor(vec![128, 4096], DType::F16);
+    let err = op
+        .validate(&[a.clone(), bad_b_class], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpClassMismatch {
+                op: "residual_add",
+                tensor: "b",
+                expected: Class::Activation,
+                got: Class::Weight
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Output dtype mismatch
+    let bad_y_dtype = act_tensor(vec![128, 4096], DType::F32);
+    let err = op.validate(&[a, b], &[bad_y_dtype]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "residual_add",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn residual_add_exposes_collect_all_on_coexisting_violations() {
+    let op = ResidualAddOp {
+        out_dtype: DType::F16,
+    };
+    let bad_a = act_tensor(vec![128, 4096], DType::U32);
+    let bad_b = weight_tensor(vec![128, 2048], DType::F32);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    let err = op.validate(&[bad_a, bad_b], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "a", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "b", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "b", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn act_mul_accepts_matching_gate_and_up_projections() {
+    let op = ActMulOp {
+        act: ActivationKind::Silu,
+        clamp: Some(10.0),
+    };
+    let gate = act_tensor(vec![128, 4096], DType::F16);
+    let up = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[gate, up], &[y]).is_ok());
+}
+
+#[test]
+fn act_mul_rejects_dimension_mismatch_and_non_positive_clamp() {
+    let op = ActMulOp {
+        act: ActivationKind::Gelu,
+        clamp: None,
+    };
+    let gate = act_tensor(vec![128, 4096], DType::F16);
+    let up = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. Gate and up shape mismatch
+    let bad_up = act_tensor(vec![128, 2048], DType::F16);
+    let err = op
+        .validate(&[gate.clone(), bad_up], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "act_mul",
+                tensor: "up",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Clamp <= 0.0
+    let bad_clamp_op = ActMulOp {
+        clamp: Some(0.0),
+        ..op
+    };
+    let err = bad_clamp_op.validate(&[gate, up], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "act_mul",
+                attribute: "clamp",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn act_mul_exposes_collect_all_on_coexisting_violations() {
+    let op = ActMulOp {
+        act: ActivationKind::GeluTanh,
+        clamp: Some(-1.0),
+    };
+    let bad_gate = act_tensor(vec![128, 4096], DType::I32);
+    let bad_up = act_tensor(vec![128, 2048], DType::F16);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    let err = op.validate(&[bad_gate, bad_up], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "clamp",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "gate", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "up", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn activation_accepts_elementwise_transforms_with_optional_clamp() {
+    let op_plain = ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    };
+    let op_clamped = ActivationOp {
+        act: ActivationKind::Relu2,
+        clamp: Some(6.0),
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op_plain
+        .validate(std::slice::from_ref(&x), std::slice::from_ref(&y))
+        .is_ok());
+    assert!(op_clamped.validate(&[x], &[y]).is_ok());
+}
+
+#[test]
+fn activation_rejects_output_rank_and_invalid_clamp() {
+    let op = ActivationOp {
+        act: ActivationKind::Gelu,
+        clamp: None,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. Output rank mismatch
+    let bad_y_rank = act_tensor(vec![128, 4096, 1], DType::F16);
+    let err = op
+        .validate(std::slice::from_ref(&x), &[bad_y_rank])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "activation",
+                tensor: "y",
+                expected: 2,
+                got: 3
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Non-positive clamp
+    let bad_clamp = ActivationOp {
+        clamp: Some(0.0),
+        ..op
+    };
+    let y = act_tensor(vec![128, 4096], DType::F16);
+    let err = bad_clamp.validate(&[x], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "activation",
+                attribute: "clamp",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn activation_exposes_collect_all_on_coexisting_violations() {
+    let op = ActivationOp {
+        act: ActivationKind::Identity,
+        clamp: Some(-5.0),
+    };
+    let bad_x = act_tensor(vec![128, 4096], DType::U32);
+    let bad_y = act_tensor(vec![128, 2048], DType::F32);
+
+    let err = op.validate(&[bad_x], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "clamp",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn rope_accepts_one_dimensional_standard_and_two_dimensional_mrope_positions() {
+    let x = act_tensor(vec![128, 32, 128], DType::F16);
+    let y = act_tensor(vec![128, 32, 128], DType::F16);
+
+    // 1. Standard 1D positions
+    let op_std = RopeOp {
+        rot_dim: 64,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+        out_dtype: DType::F16,
+    };
+    let pos_1d = act_tensor(vec![128], DType::U32);
+    assert!(op_std
+        .validate(&[x.clone(), pos_1d], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 2. MRoPE 2D positions with 3 coordinates
+    let op_mrope = RopeOp {
+        rot_dim: 64,
+        theta: 10000.0,
+        style: RopeStyle::Interleaved,
+        scaling: RopeScaling::None,
+        mrope_sections: Some([16, 24, 24]),
+        out_dtype: DType::F16,
+    };
+    let pos_2d = act_tensor(vec![128, 3], DType::U32);
+    assert!(op_mrope.validate(&[x, pos_2d], &[y]).is_ok());
+}
+
+#[test]
+fn rope_rejects_odd_rot_dim_and_positions_rank_or_dtype_violations() {
+    let op = RopeOp {
+        rot_dim: 64,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+        out_dtype: DType::F16,
+    };
+
+    let x = act_tensor(vec![128, 32, 128], DType::F16);
+    let positions = act_tensor(vec![128], DType::U32);
+    let y = act_tensor(vec![128, 32, 128], DType::F16);
+
+    // 1. rot_dim odd
+    let bad_rot = RopeOp { rot_dim: 65, ..op };
+    let err = bad_rot
+        .validate(&[x.clone(), positions.clone()], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "rope",
+                attribute: "rot_dim",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. positions wrong dtype
+    let bad_pos_dtype = act_tensor(vec![128], DType::F32);
+    let err = op
+        .validate(&[x.clone(), bad_pos_dtype], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "rope",
+                tensor: "positions",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. MRoPE with width != 3
+    let bad_mrope = RopeOp {
+        mrope_sections: Some([16, 24, 24]),
+        ..op
+    };
+    let bad_pos_width = act_tensor(vec![128, 4], DType::U32);
+    let err = bad_mrope.validate(&[x, bad_pos_width], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "rope",
+                tensor: "positions",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn rope_exposes_collect_all_on_coexisting_violations() {
+    let op = RopeOp {
+        rot_dim: 65,
+        theta: -100.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::Linear(0.0),
+        mrope_sections: None,
+        out_dtype: DType::U32,
+    };
+
+    let bad_x = act_tensor(vec![128, 32, 128], DType::I32);
+    let bad_pos = act_tensor(vec![128], DType::F32);
+    let bad_y = act_tensor(vec![128, 32, 128], DType::F32);
+
+    let err = op.validate(&[bad_x, bad_pos], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 6);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "rot_dim",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "theta",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "scaling.factor",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "out_dtype",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "positions",
+            ..
+        }
+    )));
+}
+
+// -----------------------------------------------------------------------------
+// §4.C Matmul family
+// -----------------------------------------------------------------------------
+
+#[test]
+fn matmul_accepts_none_act_bias_and_residual_epilogues() {
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let w = weight_tensor(vec![2048, 4096], DType::F16);
+    let y = act_tensor(vec![128, 2048], DType::F16);
+
+    // 1. None epilogue (2 inputs)
+    let op_none = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    };
+    assert!(op_none
+        .validate(&[x.clone(), w.clone()], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 2. Act epilogue (2 inputs)
+    let op_act = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::Act(ActivationKind::Silu),
+        transpose_w: false,
+    };
+    assert!(op_act
+        .validate(&[x.clone(), w.clone()], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 3. Bias epilogue (3 inputs)
+    let op_bias = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::Bias,
+        transpose_w: false,
+    };
+    let bias = param_tensor(vec![2048], DType::F32);
+    assert!(op_bias
+        .validate(&[x.clone(), w.clone(), bias], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 4. Residual epilogue (3 inputs)
+    let op_res = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::Residual,
+        transpose_w: false,
+    };
+    let residual = act_tensor(vec![128, 2048], DType::F16);
+    assert!(op_res.validate(&[x, w, residual], &[y]).is_ok());
+}
+
+#[test]
+fn matmul_rejects_inner_k_mismatch_and_epilogue_signature_violations() {
+    let op_none = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let w = weight_tensor(vec![2048, 4096], DType::F16);
+    let y = act_tensor(vec![128, 2048], DType::F16);
+
+    // 1. Inner K mismatch
+    let bad_w_k = weight_tensor(vec![2048, 2048], DType::F16);
+    let err = op_none
+        .validate(&[x.clone(), bad_w_k], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "matmul",
+                tensor: "w",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Bias epilogue missing bias input
+    let op_bias = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::Bias,
+        transpose_w: false,
+    };
+    let err = op_bias
+        .validate(&[x.clone(), w.clone()], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountMismatch {
+                op: "matmul",
+                expected: 3,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Bias epilogue with non-Param class
+    let bad_bias_class = weight_tensor(vec![2048], DType::F32);
+    let err = op_bias
+        .validate(
+            &[x.clone(), w.clone(), bad_bias_class],
+            std::slice::from_ref(&y),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpClassMismatch {
+                op: "matmul",
+                tensor: "bias",
+                expected: Class::Param,
+                got: Class::Weight
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 4. None epilogue with extraneous third input
+    let extra = act_tensor(vec![128, 2048], DType::F16);
+    let err = op_none.validate(&[x, w, extra], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountMismatch {
+                op: "matmul",
+                expected: 2,
+                got: 3
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn matmul_exposes_collect_all_on_coexisting_violations() {
+    let op = MatmulOp {
+        out_dtype: DType::I32,
+        epilogue: Epilogue::Bias,
+        transpose_w: false,
+    };
+
+    let bad_x = weight_tensor(vec![128, 4096], DType::F16);
+    let bad_w = act_tensor(vec![2048, 2048], DType::F16);
+    let bad_bias = act_tensor(vec![1024], DType::F16);
+    let bad_y = act_tensor(vec![128, 2048], DType::F32);
+
+    let err = op
+        .validate(&[bad_x, bad_w, bad_bias], &[bad_y])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 6);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "out_dtype",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "w", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "bias", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "w", .. })));
+}
+
+#[test]
+fn matmul_rejects_invalid_gemm_operands_and_dense_host_weights() {
+    let op = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    };
+    let y = act_tensor(vec![8, 16], DType::F16);
+
+    let bad_x = act_tensor(vec![8, 32], DType::F32);
+    let bad_w = weight_tensor(vec![16, 32], DType::Bf16);
+    let problems = assert_multiple_problems(
+        op.validate(&[bad_x, bad_w], std::slice::from_ref(&y))
+            .unwrap_err(),
+        2,
+    );
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "w", .. })));
+
+    let x = act_tensor(vec![8, 32], DType::F16);
+    let host_w = host_tensor(vec![16, 32], DType::F16);
+    assert!(matches!(
+        op.validate(&[x, host_w], std::slice::from_ref(&y))
+            .unwrap_err(),
+        IrError::OpPlacementMismatch {
+            op: "matmul",
+            tensor: "w",
+            ..
+        }
+    ));
+
+    let unquantized_x = act_tensor(vec![8, 32], DType::I8);
+    let w = weight_tensor(vec![16, 32], DType::F16);
+    assert!(matches!(
+        op.validate(&[unquantized_x, w], std::slice::from_ref(&y))
+            .unwrap_err(),
+        IrError::OpQuantMismatch {
+            op: "matmul",
+            tensor: "x",
+            ..
+        }
+    ));
+
+    let x = act_tensor(vec![8, 32], DType::F16);
+    let unquantized_w = weight_tensor(vec![16, 32], DType::I8);
+    assert!(matches!(
+        op.validate(&[x, unquantized_w], &[y]).unwrap_err(),
+        IrError::OpQuantMismatch {
+            op: "matmul",
+            tensor: "w",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn moe_route_accepts_one_and_two_input_signatures() {
+    let op = MoeRouteOp {
+        top_k: 2,
+        scoring: MoeScoring::Softmax,
+        renormalize: true,
+        group: Some(MoeGroup {
+            n_group: 2,
+            topk_group: 1,
+        }),
+        scale: 1.0,
+    };
+
+    let logits = act_tensor(vec![128, 8], DType::F32);
+    let bias = param_tensor(vec![8], DType::F32);
+    let expert_ids = act_tensor(vec![128, 2], DType::U32);
+    let weights = act_tensor(vec![128, 2], DType::F32);
+
+    // 1. One input (without bias)
+    assert!(op
+        .validate(
+            std::slice::from_ref(&logits),
+            &[expert_ids.clone(), weights.clone()]
+        )
+        .is_ok());
+
+    // 2. Two inputs (with bias)
+    assert!(op.validate(&[logits, bias], &[expert_ids, weights]).is_ok());
+}
+
+#[test]
+fn moe_route_rejects_zero_top_k_and_weight_dtype_mismatches() {
+    let op = MoeRouteOp {
+        top_k: 2,
+        scoring: MoeScoring::Sigmoid,
+        renormalize: false,
+        group: None,
+        scale: 1.0,
+    };
+
+    let logits = act_tensor(vec![128, 8], DType::F32);
+    let expert_ids = act_tensor(vec![128, 2], DType::U32);
+    let weights = act_tensor(vec![128, 2], DType::F32);
+
+    // 1. top_k == 0 (collect-all surfaces OpAttributeInvalid and OpShapeMismatch against expert_ids)
+    let bad_k = MoeRouteOp { top_k: 0, ..op };
+    let err = bad_k
+        .validate(
+            std::slice::from_ref(&logits),
+            &[expert_ids.clone(), weights.clone()],
+        )
+        .unwrap_err();
+    let problems = match err {
+        IrError::Multiple { problems } => problems,
+        single => vec![single].into_boxed_slice(),
+    };
+    assert!(
+        problems.iter().any(|p| matches!(
+            p,
+            IrError::OpAttributeInvalid {
+                op: "moe_route",
+                attribute: "top_k",
+                ..
+            }
+        )),
+        "got: {problems:?}"
+    );
+
+    // 2. weights wrong dtype
+    let bad_weights = act_tensor(vec![128, 2], DType::U32);
+    let err = op
+        .validate(
+            std::slice::from_ref(&logits),
+            &[expert_ids.clone(), bad_weights],
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "moe_route",
+                tensor: "weights",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. group topk_group > top_k
+    let bad_group = MoeRouteOp {
+        group: Some(MoeGroup {
+            n_group: 2,
+            topk_group: 3,
+        }),
+        ..op
+    };
+    let err = bad_group
+        .validate(&[logits], &[expert_ids, weights])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "moe_route",
+                attribute: "group.topk_group",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn moe_route_exposes_collect_all_on_coexisting_violations() {
+    let op = MoeRouteOp {
+        top_k: 0,
+        scoring: MoeScoring::Softmax,
+        renormalize: true,
+        group: None,
+        scale: -1.0,
+    };
+
+    let bad_logits = act_tensor(vec![128, 8], DType::I32);
+    let bad_bias = act_tensor(vec![8], DType::F16);
+    let bad_expert_ids = act_tensor(vec![128, 2], DType::F32);
+    let bad_weights = act_tensor(vec![128, 2], DType::I32);
+
+    let err = op
+        .validate(&[bad_logits, bad_bias], &[bad_expert_ids, bad_weights])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 6);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "top_k",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "scale",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "logits",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "bias", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "expert_ids",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "weights",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn moe_ffn_accepts_grouped_expert_gemm_operands() {
+    let op = MoeFfnOp {
+        act: ActivationKind::Silu,
+        out_dtype: DType::F16,
+        shared_experts: 0,
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let expert_ids = act_tensor(vec![128, 2], DType::U32);
+    let weights = act_tensor(vec![128, 2], DType::F32);
+    let w_gate_up = weight_tensor(vec![8, 8192, 4096], DType::F16);
+    let w_down = weight_tensor(vec![8, 4096, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op
+        .validate(&[x, expert_ids, weights, w_gate_up, w_down], &[y])
+        .is_ok());
+
+    let x = quant_act_tensor(vec![128, 4096], DType::I8, QuantScheme::PerToken);
+    let expert_ids = act_tensor(vec![128, 2], DType::U32);
+    let weights = act_tensor(vec![128, 2], DType::F32);
+    let w_gate_up = quant_weight_tensor(vec![8, 8192, 4096], DType::I8, QuantScheme::PerRow);
+    let w_down = quant_weight_tensor(vec![8, 4096, 4096], DType::I8, QuantScheme::PerRow);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+    assert!(op
+        .validate(&[x, expert_ids, weights, w_gate_up, w_down], &[y])
+        .is_ok());
+}
+
+#[test]
+fn moe_ffn_rejects_expert_id_dtype_and_w_down_rank_mismatches() {
+    let op = MoeFfnOp {
+        act: ActivationKind::Silu,
+        out_dtype: DType::F16,
+        shared_experts: 0,
+    };
+
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let expert_ids = act_tensor(vec![128, 2], DType::U32);
+    let weights = act_tensor(vec![128, 2], DType::F32);
+    let w_gate_up = weight_tensor(vec![8, 8192, 4096], DType::F16);
+    let w_down = weight_tensor(vec![8, 4096, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. expert_ids not U32
+    let bad_expert_ids = act_tensor(vec![128, 2], DType::F32);
+    let err = op
+        .validate(
+            &[
+                x.clone(),
+                bad_expert_ids,
+                weights.clone(),
+                w_gate_up.clone(),
+                w_down.clone(),
+            ],
+            std::slice::from_ref(&y),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "moe_ffn",
+                tensor: "expert_ids",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. w_down rank != 3
+    let bad_w_down = weight_tensor(vec![8, 4096], DType::F16);
+    let err = op
+        .validate(&[x, expert_ids, weights, w_gate_up, bad_w_down], &[y])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "moe_ffn",
+                tensor: "w_down",
+                expected: 3,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn moe_ffn_exposes_collect_all_on_coexisting_violations() {
+    let op = MoeFfnOp {
+        act: ActivationKind::Silu,
+        out_dtype: DType::I32,
+        shared_experts: 0,
+    };
+
+    let bad_x = weight_tensor(vec![128, 4096], DType::F16);
+    let bad_expert_ids = act_tensor(vec![128, 2], DType::F32);
+    let bad_weights = act_tensor(vec![128, 2], DType::I32);
+    let bad_w_gate_up = act_tensor(vec![8, 8192], DType::F16);
+    let bad_w_down = weight_tensor(vec![8, 4096, 4096], DType::I32);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    let err = op
+        .validate(
+            &[
+                bad_x,
+                bad_expert_ids,
+                bad_weights,
+                bad_w_gate_up,
+                bad_w_down,
+            ],
+            &[bad_y],
+        )
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 6);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "out_dtype",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "x", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "expert_ids",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "weights",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "w_gate_up",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn moe_ffn_rejects_operands_outside_matmul_numerics_contract() {
+    let op = MoeFfnOp {
+        act: ActivationKind::Silu,
+        out_dtype: DType::F16,
+        shared_experts: 0,
+    };
+    let expert_ids = act_tensor(vec![4, 2], DType::U32);
+    let weights = act_tensor(vec![4, 2], DType::F32);
+    let y = act_tensor(vec![4, 32], DType::F16);
+
+    let bad_x = act_tensor(vec![4, 32], DType::F32);
+    let bad_gate = weight_tensor(vec![8, 64, 32], DType::Bf16);
+    let bad_down = weight_tensor(vec![8, 32, 32], DType::I8);
+    let problems = assert_multiple_problems(
+        op.validate(&[bad_x, expert_ids, weights, bad_gate, bad_down], &[y])
+            .unwrap_err(),
+        3,
+    );
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "w_gate_up",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpQuantMismatch {
+            tensor: "w_down",
+            ..
+        }
+    )));
+}
+
+// -----------------------------------------------------------------------------
+// §4.D Attention
+// -----------------------------------------------------------------------------
+
+#[test]
+fn state_write_kv_accepts_paged_and_mla_latent_signatures() {
+    let k = act_tensor(vec![128, 8, 128], DType::F16);
+    let v = act_tensor(vec![128, 8, 128], DType::F16);
+
+    // 1. Standard paged attention cache write
+    let op_paged = StateWriteKvOp {
+        cache_dtype: DType::F16,
+        scale_granularity: CacheScaleGranularity::PerTokenHead,
+        latent: None,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+    assert!(op_paged.validate(&[k.clone(), v.clone()], &[]).is_ok());
+
+    // 2. MLA latent cache write
+    let op_mla = StateWriteKvOp {
+        cache_dtype: DType::F16,
+        scale_granularity: CacheScaleGranularity::PerBlock,
+        latent: Some(MlaLatent {
+            kv_lora_rank: 512,
+            rope_dim: 64,
+        }),
+        handle: StateHandle::new(1, StateKind::KvLatent),
+    };
+    let k_mla = act_tensor(vec![128, 1, 576], DType::F16);
+    let v_mla = act_tensor(vec![128, 1, 512], DType::F16);
+    assert!(op_mla.validate(&[k_mla, v_mla], &[]).is_ok());
+}
+
+#[test]
+fn state_write_kv_rejects_state_handle_mismatch_and_tensorized_slot_map() {
+    let op = StateWriteKvOp {
+        cache_dtype: DType::F16,
+        scale_granularity: CacheScaleGranularity::PerTokenHead,
+        latent: None,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+
+    let k = act_tensor(vec![128, 8, 128], DType::F16);
+    let v = act_tensor(vec![128, 8, 128], DType::F16);
+    let slot_map = act_tensor(vec![1, 128], DType::U32);
+
+    // 1. State handle kind mismatch (Recurrent instead of KvPaged)
+    let bad_handle_op = StateWriteKvOp {
+        handle: StateHandle::new(0, StateKind::Recurrent),
+        ..op.clone()
+    };
+    let err = bad_handle_op
+        .validate(&[k.clone(), v.clone()], &[])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::StateHandleKindMismatch {
+                op: "state_write_kv",
+                expected: StateKind::KvPaged,
+                got: StateKind::Recurrent
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. slot_map belongs to structured BatchMeta and is rejected as a tensor operand.
+    let err = op
+        .validate(&[k.clone(), v.clone(), slot_map], &[])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountMismatch {
+                op: "state_write_kv",
+                expected: 2,
+                got: 3
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Non-empty output
+    let bad_out = act_tensor(vec![128], DType::F16);
+    let err = op.validate(&[k, v], &[bad_out]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpOutputCountMismatch {
+                op: "state_write_kv",
+                expected: 0,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn state_write_kv_exposes_collect_all_on_coexisting_violations() {
+    let op = StateWriteKvOp {
+        cache_dtype: DType::F32,
+        scale_granularity: CacheScaleGranularity::PerTokenHead,
+        latent: None,
+        handle: StateHandle::new(0, StateKind::Recurrent),
+    };
+
+    let bad_k = act_tensor(vec![128, 8], DType::I32);
+    let bad_v = act_tensor(vec![128, 8, 128], DType::F16);
+    let bad_out = act_tensor(vec![1], DType::F32);
+
+    let err = op.validate(&[bad_k, bad_v], &[bad_out]).unwrap_err();
+    let problems = assert_multiple_problems(err, 5);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "cache_dtype",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::StateHandleKindMismatch { .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpRankMismatch { tensor: "k", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "k", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpOutputCountMismatch { .. })));
+}
+
+#[test]
+fn attention_accepts_paged_mla_and_windowed_masks_without_batch_meta_as_tensor() {
+    let q = act_tensor(vec![128, 32, 128], DType::F16);
+    let o = act_tensor(vec![128, 32, 128], DType::F16);
+
+    // 1. Standard Causal paged attention (SI-12: BatchMeta is non-tensor metadata, not in slice)
+    let op_causal = AttentionOp {
+        softmax_scale: 0.125,
+        mask: AttentionMask::Causal,
+        sinks: 0,
+        logit_softcap: None,
+        mla: None,
+        out_dtype: DType::F16,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+    assert!(op_causal
+        .validate(std::slice::from_ref(&q), std::slice::from_ref(&o))
+        .is_ok());
+
+    // 2. Sliding window causal mask
+    let op_window = AttentionOp {
+        mask: AttentionMask::CausalWindow(512),
+        ..op_causal.clone()
+    };
+    assert!(op_window
+        .validate(std::slice::from_ref(&q), std::slice::from_ref(&o))
+        .is_ok());
+
+    // 3. MLA attention with KvLatent state handle
+    let op_mla = AttentionOp {
+        mla: Some(MlaAttentionSpec {
+            q_lora_rank: None,
+            kv_lora_rank: 512,
+            qk_nope_dim: 128,
+            qk_rope_dim: 64,
+            v_dim: 128,
+        }),
+        handle: StateHandle::new(1, StateKind::KvLatent),
+        ..op_causal
+    };
+    let q_mla = act_tensor(vec![128, 32, 192], DType::F16);
+    let o_mla = act_tensor(vec![128, 32, 128], DType::F16);
+    assert!(op_mla.validate(&[q_mla], &[o_mla]).is_ok());
+}
+
+#[test]
+fn attention_rejects_invalid_scale_and_mismatched_state_kind() {
+    let op = AttentionOp {
+        softmax_scale: 0.125,
+        mask: AttentionMask::Causal,
+        sinks: 0,
+        logit_softcap: None,
+        mla: None,
+        out_dtype: DType::F16,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+
+    let q = act_tensor(vec![128, 32, 128], DType::F16);
+    let o = act_tensor(vec![128, 32, 128], DType::F16);
+
+    // 1. softmax_scale <= 0
+    let bad_scale_op = AttentionOp {
+        softmax_scale: 0.0,
+        ..op.clone()
+    };
+    let err = bad_scale_op
+        .validate(std::slice::from_ref(&q), std::slice::from_ref(&o))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "attention",
+                attribute: "softmax_scale",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. State handle kind mismatch (KvLatent without mla spec)
+    let bad_handle_op = AttentionOp {
+        handle: StateHandle::new(0, StateKind::KvLatent),
+        ..op.clone()
+    };
+    let err = bad_handle_op
+        .validate(std::slice::from_ref(&q), std::slice::from_ref(&o))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::StateHandleKindMismatch {
+                op: "attention",
+                expected: StateKind::KvPaged,
+                got: StateKind::KvLatent
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. q rank != 3
+    let bad_q_rank = act_tensor(vec![128, 32], DType::F16);
+    let err = op.validate(&[bad_q_rank], &[o]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "attention",
+                tensor: "q",
+                expected: 3,
+                got: 2
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn attention_exposes_collect_all_on_coexisting_violations() {
+    let op = AttentionOp {
+        softmax_scale: -0.1,
+        mask: AttentionMask::CausalWindow(0),
+        sinks: 0,
+        logit_softcap: Some(0.0),
+        mla: None,
+        out_dtype: DType::F16,
+        handle: StateHandle::new(0, StateKind::Recurrent),
+    };
+
+    let bad_q = act_tensor(vec![128, 32], DType::I32);
+    let bad_o = act_tensor(vec![128, 32, 128], DType::F32);
+
+    let err = op.validate(&[bad_q], &[bad_o]).unwrap_err();
+    let problems = assert_multiple_problems(err, 6);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "softmax_scale",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "mask",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "logit_softcap",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::StateHandleKindMismatch { .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpRankMismatch { tensor: "q", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "o", .. })));
+}
+
+// -----------------------------------------------------------------------------
+// §4.E Sequence-state ops beyond attention
+// -----------------------------------------------------------------------------
+
+#[test]
+fn causal_conv1d_accepts_two_and_three_input_signatures() {
+    let handle = StateHandle::new(0, StateKind::ConvWindow);
+    let op = CausalConv1dOp {
+        kernel: 4,
+        act: ConvActivation::Silu,
+        handle,
+    };
+
+    let x = act_tensor(vec![128, 256], DType::F16);
+    let w = weight_tensor(vec![256, 4], DType::F16);
+    let bias = param_tensor(vec![256], DType::F16);
+    let y = act_tensor(vec![128, 256], DType::F16);
+
+    // 1. Two inputs (without bias)
+    assert!(op
+        .validate(&[x.clone(), w.clone()], std::slice::from_ref(&y))
+        .is_ok());
+
+    // 2. Three inputs (with bias)
+    assert!(op.validate(&[x, w, bias], &[y]).is_ok());
+}
+
+#[test]
+fn causal_conv1d_rejects_kernel_zero_and_state_handle_kind_mismatches() {
+    let handle = StateHandle::new(0, StateKind::ConvWindow);
+    let op = CausalConv1dOp {
+        kernel: 4,
+        act: ConvActivation::Silu,
+        handle,
+    };
+
+    let x = act_tensor(vec![128, 256], DType::F16);
+    let w = weight_tensor(vec![256, 4], DType::F16);
+    let y = act_tensor(vec![128, 256], DType::F16);
+
+    // 1. kernel == 0 (collects attribute error and shape mismatch against w width)
+    let bad_kernel_op = CausalConv1dOp { kernel: 0, ..op };
+    let err = bad_kernel_op
+        .validate(&[x.clone(), w.clone()], std::slice::from_ref(&y))
+        .unwrap_err();
+    let problems = match err {
+        IrError::Multiple { problems } => problems,
+        single => vec![single].into_boxed_slice(),
+    };
+    assert!(
+        problems.iter().any(|p| matches!(
+            p,
+            IrError::OpAttributeInvalid {
+                op: "causal_conv1d",
+                attribute: "kernel",
+                ..
+            }
+        )),
+        "got: {problems:?}"
+    );
+
+    // 2. State handle kind mismatch
+    let bad_handle_op = CausalConv1dOp {
+        handle: StateHandle::new(0, StateKind::KvPaged),
+        ..op
+    };
+    let err = bad_handle_op
+        .validate(&[x.clone(), w.clone()], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::StateHandleKindMismatch {
+                op: "causal_conv1d",
+                expected: StateKind::ConvWindow,
+                got: StateKind::KvPaged
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. w kernel dimension mismatch
+    let bad_w_k = weight_tensor(vec![256, 5], DType::F16);
+    let err = op.validate(&[x, bad_w_k], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "causal_conv1d",
+                tensor: "w",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn causal_conv1d_exposes_collect_all_on_coexisting_violations() {
+    let op = CausalConv1dOp {
+        kernel: 0,
+        act: ConvActivation::Identity,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+
+    let bad_x = act_tensor(vec![128, 256], DType::I32);
+    let bad_w = act_tensor(vec![256, 5], DType::F16);
+    let bad_y = act_tensor(vec![128, 256], DType::F32);
+
+    let err = op.validate(&[bad_x, bad_w], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 5);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "kernel",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::StateHandleKindMismatch { .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpClassMismatch { tensor: "w", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "w", .. })));
+}
+
+#[test]
+fn linear_attn_scan_accepts_recurrent_five_input_operands() {
+    let handle = StateHandle::new(0, StateKind::Recurrent);
+    let op = LinearAttnScanOp {
+        kind: LinearAttnKind::GLA,
+        chunk: 64,
+        out_dtype: DType::F16,
+        handle,
+    };
+
+    let q = act_tensor(vec![128, 16, 64], DType::F16);
+    let k = act_tensor(vec![128, 16, 64], DType::F16);
+    let v = act_tensor(vec![128, 16, 64], DType::F16);
+    let alpha = act_tensor(vec![128, 16], DType::F32);
+    let beta = act_tensor(vec![128, 16], DType::F32);
+    let o = act_tensor(vec![128, 16, 64], DType::F16);
+
+    assert!(op.validate(&[q, k, v, alpha, beta], &[o]).is_ok());
+}
+
+#[test]
+fn linear_attn_scan_rejects_alpha_dtype_and_state_handle_mismatches() {
+    let handle = StateHandle::new(0, StateKind::Recurrent);
+    let op = LinearAttnScanOp {
+        kind: LinearAttnKind::Mamba2,
+        chunk: 64,
+        out_dtype: DType::F16,
+        handle,
+    };
+
+    let q = act_tensor(vec![128, 16, 64], DType::F16);
+    let k = act_tensor(vec![128, 16, 64], DType::F16);
+    let v = act_tensor(vec![128, 16, 64], DType::F16);
+    let alpha = act_tensor(vec![128, 16], DType::F32);
+    let beta = act_tensor(vec![128, 16], DType::F32);
+    let o = act_tensor(vec![128, 16, 64], DType::F16);
+
+    // 1. alpha not F32
+    let bad_alpha = act_tensor(vec![128, 16], DType::F16);
+    let err = op
+        .validate(
+            &[q.clone(), k.clone(), v.clone(), bad_alpha, beta.clone()],
+            std::slice::from_ref(&o),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "linear_attn_scan",
+                tensor: "alpha",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. handle kind mismatch
+    let bad_handle_op = LinearAttnScanOp {
+        handle: StateHandle::new(0, StateKind::KvPaged),
+        ..op
+    };
+    let err = bad_handle_op
+        .validate(&[q, k, v, alpha, beta], &[o])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::StateHandleKindMismatch {
+                op: "linear_attn_scan",
+                expected: StateKind::Recurrent,
+                got: StateKind::KvPaged
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn linear_attn_scan_exposes_collect_all_on_coexisting_violations() {
+    let op = LinearAttnScanOp {
+        kind: LinearAttnKind::GatedDeltaNet,
+        chunk: 0,
+        out_dtype: DType::I32,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+
+    let bad_q = act_tensor(vec![128, 16], DType::F16);
+    let bad_k = act_tensor(vec![128, 16, 64], DType::I32);
+    let bad_v = act_tensor(vec![128, 16, 64], DType::F16);
+    let bad_alpha = act_tensor(vec![128, 16], DType::F16);
+    let bad_beta = act_tensor(vec![128, 16], DType::I32);
+    let bad_o = act_tensor(vec![128, 16, 64], DType::F32);
+
+    let err = op
+        .validate(&[bad_q, bad_k, bad_v, bad_alpha, bad_beta], &[bad_o])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 6);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "chunk",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "out_dtype",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::StateHandleKindMismatch { .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpRankMismatch { tensor: "q", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "alpha",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "o", .. })));
+}
+
+// -----------------------------------------------------------------------------
+// §4.F Sampling and verification
+// -----------------------------------------------------------------------------
+
+#[test]
+fn logits_postprocess_accepts_one_two_and_three_input_signatures_without_sampling_params_tensor() {
+    let op = LogitsPostprocessOp;
+    let logits_3d = act_tensor(vec![1, 1, 32000], DType::F32);
+    let history = act_tensor(vec![1, 32000], DType::U32);
+    let mask = bool_tensor(vec![1, 1, 32000]);
+    let probs_3d = act_tensor(vec![1, 1, 32000], DType::F32);
+
+    // 1. One input (3D logits)
+    assert!(op
+        .validate(
+            std::slice::from_ref(&logits_3d),
+            std::slice::from_ref(&probs_3d)
+        )
+        .is_ok());
+
+    // 2. Two inputs (logits + history_counts)
+    assert!(op
+        .validate(
+            &[logits_3d.clone(), history.clone()],
+            std::slice::from_ref(&probs_3d)
+        )
+        .is_ok());
+
+    // 3. Two inputs (logits + grammar_mask)
+    assert!(op
+        .validate(
+            &[logits_3d.clone(), mask.clone()],
+            std::slice::from_ref(&probs_3d)
+        )
+        .is_ok());
+
+    // 4. Three inputs (logits + history_counts + grammar_mask; SamplingParams is non-tensor per SI-12)
+    assert!(op
+        .validate(&[logits_3d, history, mask], &[probs_3d])
+        .is_ok());
+}
+
+#[test]
+fn logits_postprocess_rejects_logits_rank_and_grammar_mask_dtype() {
+    let op = LogitsPostprocessOp;
+    let logits = act_tensor(vec![1, 1, 32000], DType::F32);
+    let probs = act_tensor(vec![1, 1, 32000], DType::F32);
+
+    // 1. Logits wrong rank (rank 4)
+    let bad_logits_rank = act_tensor(vec![1, 1, 1, 32000], DType::F32);
+    let err = op
+        .validate(&[bad_logits_rank], std::slice::from_ref(&probs))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpRankMismatch {
+                op: "logits_postprocess",
+                tensor: "logits",
+                expected: 3,
+                got: 4
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Logits wrong dtype
+    let bad_logits_dtype = act_tensor(vec![1, 1, 32000], DType::F16);
+    let err = op
+        .validate(&[bad_logits_dtype], std::slice::from_ref(&probs))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "logits_postprocess",
+                tensor: "logits",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Grammar mask wrong dtype (F32 instead of Bool)
+    let bad_mask_dtype = act_tensor(vec![1, 1, 32000], DType::F32);
+    let history = act_tensor(vec![1, 32000], DType::U32);
+    let err = op
+        .validate(&[logits, history, bad_mask_dtype], &[probs])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "logits_postprocess",
+                tensor: "grammar_mask",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn logits_postprocess_exposes_collect_all_on_coexisting_violations() {
+    let op = LogitsPostprocessOp;
+    let bad_logits = act_tensor(vec![1, 1, 1, 32000], DType::F16);
+    let bad_history = act_tensor(vec![1, 32000], DType::F32);
+    let bad_mask = act_tensor(vec![1, 32000], DType::F32);
+    let bad_probs = act_tensor(vec![1, 1, 32000], DType::F16);
+
+    let err = op
+        .validate(&[bad_logits, bad_history, bad_mask], &[bad_probs])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "logits",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "logits",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "history_counts",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "probs",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn sample_accepts_prob_distribution_without_rng_as_tensor() {
+    let op = SampleOp {
+        rng: RngAlgorithm::Philox4x32,
+    };
+    // SI-12: rng_state is typed external value, not passed in tensor slice
+    let probs = act_tensor(vec![1, 32000], DType::F32);
+    let token = act_tensor(vec![1], DType::U32);
+
+    assert!(op.validate(&[probs], &[token]).is_ok());
+}
+
+#[test]
+fn sample_rejects_rank_dtype_and_batch_dimension_mismatches() {
+    let op = SampleOp {
+        rng: RngAlgorithm::Philox4x32,
+    };
+    let probs = act_tensor(vec![1, 32000], DType::F32);
+    let token = act_tensor(vec![1], DType::U32);
+
+    // 1. token not U32
+    let bad_token_dtype = act_tensor(vec![1], DType::F32);
+    let err = op
+        .validate(std::slice::from_ref(&probs), &[bad_token_dtype])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "sample",
+                tensor: "token",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. probs not F32
+    let bad_probs_dtype = act_tensor(vec![1, 32000], DType::F16);
+    let err = op
+        .validate(&[bad_probs_dtype], std::slice::from_ref(&token))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "sample",
+                tensor: "probs",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Batch dimension S mismatch
+    let bad_token_batch = act_tensor(vec![2], DType::U32);
+    let err = op.validate(&[probs], &[bad_token_batch]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "sample",
+                tensor: "token",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn sample_exposes_collect_all_on_coexisting_violations() {
+    let op = SampleOp {
+        rng: RngAlgorithm::Philox4x32,
+    };
+    let bad_probs = act_tensor(vec![1, 32000, 1], DType::F16);
+    let bad_token = act_tensor(vec![2, 1], DType::F32);
+
+    let err = op.validate(&[bad_probs], &[bad_token]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "probs",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "probs",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpRankMismatch {
+            tensor: "token",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "token",
+            ..
+        }
+    )));
+}
+
+#[test]
+fn verify_accepts_two_and_three_input_arities_without_tree_as_tensor() {
+    let op = VerifyOp {
+        method: VerifyMethod::Greedy,
+    };
+
+    let draft_tokens = act_tensor(vec![1, 4], DType::U32);
+    let target_probs = act_tensor(vec![1, 5, 32000], DType::F32);
+    let draft_probs = act_tensor(vec![1, 4, 32000], DType::F32);
+    let accepted = act_tensor(vec![1, 5], DType::U32);
+    let accept_len = act_tensor(vec![1], DType::U32);
+
+    // 1. Two inputs (deterministic proposer, draft_probs omitted)
+    assert!(op
+        .validate(
+            &[draft_tokens.clone(), target_probs.clone()],
+            &[accepted.clone(), accept_len.clone()]
+        )
+        .is_ok());
+
+    // 2. Three inputs (stochastic proposer with draft_probs; SI-12: tree is non-tensor)
+    assert!(op
+        .validate(
+            &[draft_tokens, draft_probs, target_probs],
+            &[accepted, accept_len]
+        )
+        .is_ok());
+}
+
+#[test]
+fn verify_rejects_draft_token_dtype_and_output_count_mismatches() {
+    let op = VerifyOp {
+        method: VerifyMethod::Rejection,
+    };
+
+    let draft_tokens = act_tensor(vec![1, 4], DType::U32);
+    let target_probs = act_tensor(vec![1, 5, 32000], DType::F32);
+    let accepted = act_tensor(vec![1, 5], DType::U32);
+    let accept_len = act_tensor(vec![1], DType::U32);
+
+    // 1. draft_tokens not U32
+    let bad_draft = act_tensor(vec![1, 4], DType::F32);
+    let err = op
+        .validate(
+            &[bad_draft, target_probs.clone()],
+            &[accepted.clone(), accept_len.clone()],
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "verify",
+                tensor: "draft_tokens",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. Output count mismatch (only 1 output instead of 2)
+    let err = op
+        .validate(&[draft_tokens, target_probs], &[accepted])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpOutputCountMismatch {
+                op: "verify",
+                expected: 2,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_exposes_collect_all_on_coexisting_violations() {
+    let op = VerifyOp {
+        method: VerifyMethod::TypicalAcceptance {
+            eps: 0.0,
+            delta: -1.0,
+        },
+    };
+
+    let bad_draft = act_tensor(vec![1, 4], DType::F32);
+    let bad_target = act_tensor(vec![1, 5, 32000], DType::F16);
+    let bad_accepted = act_tensor(vec![1, 5], DType::F32);
+
+    let err = op
+        .validate(&[bad_draft, bad_target], &[bad_accepted])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 5);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "method.eps",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "method.delta",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "draft_tokens",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "target_probs",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpOutputCountMismatch { .. })));
+}
+
+// -----------------------------------------------------------------------------
+// §4.G Collectives
+// -----------------------------------------------------------------------------
+
+#[test]
+fn all_reduce_accepts_matching_element_dtype() {
+    let op = AllReduceOp {
+        group: GroupId::new(0),
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F32,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[x], &[y]).is_ok());
+}
+
+#[test]
+fn all_reduce_rejects_invalid_reduce_in_and_dtype_mismatches() {
+    let op = AllReduceOp {
+        group: GroupId::new(0),
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F32,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. reduce_in != F32
+    let bad_reduce_in = AllReduceOp {
+        reduce_in: DType::F16,
+        ..op
+    };
+    let err = bad_reduce_in
+        .validate(std::slice::from_ref(&x), std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "all_reduce",
+                attribute: "reduce_in",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. output dtype mismatch
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+    let err = op.validate(&[x], &[bad_y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "all_reduce",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn all_reduce_exposes_collect_all_on_coexisting_violations() {
+    let op = AllReduceOp {
+        group: GroupId::new(0),
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F16,
+    };
+
+    let bad_x = act_tensor(vec![128, 4096], DType::I32);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    let err = op.validate(&[bad_x], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 3);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "reduce_in",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn all_gather_accepts_gathered_axis_dimension() {
+    let op = AllGatherOp {
+        group: GroupId::new(0),
+        axis: 0,
+        dtype: DType::F16,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![256, 4096], DType::F16);
+
+    assert!(op.validate(&[x], &[y]).is_ok());
+}
+
+#[test]
+fn all_gather_rejects_out_of_bounds_axis_and_rank_mismatch() {
+    let op = AllGatherOp {
+        group: GroupId::new(0),
+        axis: 2,
+        dtype: DType::F16,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. axis >= rank
+    let err = op.validate(std::slice::from_ref(&x), &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "all_gather",
+                attribute: "axis",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. non-gathered dimension mismatch
+    let op_valid_axis = AllGatherOp { axis: 0, ..op };
+    let bad_y_dim = act_tensor(vec![256, 2048], DType::F16);
+    let err = op_valid_axis.validate(&[x], &[bad_y_dim]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "all_gather",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn all_gather_exposes_collect_all_on_coexisting_violations() {
+    let op = AllGatherOp {
+        group: GroupId::new(0),
+        axis: 4,
+        dtype: DType::F16,
+    };
+    let bad_x = act_tensor(vec![128, 4096], DType::I32);
+    let bad_y = act_tensor(vec![256, 4096, 1], DType::F32);
+
+    let err = op.validate(&[bad_x], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "axis",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpRankMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn reduce_scatter_accepts_partitioned_axis_dimension() {
+    let op = ReduceScatterOp {
+        group: GroupId::new(0),
+        axis: 0,
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F32,
+    };
+    let x = act_tensor(vec![256, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[x], &[y]).is_ok());
+}
+
+#[test]
+fn reduce_scatter_rejects_invalid_reduce_in_and_axis_bounds() {
+    let op = ReduceScatterOp {
+        group: GroupId::new(0),
+        axis: 0,
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F32,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. reduce_in != F32
+    let bad_reduce = ReduceScatterOp {
+        reduce_in: DType::F16,
+        ..op
+    };
+    let err = bad_reduce
+        .validate(std::slice::from_ref(&x), std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "reduce_scatter",
+                attribute: "reduce_in",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. axis >= rank
+    let bad_axis = ReduceScatterOp { axis: 3, ..op };
+    let err = bad_axis.validate(&[x], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpAttributeInvalid {
+                op: "reduce_scatter",
+                attribute: "axis",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn reduce_scatter_exposes_collect_all_on_coexisting_violations() {
+    let op = ReduceScatterOp {
+        group: GroupId::new(0),
+        axis: 5,
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F16,
+    };
+    let bad_x = act_tensor(vec![256, 4096], DType::I32);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    let err = op.validate(&[bad_x], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "reduce_in",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpAttributeInvalid {
+            attribute: "axis",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn all_to_all_requires_explicit_counts_and_one_output() {
+    let op = AllToAllOp {
+        group: GroupId::new(0),
+        dtype: DType::F16,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+    let counts = act_tensor(vec![4], DType::U32);
+    assert!(op.validate(&[x, counts], &[y]).is_ok());
+}
+
+#[test]
+fn all_to_all_rejects_counts_dtype_and_count_candidate_violations() {
+    let op = AllToAllOp {
+        group: GroupId::new(0),
+        dtype: DType::F16,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. counts not U32
+    let bad_counts = act_tensor(vec![4], DType::F32);
+    let err = op
+        .validate(&[x.clone(), bad_counts], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "all_to_all",
+                tensor: "counts",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. output dtype mismatch
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+    let counts = act_tensor(vec![4], DType::U32);
+    let err = op.validate(&[x.clone(), counts], &[bad_y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "all_to_all",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. Empty inputs
+    let err = op.validate(&[], &[y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountMismatch {
+                op: "all_to_all",
+                expected: 2,
+                got: 0
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn all_to_all_exposes_collect_all_on_coexisting_violations() {
+    let op = AllToAllOp {
+        group: GroupId::new(0),
+        dtype: DType::F16,
+    };
+    let bad_x = act_tensor(vec![128, 4096], DType::I32);
+    let bad_counts = act_tensor(vec![4], DType::F32);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+    let bad_recv = act_tensor(vec![4], DType::F32);
+
+    let err = op
+        .validate(&[bad_x, bad_counts], &[bad_y, bad_recv])
+        .unwrap_err();
+    let problems = assert_multiple_problems(err, 4);
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpDTypeMismatch {
+            tensor: "counts",
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpOutputCountMismatch {
+            expected: 1,
+            got: 2,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn send_accepts_valid_tensor_and_empty_output() {
+    let op = SendOp {
+        group: GroupId::new(0),
+        peer: 1,
+        dtype: DType::F16,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[x], &[]).is_ok());
+}
+
+#[test]
+fn send_rejects_non_empty_output_and_dtype_mismatch() {
+    let op = SendOp {
+        group: GroupId::new(0),
+        peer: 1,
+        dtype: DType::F16,
+    };
+    let x = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. non-empty output
+    let bad_out = act_tensor(vec![128, 4096], DType::F16);
+    let err = op
+        .validate(std::slice::from_ref(&x), &[bad_out])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpOutputCountMismatch {
+                op: "send",
+                expected: 0,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. x dtype mismatch
+    let bad_x = act_tensor(vec![128, 4096], DType::F32);
+    let err = op.validate(&[bad_x], &[]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "send",
+                tensor: "x",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn send_exposes_collect_all_on_coexisting_violations() {
+    let op = SendOp {
+        group: GroupId::new(0),
+        peer: 1,
+        dtype: DType::F16,
+    };
+    let bad_x = act_tensor(vec![128, 4096], DType::F32);
+    let bad_out = act_tensor(vec![1], DType::F32);
+
+    let err = op.validate(&[bad_x], &[bad_out]).unwrap_err();
+    let problems = assert_multiple_problems(err, 2);
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "x", .. })));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpOutputCountMismatch {
+            expected: 0,
+            got: 1,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn recv_accepts_empty_input_and_matching_shape() {
+    let op = RecvOp {
+        group: GroupId::new(0),
+        peer: 0,
+        shape: vec![Dim::Concrete(128), Dim::Concrete(4096)].into_boxed_slice(),
+        dtype: DType::F16,
+    };
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    assert!(op.validate(&[], &[y]).is_ok());
+}
+
+#[test]
+fn recv_rejects_non_empty_input_and_shape_mismatches() {
+    let op = RecvOp {
+        group: GroupId::new(0),
+        peer: 0,
+        shape: vec![Dim::Concrete(128), Dim::Concrete(4096)].into_boxed_slice(),
+        dtype: DType::F16,
+    };
+    let y = act_tensor(vec![128, 4096], DType::F16);
+
+    // 1. non-empty input
+    let bad_in = act_tensor(vec![128, 4096], DType::F16);
+    let err = op
+        .validate(&[bad_in], std::slice::from_ref(&y))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountMismatch {
+                op: "recv",
+                expected: 0,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. y shape mismatch
+    let bad_y = act_tensor(vec![128, 2048], DType::F16);
+    let err = op.validate(&[], &[bad_y]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpShapeMismatch {
+                op: "recv",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 3. y dtype mismatch
+    let bad_y_dtype = act_tensor(vec![128, 4096], DType::F32);
+    let err = op.validate(&[], &[bad_y_dtype]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpDTypeMismatch {
+                op: "recv",
+                tensor: "y",
+                ..
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn recv_exposes_collect_all_on_coexisting_violations() {
+    let op = RecvOp {
+        group: GroupId::new(0),
+        peer: 0,
+        shape: vec![Dim::Concrete(128), Dim::Concrete(4096)].into_boxed_slice(),
+        dtype: DType::F16,
+    };
+    let bad_in = act_tensor(vec![1], DType::F16);
+    let bad_y = act_tensor(vec![128, 2048], DType::F32);
+
+    let err = op.validate(&[bad_in], &[bad_y]).unwrap_err();
+    let problems = assert_multiple_problems(err, 3);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpInputCountMismatch {
+            expected: 0,
+            got: 1,
+            ..
+        }
+    )));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpDTypeMismatch { tensor: "y", .. })));
+    assert!(problems
+        .iter()
+        .any(|p| matches!(p, IrError::OpShapeMismatch { tensor: "y", .. })));
+}
+
+#[test]
+fn barrier_accepts_empty_inputs_and_outputs() {
+    let op = BarrierOp {
+        group: GroupId::new(0),
+    };
+
+    assert!(op.validate(&[], &[]).is_ok());
+}
+
+#[test]
+fn barrier_rejects_non_empty_inputs_or_outputs() {
+    let op = BarrierOp {
+        group: GroupId::new(0),
+    };
+    let tensor = act_tensor(vec![1], DType::F32);
+
+    // 1. non-empty input
+    let err = op.validate(std::slice::from_ref(&tensor), &[]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpInputCountMismatch {
+                op: "barrier",
+                expected: 0,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+
+    // 2. non-empty output
+    let err = op.validate(&[], &[tensor]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            IrError::OpOutputCountMismatch {
+                op: "barrier",
+                expected: 0,
+                got: 1
+            }
+        ),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn barrier_exposes_collect_all_on_coexisting_violations() {
+    let op = BarrierOp {
+        group: GroupId::new(0),
+    };
+    let bad_in = act_tensor(vec![1], DType::F32);
+    let bad_out = act_tensor(vec![1], DType::F32);
+
+    let err = op.validate(&[bad_in], &[bad_out]).unwrap_err();
+    let problems = assert_multiple_problems(err, 2);
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpInputCountMismatch {
+            expected: 0,
+            got: 1,
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|p| matches!(
+        p,
+        IrError::OpOutputCountMismatch {
+            expected: 0,
+            got: 1,
+            ..
+        }
+    )));
+}
+
+// -----------------------------------------------------------------------------
+// Op Enum Dispatch
+// -----------------------------------------------------------------------------
+
+#[test]
+fn op_enum_dispatch_validates_variants_consistently() {
+    let cast = Op::Cast(CastOp { dtype: DType::Bf16 });
+    let x = act_tensor(vec![128, 4096], DType::F16);
+    let y = act_tensor(vec![128, 4096], DType::Bf16);
+    let bad_y = act_tensor(vec![128, 4096], DType::F32);
+
+    assert!(cast.validate(std::slice::from_ref(&x), &[y]).is_ok());
+    assert!(cast.validate(&[x], &[bad_y]).is_err());
+}
+
+#[test]
+fn op_enum_dispatches_validation_across_groups_d_through_g() {
+    let representatives = [
+        Op::Attention(AttentionOp {
+            softmax_scale: 0.125,
+            mask: AttentionMask::Causal,
+            sinks: 0,
+            logit_softcap: None,
+            mla: None,
+            out_dtype: DType::F16,
+            handle: StateHandle::new(0, StateKind::KvPaged),
+        }),
+        Op::CausalConv1d(CausalConv1dOp {
+            kernel: 4,
+            act: ConvActivation::Silu,
+            handle: StateHandle::new(0, StateKind::ConvWindow),
+        }),
+        Op::LogitsPostprocess(LogitsPostprocessOp),
+        Op::AllReduce(AllReduceOp {
+            group: GroupId::new(0),
+            op: ReduceOp::Sum,
+            dtype: DType::F16,
+            reduce_in: DType::F32,
+        }),
+    ];
+    assert_eq!(
+        representatives.map(|op| (op.op_name(), op.validate(&[], &[]).is_err())),
+        [
+            ("attention", true),
+            ("causal_conv1d", true),
+            ("logits_postprocess", true),
+            ("all_reduce", true),
+        ]
+    );
+}
+
+#[test]
+fn op_enum_dispatches_public_numerics_contracts() {
+    let attention = Op::Attention(AttentionOp {
+        softmax_scale: 0.125,
+        mask: AttentionMask::Causal,
+        sinks: 0,
+        logit_softcap: None,
+        mla: None,
+        out_dtype: DType::F16,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    });
+    assert_eq!(
+        attention.numerics(&[]).unwrap(),
+        Numerics::f32(ReductionOrder::AscendingBlock)
+    );
+
+    let logits = Op::LogitsPostprocess(LogitsPostprocessOp);
+    assert_eq!(
+        logits.numerics(&[]).unwrap(),
+        Numerics::f32(ReductionOrder::AscendingIndex)
+    );
+
+    let all_reduce = Op::AllReduce(AllReduceOp {
+        group: GroupId::new(0),
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F32,
+    });
+    assert_eq!(
+        all_reduce.numerics(&[]).unwrap(),
+        Numerics::f32(ReductionOrder::AscendingRank)
+    );
+
+    let all_to_all = Op::AllToAll(AllToAllOp {
+        group: GroupId::new(0),
+        dtype: DType::F16,
+    });
+    assert_eq!(all_to_all.numerics(&[]).unwrap(), Numerics::none());
+}
+
+#[test]
+fn validation_reports_dimension_overflow_without_panicking() {
+    let ngram_device = NgramGatherOp {
+        source: NgramSource::Device,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(1),
+        table_sizes: vec![u32::MAX, 1].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+    let token_ids = act_tensor(vec![1], DType::U32);
+    let table = weight_tensor(vec![1, 1], DType::F16);
+    let x = act_tensor(vec![1, 2], DType::F16);
+    assert!(ngram_device.validate(&[token_ids, table], &[x]).is_err());
+
+    let ngram_staged = NgramGatherOp {
+        source: NgramSource::Staged,
+        orders: vec![2].into_boxed_slice(),
+        heads: u32::MAX,
+        hash: HashId::new(1),
+        table_sizes: vec![1].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+    let staging = staging_tensor(vec![1, 1, 2], DType::I8);
+    let scales = act_tensor(vec![1], DType::F32);
+    let x = act_tensor(vec![1, 1], DType::F16);
+    assert!(ngram_staged.validate(&[staging, scales], &[x]).is_err());
+
+    let rope = RopeOp {
+        rot_dim: u32::MAX,
+        theta: 10_000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: Some([u32::MAX, 2, 2]),
+        out_dtype: DType::F16,
+    };
+    let x = act_tensor(vec![1, 1, 2], DType::F16);
+    let positions = act_tensor(vec![1, 3], DType::U32);
+    let y = act_tensor(vec![1, 1, 2], DType::F16);
+    assert!(rope.validate(&[x, positions], &[y]).is_err());
+
+    let moe = MoeFfnOp {
+        act: ActivationKind::Silu,
+        out_dtype: DType::F16,
+        shared_experts: 0,
+    };
+    let x = act_tensor(vec![1, 1], DType::F16);
+    let expert_ids = act_tensor(vec![1, 1], DType::U32);
+    let weights = act_tensor(vec![1, 1], DType::F32);
+    let w_gate_up = weight_tensor(vec![1, 1, 1], DType::F16);
+    let w_down = weight_tensor(vec![1, 1, u32::MAX], DType::F16);
+    let y = act_tensor(vec![1, 1], DType::F16);
+    assert!(moe
+        .validate(&[x, expert_ids, weights, w_gate_up, w_down], &[y])
+        .is_err());
+
+    let state_write = StateWriteKvOp {
+        cache_dtype: DType::F16,
+        scale_granularity: CacheScaleGranularity::PerTokenHead,
+        latent: Some(MlaLatent {
+            kv_lora_rank: u32::MAX,
+            rope_dim: 2,
+        }),
+        handle: StateHandle::new(0, StateKind::KvLatent),
+    };
+    let k = act_tensor(vec![1, 1, 3], DType::F16);
+    let v = act_tensor(vec![1, 1, 3], DType::F16);
+    assert!(state_write.validate(&[k, v], &[]).is_err());
+
+    let attention = AttentionOp {
+        softmax_scale: 1.0,
+        mask: AttentionMask::Causal,
+        sinks: 0,
+        logit_softcap: None,
+        mla: Some(MlaAttentionSpec {
+            q_lora_rank: None,
+            kv_lora_rank: 1,
+            qk_nope_dim: u32::MAX,
+            qk_rope_dim: 2,
+            v_dim: 1,
+        }),
+        out_dtype: DType::F16,
+        handle: StateHandle::new(0, StateKind::KvLatent),
+    };
+    let q = act_tensor(vec![1, 1, 1], DType::F16);
+    let o = act_tensor(vec![1, 1, 1], DType::F16);
+    assert!(attention.validate(&[q], &[o]).is_err());
+
+    let verify = VerifyOp {
+        method: VerifyMethod::Greedy,
+    };
+    let draft_tokens = act_tensor(vec![1, u32::MAX], DType::U32);
+    let target_probs = act_tensor(vec![1, 1, 2], DType::F32);
+    let accepted = act_tensor(vec![1, 1], DType::U32);
+    let accept_len = act_tensor(vec![1], DType::U32);
+    let problems = assert_multiple_problems(
+        verify
+            .validate(&[draft_tokens, target_probs], &[accepted, accept_len])
+            .unwrap_err(),
+        2,
+    );
+    assert!(problems.iter().any(|problem| matches!(
+        problem,
+        IrError::OpShapeMismatch {
+            tensor: "target_probs",
+            ..
+        }
+    )));
+    assert!(problems.iter().any(|problem| matches!(
+        problem,
+        IrError::OpShapeMismatch {
+            tensor: "accepted",
+            ..
+        }
+    )));
+}

--- a/crates/r9v-ir/tests/sharding_tables.rs
+++ b/crates/r9v-ir/tests/sharding_tables.rs
@@ -1,0 +1,698 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for Op sharding tables and propagation rules (Spec 1 §5.2; card A1.2).
+
+use r9v_ir::{
+    legal_layout_tuples, legal_layouts, ActMulOp, ActivationKind, ActivationOp, AllGatherOp,
+    AllReduceOp, AllToAllOp, AttentionMask, AttentionOp, BarrierOp, CacheScaleGranularity, CastOp,
+    CausalConv1dOp, Class, ConvActivation, CopyOp, DType, Dim, EmbedGatherOp, Epilogue,
+    ExpertCount, GatherRowsOp, GroupId, HashId, HeadCount, LayoutId, LinearAttnKind,
+    LinearAttnScanOp, LogitsPostprocessOp, MatmulOp, MoeFfnOp, MoeRouteOp, MoeScoring,
+    NgramCombine, NgramGatherOp, NgramSource, NormAxis, NormKind, NormOp, Op, Placement,
+    QuantActOp, QuantScheme, RecvOp, ReduceOp, ReduceScatterOp, ResidualAddOp, RngAlgorithm,
+    RopeOp, RopeScaling, RopeStyle, SampleOp, ScatterAddRowsOp, SendOp, ShardLayout,
+    ShardLayoutPattern, ShardingRule, Smoothing, StateHandle, StateKind, StateWriteKvOp, Tensor,
+    VerifyMethod, VerifyOp,
+};
+
+fn all_sample_ops() -> Vec<Op> {
+    vec![
+        Op::EmbedGather(EmbedGatherOp {
+            scale: 1.0,
+            out_dtype: DType::F16,
+        }),
+        Op::NgramGather(NgramGatherOp {
+            source: NgramSource::Device,
+            orders: vec![2, 3].into_boxed_slice(),
+            heads: 2,
+            hash: HashId::new(1),
+            table_sizes: vec![1024, 1024].into_boxed_slice(),
+            combine: NgramCombine::Concat,
+            out_dtype: DType::F16,
+        }),
+        Op::QuantAct(QuantActOp {
+            scheme: QuantScheme::PerToken,
+            target: DType::I8,
+            smoothing: Smoothing::None,
+        }),
+        Op::Cast(CastOp { dtype: DType::F16 }),
+        Op::Copy(CopyOp::default()),
+        Op::GatherRows(GatherRowsOp),
+        Op::ScatterAddRows(ScatterAddRowsOp),
+        Op::Norm(NormOp {
+            kind: NormKind::Rms,
+            eps: 1e-5,
+            axis: NormAxis::Last,
+            weight_offset: 0.0,
+            out_dtype: DType::F16,
+        }),
+        Op::ResidualAdd(ResidualAddOp {
+            out_dtype: DType::F16,
+        }),
+        Op::ActMul(ActMulOp {
+            act: ActivationKind::Silu,
+            clamp: None,
+        }),
+        Op::Activation(ActivationOp {
+            act: ActivationKind::Silu,
+            clamp: None,
+        }),
+        Op::Rope(RopeOp {
+            rot_dim: 64,
+            theta: 10000.0,
+            style: RopeStyle::Neox,
+            scaling: RopeScaling::None,
+            mrope_sections: None,
+            out_dtype: DType::F16,
+        }),
+        Op::Matmul(MatmulOp {
+            out_dtype: DType::F16,
+            epilogue: Epilogue::None,
+            transpose_w: false,
+        }),
+        Op::MoeRoute(MoeRouteOp {
+            top_k: 2,
+            scoring: MoeScoring::Softmax,
+            renormalize: true,
+            group: None,
+            scale: 1.0,
+        }),
+        Op::MoeFfn(MoeFfnOp {
+            act: ActivationKind::Silu,
+            out_dtype: DType::F16,
+            shared_experts: 0,
+        }),
+        Op::StateWriteKv(StateWriteKvOp {
+            cache_dtype: DType::F16,
+            scale_granularity: CacheScaleGranularity::PerTokenHead,
+            latent: None,
+            handle: StateHandle::new(0, StateKind::KvPaged),
+        }),
+        Op::Attention(AttentionOp {
+            softmax_scale: 0.125,
+            mask: AttentionMask::Causal,
+            sinks: 0,
+            logit_softcap: None,
+            mla: None,
+            out_dtype: DType::F16,
+            handle: StateHandle::new(0, StateKind::KvPaged),
+        }),
+        Op::CausalConv1d(CausalConv1dOp {
+            kernel: 4,
+            act: ConvActivation::Silu,
+            handle: StateHandle::new(0, StateKind::ConvWindow),
+        }),
+        Op::LinearAttnScan(LinearAttnScanOp {
+            kind: LinearAttnKind::GLA,
+            chunk: 64,
+            out_dtype: DType::F16,
+            handle: StateHandle::new(0, StateKind::Recurrent),
+        }),
+        Op::LogitsPostprocess(LogitsPostprocessOp),
+        Op::Sample(SampleOp {
+            rng: RngAlgorithm::Philox4x32,
+        }),
+        Op::Verify(VerifyOp {
+            method: VerifyMethod::Greedy,
+        }),
+        Op::AllReduce(AllReduceOp {
+            group: GroupId::new(0),
+            op: ReduceOp::Sum,
+            dtype: DType::F16,
+            reduce_in: DType::F32,
+        }),
+        Op::AllGather(AllGatherOp {
+            group: GroupId::new(0),
+            axis: 0,
+            dtype: DType::F16,
+        }),
+        Op::ReduceScatter(ReduceScatterOp {
+            group: GroupId::new(0),
+            axis: 0,
+            op: ReduceOp::Sum,
+            dtype: DType::F16,
+            reduce_in: DType::F32,
+        }),
+        Op::AllToAll(AllToAllOp {
+            group: GroupId::new(0),
+            dtype: DType::F16,
+        }),
+        Op::Send(SendOp {
+            group: GroupId::new(0),
+            peer: 1,
+            dtype: DType::F16,
+        }),
+        Op::Recv(RecvOp {
+            group: GroupId::new(0),
+            peer: 0,
+            shape: vec![].into_boxed_slice(),
+            dtype: DType::F16,
+        }),
+        Op::Barrier(BarrierOp {
+            group: GroupId::new(0),
+        }),
+    ]
+}
+
+#[test]
+fn every_op_has_at_least_one_legal_sharding_tuple() {
+    let ops = all_sample_ops();
+    assert_eq!(ops.len(), 29, "Must cover all 29 closed ops in Spec 1 §4");
+
+    for op in &ops {
+        let rules = legal_layouts(op);
+        assert!(
+            !rules.is_empty(),
+            "Op {} must have at least one legal sharding rule",
+            op.op_name()
+        );
+
+        let tuples = legal_layout_tuples(op);
+        assert_eq!(
+            rules.len(),
+            tuples.len(),
+            "Rules count must match tuples count for op {}",
+            op.op_name()
+        );
+
+        for rule in rules {
+            // Verify rule has valid input/output shard layout patterns without magic zero
+            for in_layout in rule.inputs {
+                assert!(matches!(
+                    in_layout,
+                    ShardLayoutPattern::Replicated
+                        | ShardLayoutPattern::ColShard { axis: _ }
+                        | ShardLayoutPattern::RowShard { axis: _ }
+                        | ShardLayoutPattern::HeadShard { heads: _ }
+                        | ShardLayoutPattern::ExpertShard { experts: _ }
+                        | ShardLayoutPattern::Partial
+                ));
+                match in_layout {
+                    ShardLayoutPattern::HeadShard { heads } => match heads {
+                        HeadCount::Concrete(c) => {
+                            assert!(*c > 0, "Concrete head count must be > 0, no magic zero");
+                        }
+                        HeadCount::Symbolic => {}
+                    },
+                    ShardLayoutPattern::ExpertShard { experts } => match experts {
+                        ExpertCount::Concrete(c) => {
+                            assert!(*c > 0, "Concrete expert count must be > 0, no magic zero");
+                        }
+                        ExpertCount::Symbolic => {}
+                    },
+                    ShardLayoutPattern::Replicated
+                    | ShardLayoutPattern::ColShard { .. }
+                    | ShardLayoutPattern::RowShard { .. }
+                    | ShardLayoutPattern::Partial => {}
+                }
+            }
+            for out_layout in rule.outputs {
+                assert!(matches!(
+                    out_layout,
+                    ShardLayoutPattern::Replicated
+                        | ShardLayoutPattern::ColShard { axis: _ }
+                        | ShardLayoutPattern::RowShard { axis: _ }
+                        | ShardLayoutPattern::HeadShard { heads: _ }
+                        | ShardLayoutPattern::ExpertShard { experts: _ }
+                        | ShardLayoutPattern::Partial
+                ));
+                match out_layout {
+                    ShardLayoutPattern::HeadShard { heads } => match heads {
+                        HeadCount::Concrete(c) => {
+                            assert!(*c > 0, "Concrete head count must be > 0, no magic zero");
+                        }
+                        HeadCount::Symbolic => {}
+                    },
+                    ShardLayoutPattern::ExpertShard { experts } => match experts {
+                        ExpertCount::Concrete(c) => {
+                            assert!(*c > 0, "Concrete expert count must be > 0, no magic zero");
+                        }
+                        ExpertCount::Symbolic => {}
+                    },
+                    ShardLayoutPattern::Replicated
+                    | ShardLayoutPattern::ColShard { .. }
+                    | ShardLayoutPattern::RowShard { .. }
+                    | ShardLayoutPattern::Partial => {}
+                }
+            }
+        }
+    }
+}
+
+fn make_test_tensor(shape: Vec<Dim>, sharding: ShardLayout) -> Tensor {
+    Tensor::new(
+        shape,
+        DType::F16,
+        QuantScheme::None,
+        LayoutId::CONTIGUOUS,
+        Placement::Device { rank: 0 },
+        sharding,
+        Class::Activation,
+    )
+    .expect("test tensor builds")
+}
+
+#[test]
+fn matmul_sharding_rules_match_spec() {
+    let matmul = MatmulOp {
+        out_dtype: DType::F16,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    };
+    let rules = matmul.legal_layouts();
+    assert_eq!(
+        rules.len(),
+        3,
+        "Matmul declares exactly the three principal two-input rows in Spec 1 §4.C"
+    );
+
+    // 1. Column parallel: x: Replicated, w: ColShard(0) -> y: ColShard(1)
+    assert_eq!(
+        rules[0].inputs,
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::ColShard { axis: 0 }
+        ]
+    );
+    assert_eq!(
+        rules[0].outputs,
+        &[ShardLayoutPattern::ColShard { axis: 1 }]
+    );
+
+    // 2. Row parallel: x: ColShard(1), w: RowShard(1) -> y: Partial
+    assert_eq!(
+        rules[1].inputs,
+        &[
+            ShardLayoutPattern::ColShard { axis: 1 },
+            ShardLayoutPattern::RowShard { axis: 1 }
+        ]
+    );
+    assert_eq!(rules[1].outputs, &[ShardLayoutPattern::Partial]);
+
+    // 3. Replicated: x: Replicated, w: Replicated -> y: Replicated
+    assert_eq!(
+        rules[2].inputs,
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated
+        ]
+    );
+    assert_eq!(rules[2].outputs, &[ShardLayoutPattern::Replicated]);
+}
+
+#[test]
+fn residual_add_supports_spec5_residual_trick() {
+    let res = ResidualAddOp {
+        out_dtype: DType::F16,
+    };
+    let rules = res.legal_layouts();
+    // Spec 5 §3.1 / §4.2 residual trick:
+    // residual_add(Partial, Replicated) -> Partial
+    // residual_add(Replicated, Partial) -> Partial
+    let has_partial_rep = rules.iter().any(|r| {
+        r.inputs == [ShardLayoutPattern::Partial, ShardLayoutPattern::Replicated]
+            && r.outputs == [ShardLayoutPattern::Partial]
+    });
+    let has_rep_partial = rules.iter().any(|r| {
+        r.inputs == [ShardLayoutPattern::Replicated, ShardLayoutPattern::Partial]
+            && r.outputs == [ShardLayoutPattern::Partial]
+    });
+    assert!(
+        has_partial_rep,
+        "Must support Spec 5 §4.2 residual trick: (Partial, Replicated) -> Partial"
+    );
+    assert!(
+        has_rep_partial,
+        "Must support Spec 5 §4.2 residual trick: (Replicated, Partial) -> Partial"
+    );
+}
+
+#[test]
+fn embed_gather_rules_has_no_invented_colshard() {
+    let op = EmbedGatherOp {
+        scale: 1.0,
+        out_dtype: DType::F16,
+    };
+    let rules = op.legal_layouts();
+    assert_eq!(
+        rules.len(),
+        2,
+        "EmbedGather has exactly 2 rules: Replicated and RowShard(0)"
+    );
+    assert_eq!(
+        rules[0].inputs,
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated
+        ]
+    );
+    assert_eq!(rules[0].outputs, &[ShardLayoutPattern::Replicated]);
+    assert_eq!(
+        rules[1].inputs,
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::RowShard { axis: 0 }
+        ]
+    );
+    assert_eq!(rules[1].outputs, &[ShardLayoutPattern::Partial]);
+
+    for rule in rules {
+        assert!(
+            !rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::ColShard { .. })),
+            "No invented ColShard on embed inputs"
+        );
+        assert!(
+            !rule
+                .outputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::ColShard { .. })),
+            "No invented ColShard on embed outputs"
+        );
+    }
+}
+
+#[test]
+fn ngram_gather_rules_has_no_stale_one_input_rows() {
+    let op = NgramGatherOp {
+        source: NgramSource::Device,
+        orders: vec![2, 3].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(1),
+        table_sizes: vec![1024, 1024].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F16,
+    };
+    let rules = op.legal_layouts();
+    assert_eq!(rules.len(), 3, "NgramGather has exactly 3 rules");
+    for rule in rules {
+        assert_eq!(
+            rule.inputs.len(),
+            2,
+            "NgramGather must have 2 inputs (no stale 1-input rule)"
+        );
+        assert_eq!(rule.outputs.len(), 1, "NgramGather must have 1 output");
+    }
+}
+
+#[test]
+fn quant_act_rules_has_no_batch_axis_rowshard() {
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+    let rules = op.legal_layouts();
+    assert_eq!(rules.len(), 2);
+    for rule in rules {
+        assert_eq!(rule.inputs.len(), 1);
+        assert_eq!(rule.outputs.len(), 2);
+        assert!(
+            !rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::RowShard { axis: 0 })),
+            "No RowShard(0) on quant_act inputs"
+        );
+    }
+}
+
+#[test]
+fn state_sampling_and_verify_rules_exclude_structured_non_tensor_values() {
+    let state_write = StateWriteKvOp {
+        cache_dtype: DType::F16,
+        scale_granularity: CacheScaleGranularity::PerTokenHead,
+        latent: None,
+        handle: StateHandle::new(0, StateKind::KvPaged),
+    };
+    for rule in state_write.legal_layouts() {
+        assert_eq!(
+            rule.inputs.len(),
+            2,
+            "StateWriteKv tensor inputs are k and v"
+        );
+        assert!(rule.outputs.is_empty());
+    }
+
+    let sample = SampleOp {
+        rng: RngAlgorithm::Philox4x32,
+    };
+    let sample_rules = sample.legal_layouts();
+    assert_eq!(sample_rules.len(), 1);
+    assert_eq!(
+        sample_rules[0].inputs.len(),
+        1,
+        "Sample tensor input is only probs"
+    );
+    assert_eq!(
+        sample_rules[0].outputs.len(),
+        1,
+        "Sample tensor output is only token (no stale 2-output)"
+    );
+
+    let verify = VerifyOp {
+        method: VerifyMethod::Greedy,
+    };
+    let verify_rules = verify.legal_layouts();
+    assert_eq!(verify_rules.len(), 2);
+    for rule in verify_rules {
+        assert!(rule.inputs.len() == 2 || rule.inputs.len() == 3);
+        assert_eq!(
+            rule.outputs.len(),
+            2,
+            "Verify tensor outputs are accepted and accept_len (no stale 3-output)"
+        );
+    }
+}
+
+#[test]
+fn all_to_all_rules_exactly_inputs_x_and_counts_to_y() {
+    let op = AllToAllOp {
+        group: GroupId::new(0),
+        dtype: DType::F16,
+    };
+    let rules = op.legal_layouts();
+    assert_eq!(rules.len(), 2, "AllToAll declares exactly 2 rules");
+    for rule in rules {
+        assert_eq!(
+            rule.inputs.len(),
+            2,
+            "AllToAll inputs are exactly x and counts"
+        );
+        assert_eq!(rule.outputs.len(), 1, "AllToAll output is exactly y");
+    }
+    assert_eq!(
+        rules[0].inputs,
+        &[
+            ShardLayoutPattern::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            },
+            ShardLayoutPattern::Replicated,
+        ]
+    );
+    assert_eq!(
+        rules[0].outputs,
+        &[ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        }]
+    );
+    assert_eq!(
+        rules[1].inputs,
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ]
+    );
+    assert_eq!(rules[1].outputs, &[ShardLayoutPattern::Replicated]);
+}
+
+#[test]
+fn partial_may_flow_only_through_residual_add_and_matmul() {
+    // Check PASSTHROUGH_RULES
+    let cast = CastOp { dtype: DType::F16 };
+    for rule in cast.legal_layouts() {
+        assert!(
+            !rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)),
+            "Cast/Copy passthrough must not accept Partial"
+        );
+        assert!(
+            !rule
+                .outputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)),
+            "Cast/Copy passthrough must not emit Partial"
+        );
+    }
+
+    // Check SEND_RULES and RECV_RULES
+    let send = SendOp {
+        group: GroupId::new(0),
+        peer: 1,
+        dtype: DType::F16,
+    };
+    for rule in send.legal_layouts() {
+        assert!(
+            !rule
+                .inputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)),
+            "Send must not accept Partial across pipeline boundaries"
+        );
+    }
+    let recv = RecvOp {
+        group: GroupId::new(0),
+        peer: 0,
+        shape: vec![].into_boxed_slice(),
+        dtype: DType::F16,
+    };
+    for rule in recv.legal_layouts() {
+        assert!(
+            !rule
+                .outputs
+                .iter()
+                .any(|p| matches!(p, ShardLayoutPattern::Partial)),
+            "Recv must not emit Partial across pipeline boundaries"
+        );
+    }
+}
+
+#[test]
+fn matches_tensors_validates_arity() {
+    let t1 = make_test_tensor(
+        vec![Dim::Concrete(1), Dim::Concrete(8)],
+        ShardLayout::Replicated,
+    );
+    let t2 = make_test_tensor(
+        vec![Dim::Concrete(1), Dim::Concrete(8)],
+        ShardLayout::Replicated,
+    );
+
+    let rule_2_in_1_out = ShardingRule::new(
+        &[
+            ShardLayoutPattern::Replicated,
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::Replicated],
+    );
+
+    // Exact arity: 2 in, 1 out -> true
+    assert!(rule_2_in_1_out.matches_tensors(&[t1.clone(), t2.clone()], std::slice::from_ref(&t1)));
+    // Arity mismatch: 1 in, 1 out -> false
+    assert!(!rule_2_in_1_out.matches_tensors(std::slice::from_ref(&t1), std::slice::from_ref(&t1)));
+    // Arity mismatch: 3 in, 1 out -> false
+    assert!(!rule_2_in_1_out.matches_tensors(
+        &[t1.clone(), t2.clone(), t1.clone()],
+        std::slice::from_ref(&t1)
+    ));
+    // Arity mismatch: 2 in, 0 out -> false
+    assert!(!rule_2_in_1_out.matches_tensors(&[t1.clone(), t2.clone()], &[]));
+    // Arity mismatch: 2 in, 2 out -> false
+    assert!(!rule_2_in_1_out.matches_tensors(&[t1.clone(), t2.clone()], &[t1.clone(), t2.clone()]));
+}
+
+#[test]
+fn matches_tensors_validates_actual_sharding_bounds() {
+    // Rank 2 tensor
+    let rank2_shape = vec![Dim::Concrete(4), Dim::Concrete(16)];
+    // Axis 2 is out of bounds for rank 2 tensor
+    let bad_axis_col = make_test_tensor(rank2_shape.clone(), ShardLayout::ColShard { axis: 2 });
+    let bad_axis_row = make_test_tensor(rank2_shape.clone(), ShardLayout::RowShard { axis: 2 });
+
+    let col_rule = ShardingRule::new(
+        &[ShardLayoutPattern::ColShard { axis: 2 }],
+        &[ShardLayoutPattern::Replicated],
+    );
+    let row_rule = ShardingRule::new(
+        &[ShardLayoutPattern::RowShard { axis: 2 }],
+        &[ShardLayoutPattern::Replicated],
+    );
+    let rep_out = make_test_tensor(vec![Dim::Concrete(4)], ShardLayout::Replicated);
+
+    // Out-of-bounds sharded axis must be rejected
+    assert!(!col_rule.matches_tensors(&[bad_axis_col], std::slice::from_ref(&rep_out)));
+    assert!(!row_rule.matches_tensors(&[bad_axis_row], std::slice::from_ref(&rep_out)));
+
+    // Magic zero heads/experts must be rejected
+    let zero_heads = make_test_tensor(rank2_shape.clone(), ShardLayout::HeadShard { heads: 0 });
+    let head_rule = ShardingRule::new(
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+        &[ShardLayoutPattern::Replicated],
+    );
+    assert!(!head_rule.matches_tensors(&[zero_heads], std::slice::from_ref(&rep_out)));
+
+    let zero_experts =
+        make_test_tensor(rank2_shape.clone(), ShardLayout::ExpertShard { experts: 0 });
+    let exp_rule = ShardingRule::new(
+        &[ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        }],
+        &[ShardLayoutPattern::Replicated],
+    );
+    assert!(!exp_rule.matches_tensors(&[zero_experts], std::slice::from_ref(&rep_out)));
+}
+
+#[test]
+fn matches_tensors_symbolic_head_and_expert_cardinalities_must_match() {
+    let shape = vec![Dim::Concrete(1), Dim::Concrete(8), Dim::Concrete(64)];
+    let q8 = make_test_tensor(shape.clone(), ShardLayout::HeadShard { heads: 8 });
+    let o8 = make_test_tensor(shape.clone(), ShardLayout::HeadShard { heads: 8 });
+    let o16 = make_test_tensor(shape.clone(), ShardLayout::HeadShard { heads: 16 });
+
+    let attn_rule = ShardingRule::new(
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+        &[ShardLayoutPattern::HeadShard {
+            heads: HeadCount::Symbolic,
+        }],
+    );
+
+    // Matching symbolic head count (8 == 8) -> true
+    assert!(attn_rule.matches_tensors(std::slice::from_ref(&q8), &[o8]));
+    // Mismatched symbolic head count (8 != 16) -> false
+    assert!(!attn_rule.matches_tensors(std::slice::from_ref(&q8), &[o16]));
+
+    // Multi-input head shard rule on state_write_kv (k, v); slot_map is BatchMeta.
+    let k8 = make_test_tensor(shape.clone(), ShardLayout::HeadShard { heads: 8 });
+    let v8 = make_test_tensor(shape.clone(), ShardLayout::HeadShard { heads: 8 });
+    let v4 = make_test_tensor(shape.clone(), ShardLayout::HeadShard { heads: 4 });
+
+    let kv_rule = &r9v_ir::sharding::STATE_WRITE_KV_RULES[1];
+    assert!(kv_rule.matches_tensors(&[k8.clone(), v8], &[]));
+    assert!(!kv_rule.matches_tensors(&[k8, v4], &[]));
+
+    // ExpertShard symbolic cardinality check
+    let x16 = make_test_tensor(
+        vec![Dim::Concrete(1), Dim::Concrete(64)],
+        ShardLayout::ExpertShard { experts: 16 },
+    );
+    let counts = make_test_tensor(vec![Dim::Concrete(16)], ShardLayout::Replicated);
+    let y16 = make_test_tensor(
+        vec![Dim::Concrete(1), Dim::Concrete(64)],
+        ShardLayout::ExpertShard { experts: 16 },
+    );
+    let y8 = make_test_tensor(
+        vec![Dim::Concrete(1), Dim::Concrete(64)],
+        ShardLayout::ExpertShard { experts: 8 },
+    );
+
+    let all_to_all_rule = ShardingRule::new(
+        &[
+            ShardLayoutPattern::ExpertShard {
+                experts: ExpertCount::Symbolic,
+            },
+            ShardLayoutPattern::Replicated,
+        ],
+        &[ShardLayoutPattern::ExpertShard {
+            experts: ExpertCount::Symbolic,
+        }],
+    );
+    assert!(all_to_all_rule.matches_tensors(&[x16.clone(), counts.clone()], &[y16]));
+    assert!(!all_to_all_rule.matches_tensors(&[x16.clone(), counts.clone()], &[y8]));
+}


### PR DESCRIPTION
## Card
A1.2 — ir ops and graph   (kind: API; GPU: no; size: M)

## Spec sections implemented
- spec 1 §3: typed step-graph DAG, external bindings, stride-aware copy materialization, fusion declarations, graph summaries, capture keys, and buckets.
- spec 1 §4: typed attributes and collect-all shape, dtype, class, placement, quantization, and arity validation for all 29 operations.
- spec 1 §5: closed sharding-layout tables and exact tuple matching for every operation.
- spec 1 §6: per-operation accumulator dtype and deterministic reduction-order contracts.

## Deliverables
- [x] One typed struct per op with attributes and `validate()` constraints from spec 1 §4.
- [x] Sharding tables exposed as data through `legal_layouts(op)`.
- [x] Closed fusion table exposed as typed data and matchers.
- [x] `Graph` DAG with typed edges and structured external inputs and outputs.
- [x] Stride-mismatch `copy` insertion with a graph-summary report.
- [x] Step-graph key `(plan_id, rank, S, T_dec, T_pre, segment)` and bucket functions.
- [x] Per-op `Numerics` accumulator and reduction-order contract used by tests.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| Accepted and rejected shapes for every spec 1 §4 op | `crates/r9v-ir/tests/op_validation.rs` | cpu-only | green |
| Every op has at least one legal sharding tuple and closed-set constraints hold | `crates/r9v-ir/tests/sharding_tables.rs` | cpu-only | green |
| A stride mismatch reports exactly one inserted copy | `crates/r9v-ir/tests/graph_and_buckets.rs` | cpu-only | green |
| Fusion table contains exactly the nine permitted patterns | `crates/r9v-ir/tests/fusion_table.rs` | cpu-only | green |
| Public API surface and closed sets remain externally consumable | `crates/r9v-ir/tests/api_shape.rs` | cpu-only | green |

## Decisions
- `crates/r9v-ir/src/op.rs`: typed mode/signature choices for underspecified op inputs, collect-all validation, structured metadata boundaries, and operand-dependent numerics.
- `crates/r9v-ir/src/sharding.rs`: symbolic table matching and exact legal-layout rows without invented layouts or stale tensor arities.
- `crates/r9v-ir/src/graph.rs`: structured non-tensor bindings, deterministic bucket refusal, safe symbolic stride handling, exact copy materialization, and graph-level metadata validation.
- `crates/r9v-ir/src/fusion.rs`: typed matching for the closed nine-pattern fusion table without a synthetic bias op.
- `crates/r9v-ir/src/numerics.rs`: operand-aware matmul scale and reduction-order classification.

## SPEC-ISSUES filed
- SI-7: reconciles `quant_act` with the required `i8 PerBlock32` activation path.
- SI-8: defines the missing staged and device `ngram_gather` signatures.
- SI-9: defines the missing matmul residual-epilogue input.
- SI-10: defines missing `gather_rows` and `scatter_add_rows` signatures.
- SI-11: defines missing per-collective attributes and tensor mappings.
- SI-12: keeps `BatchMeta`, `SamplingParams`, RNG state, and tree metadata as structured non-tensor graph values.
- SI-13: scopes `logits_postprocess -> sample` fusion to decode-class `q = 1` steps.

## New dependencies
- none

## Hardware
Tests run here: hosted cpu-only
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command none, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- none

## Size check
Diff size vs card size class: 18,120 insertions and 10 deletions vs M — the size is explained by the closed 29-op validation surface and exhaustive accepted/rejected, collect-all, API-shape, graph, fusion, numerics, and sharding tests; no scope was added outside `r9v-ir` and `SPEC-ISSUES.md`.
