### PR TITLE
A1.5: implement deterministic scalar T0 elementwise group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,8 @@ name = "r9v-t0"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
+ "r9v-ir",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/r9v-t0/Cargo.toml
+++ b/crates/r9v-t0/Cargo.toml
@@ -9,3 +9,5 @@ description = "R9V CPU reference scalar T0 and SIMD T0v implementations (Spec 4,
 
 [dependencies]
 r9v-common = { path = "../r9v-common" }
+r9v-ir = { path = "../r9v-ir" }
+thiserror = "2.0"

--- a/crates/r9v-t0/src/act_mul.rs
+++ b/crates/r9v-t0/src/act_mul.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of gated activation multiplication (Spec 1 §4.B, §6.4, Spec 4 §2).
+
+use r9v_ir::{ActMulOp, DType};
+
+use crate::activation::{eval_activation_f32, eval_activation_f64};
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Executes scalar T0 gated activation product: `y = act(gate) * up` (Spec 1 §4.B, §6.4).
+pub fn act_mul(
+    op: &ActMulOp,
+    gate: &TensorView<'_>,
+    up: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if gate.rank() != 2 {
+        problems.push(format!(
+            "operand gate: expected rank 2 [T, Dff], got rank {} with shape {:?}",
+            gate.rank(),
+            gate.shape()
+        ));
+    }
+    if up.rank() != 2 {
+        problems.push(format!(
+            "operand up: expected rank 2 [T, Dff], got rank {} with shape {:?}",
+            up.rank(),
+            up.shape()
+        ));
+    }
+    if y.rank() != 2 {
+        problems.push(format!(
+            "output y: expected rank 2 [T, Dff], got rank {} with shape {:?}",
+            y.rank(),
+            y.shape()
+        ));
+    }
+    if !matches!(gate.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "operand gate: expected f16, bf16, or f32, got {:?}",
+            gate.dtype()
+        ));
+    }
+    if up.dtype() != gate.dtype() {
+        problems.push(format!(
+            "operand up dtype {:?} does not match gate dtype {:?}",
+            up.dtype(),
+            gate.dtype()
+        ));
+    }
+    if y.dtype() != gate.dtype() {
+        problems.push(format!(
+            "output y dtype {:?} does not match gate dtype {:?}",
+            y.dtype(),
+            gate.dtype()
+        ));
+    }
+    if gate.rank() == 2 && up.rank() == 2 && gate.shape() != up.shape() {
+        problems.push(format!(
+            "operand up shape {:?} does not match gate shape {:?}",
+            up.shape(),
+            gate.shape()
+        ));
+    }
+    if gate.rank() == 2 && y.rank() == 2 && gate.shape() != y.shape() {
+        problems.push(format!(
+            "output y shape {:?} does not match gate shape {:?}",
+            y.shape(),
+            gate.shape()
+        ));
+    }
+    if let Some(c) = op.clamp {
+        if !c.is_finite() || c <= 0.0 {
+            problems.push(format!("clamp must be finite and > 0, got {c}"));
+        }
+    }
+
+    T0Error::from_problems("act_mul", problems)?;
+
+    let num_elem = gate.num_elements();
+    for i in 0..num_elem {
+        let g = gate.read_f32(i);
+        let u = up.read_f32(i);
+
+        // DECISION(A1.5): in act_mul, clamp is applied to the activated gate value act(gate).min(c) before multiplying with up (matching activation op where y = act(x).min(c)); rejected clamping post-multiplication (act(gate)*up).min(c) because clamp is an activation-level attribute paired with act in both ActMulOp and ActivationOp (Spec 1 §4.B).
+        let mut act_g = eval_activation_f32(g, op.act);
+        if let Some(c) = op.clamp {
+            act_g = act_g.min(c);
+        }
+
+        let out = act_g * u;
+        y.write_f32(i, out);
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+pub fn act_mul_f64_reference(op: &ActMulOp, gate: &[f64], up: &[f64]) -> Vec<f64> {
+    assert_eq!(gate.len(), up.len());
+    gate.iter()
+        .zip(up.iter())
+        .map(|(&g, &u)| {
+            let mut act_g = eval_activation_f64(g, op.act);
+            if let Some(c) = op.clamp {
+                act_g = act_g.min(c as f64);
+            }
+            act_g * u
+        })
+        .collect()
+}

--- a/crates/r9v-t0/src/act_mul.rs
+++ b/crates/r9v-t0/src/act_mul.rs
@@ -7,13 +7,17 @@ use crate::activation::{eval_activation_f32, eval_activation_f64};
 use crate::buffer::{TensorView, TensorViewMut};
 use crate::error::T0Error;
 
-/// Executes scalar T0 gated activation product: `y = act(gate) * up` (Spec 1 §4.B, §6.4).
+/// Executes scalar T0 gated activation product: `y = act(gate) * up` (Spec 1 §4.B, Spec 1 §6.4, Spec 4 §2).
 pub fn act_mul(
     op: &ActMulOp,
     gate: &TensorView<'_>,
     up: &TensorView<'_>,
     y: &mut TensorViewMut<'_>,
 ) -> Result<(), T0Error> {
+    gate.validate_backing("gate")?;
+    up.validate_backing("up")?;
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
 
     if gate.rank() != 2 {
@@ -97,7 +101,7 @@ pub fn act_mul(
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.B, Spec 4 §2).
 pub fn act_mul_f64_reference(op: &ActMulOp, gate: &[f64], up: &[f64]) -> Vec<f64> {
     assert_eq!(gate.len(), up.len());
     gate.iter()

--- a/crates/r9v-t0/src/activation.rs
+++ b/crates/r9v-t0/src/activation.rs
@@ -11,7 +11,7 @@ use std::f64::consts::{FRAC_1_SQRT_2 as INV_SQRT_2_F64, FRAC_2_SQRT_PI as TWO_DI
 const SQRT_2_DIV_PI_F64: f64 = 0.79788456080286535587989211986876;
 const ONE_DIV_SQRT_PI_F64: f64 = 0.56418958354775628694807945156077;
 
-/// Computes the exact error function `erf(x)` in 64-bit precision without external dependencies.
+/// Computes the exact error function `erf(x)` in 64-bit precision without external dependencies (Spec 1 §6.4, Spec 4 §2).
 pub fn erf_f64(x: f64) -> f64 {
     if x.is_nan() {
         return f64::NAN;
@@ -68,12 +68,68 @@ pub fn erf_f64(x: f64) -> f64 {
     }
 }
 
-/// Computes error function in 32-bit float precision.
+/// Computes error function in genuine 32-bit float precision (Spec 1 §6.4, Spec 4 §2).
+///
+/// Uses genuine f32 arithmetic throughout so Spec 1 §6.4 activation evaluation remains
+/// all-f32 and the f64 reference oracle remains strictly independent.
 pub fn erf_f32(x: f32) -> f32 {
-    erf_f64(x as f64) as f32
+    if x.is_nan() {
+        return f32::NAN;
+    }
+    if x == 0.0f32 {
+        return 0.0f32;
+    }
+    let sign = if x > 0.0f32 { 1.0f32 } else { -1.0f32 };
+    let ax = x.abs();
+    if ax > 5.0f32 {
+        return sign;
+    }
+
+    if ax < 1.5f32 {
+        // Taylor series expansion in f32:
+        // erf(x) = (2 / sqrt(pi)) * sum_{n=0}^inf ((-1)^n * x^(2n+1)) / (n! * (2n+1))
+        let mut term = ax * std::f32::consts::FRAC_2_SQRT_PI;
+        let mut total = term;
+        let ax2 = ax * ax;
+        for n in 1..25 {
+            let n_f = n as f32;
+            term = -term * ax2 / n_f * (2.0f32 * n_f - 1.0f32) / (2.0f32 * n_f + 1.0f32);
+            total += term;
+            if term.abs() < 1e-8f32 {
+                break;
+            }
+        }
+        sign * total
+    } else {
+        // Continued fraction via modified Lentz's method in f32
+        let tiny = 1e-30f32;
+        let mut f = ax;
+        let mut c = f;
+        let mut d = 0.0f32;
+        for j in 1..50 {
+            let a = (j as f32) * 0.5f32;
+            let b = ax;
+            d = b + a * d;
+            if d.abs() < tiny {
+                d = tiny;
+            }
+            c = b + a / c;
+            if c.abs() < tiny {
+                c = tiny;
+            }
+            d = 1.0f32 / d;
+            let delta = c * d;
+            f *= delta;
+            if (delta - 1.0f32).abs() < 1e-7f32 {
+                break;
+            }
+        }
+        let erfc_val = (-ax * ax).exp() * (std::f32::consts::FRAC_2_SQRT_PI * 0.5f32) / f;
+        sign * (1.0f32 - erfc_val)
+    }
 }
 
-/// Evaluates an activation function in 32-bit float precision.
+/// Evaluates an activation function in 32-bit float precision (Spec 1 §4.B, Spec 1 §6.4, Spec 4 §2).
 pub fn eval_activation_f32(x: f32, kind: ActivationKind) -> f32 {
     match kind {
         ActivationKind::Silu => {
@@ -98,7 +154,7 @@ pub fn eval_activation_f32(x: f32, kind: ActivationKind) -> f32 {
     }
 }
 
-/// Evaluates an activation function in 64-bit float precision for testing.
+/// Evaluates an activation function in 64-bit float precision for testing (Spec 1 §4.B, Spec 4 §2).
 pub fn eval_activation_f64(x: f64, kind: ActivationKind) -> f64 {
     match kind {
         ActivationKind::Silu => x / (1.0f64 + (-x).exp()),
@@ -118,12 +174,15 @@ pub fn eval_activation_f64(x: f64, kind: ActivationKind) -> f64 {
     }
 }
 
-/// Executes scalar T0 standalone non-gated activation (Spec 1 §4.B, §6.4).
+/// Executes scalar T0 standalone non-gated activation (Spec 1 §4.B, §6.4, Spec 4 §2).
 pub fn activation(
     op: &ActivationOp,
     x: &TensorView<'_>,
     y: &mut TensorViewMut<'_>,
 ) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
 
     if x.rank() != 2 {
@@ -181,7 +240,7 @@ pub fn activation(
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.B, Spec 4 §2).
 pub fn activation_f64_reference(op: &ActivationOp, x: &[f64]) -> Vec<f64> {
     x.iter()
         .map(|&val| {

--- a/crates/r9v-t0/src/activation.rs
+++ b/crates/r9v-t0/src/activation.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of standalone non-gated activation op (Spec 1 §4.B, §6.4, Spec 4 §2).
+
+use r9v_ir::{ActivationKind, ActivationOp, DType};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+use std::f64::consts::{FRAC_1_SQRT_2 as INV_SQRT_2_F64, FRAC_2_SQRT_PI as TWO_DIV_SQRT_PI_F64};
+
+const SQRT_2_DIV_PI_F64: f64 = 0.79788456080286535587989211986876;
+const ONE_DIV_SQRT_PI_F64: f64 = 0.56418958354775628694807945156077;
+
+/// Computes the exact error function `erf(x)` in 64-bit precision without external dependencies.
+pub fn erf_f64(x: f64) -> f64 {
+    if x.is_nan() {
+        return f64::NAN;
+    }
+    if x == 0.0 {
+        return 0.0;
+    }
+    let sign = if x > 0.0 { 1.0 } else { -1.0 };
+    let ax = x.abs();
+    if ax > 6.0 {
+        return sign;
+    }
+
+    if ax < 1.5 {
+        // Taylor series expansion for small to medium arguments
+        let mut term = ax * TWO_DIV_SQRT_PI_F64;
+        let mut total = term;
+        let ax2 = ax * ax;
+        for n in 1..40 {
+            let n_f = n as f64;
+            term = -term * ax2 / n_f * (2.0 * n_f - 1.0) / (2.0 * n_f + 1.0);
+            total += term;
+            if term.abs() < 1e-17 {
+                break;
+            }
+        }
+        sign * total
+    } else {
+        // Continued fraction via modified Lentz's method for larger arguments
+        let tiny = 1e-30f64;
+        let mut f = ax;
+        let mut c = f;
+        let mut d = 0.0f64;
+        for j in 1..80 {
+            let a = (j as f64) * 0.5;
+            let b = ax;
+            d = b + a * d;
+            if d.abs() < tiny {
+                d = tiny;
+            }
+            c = b + a / c;
+            if c.abs() < tiny {
+                c = tiny;
+            }
+            d = 1.0 / d;
+            let delta = c * d;
+            f *= delta;
+            if (delta - 1.0).abs() < 1e-16 {
+                break;
+            }
+        }
+        let erfc_val = (-ax * ax).exp() * ONE_DIV_SQRT_PI_F64 / f;
+        sign * (1.0 - erfc_val)
+    }
+}
+
+/// Computes error function in 32-bit float precision.
+pub fn erf_f32(x: f32) -> f32 {
+    erf_f64(x as f64) as f32
+}
+
+/// Evaluates an activation function in 32-bit float precision.
+pub fn eval_activation_f32(x: f32, kind: ActivationKind) -> f32 {
+    match kind {
+        ActivationKind::Silu => {
+            // x / (1 + exp(-x))
+            x / (1.0f32 + (-x).exp())
+        }
+        ActivationKind::Gelu => {
+            // 0.5 * x * (1 + erf(x / sqrt(2)))
+            let scaled_x = x * (INV_SQRT_2_F64 as f32);
+            0.5f32 * x * (1.0f32 + erf_f32(scaled_x))
+        }
+        ActivationKind::GeluTanh => {
+            // 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+            let inner = (SQRT_2_DIV_PI_F64 as f32) * (x + 0.044715f32 * x * x * x);
+            0.5f32 * x * (1.0f32 + inner.tanh())
+        }
+        ActivationKind::Relu2 => {
+            let relu = if x > 0.0 { x } else { 0.0 };
+            relu * relu
+        }
+        ActivationKind::Identity => x,
+    }
+}
+
+/// Evaluates an activation function in 64-bit float precision for testing.
+pub fn eval_activation_f64(x: f64, kind: ActivationKind) -> f64 {
+    match kind {
+        ActivationKind::Silu => x / (1.0f64 + (-x).exp()),
+        ActivationKind::Gelu => {
+            let scaled_x = x * INV_SQRT_2_F64;
+            0.5f64 * x * (1.0f64 + erf_f64(scaled_x))
+        }
+        ActivationKind::GeluTanh => {
+            let inner = SQRT_2_DIV_PI_F64 * (x + 0.044715f64 * x * x * x);
+            0.5f64 * x * (1.0f64 + inner.tanh())
+        }
+        ActivationKind::Relu2 => {
+            let relu = if x > 0.0 { x } else { 0.0 };
+            relu * relu
+        }
+        ActivationKind::Identity => x,
+    }
+}
+
+/// Executes scalar T0 standalone non-gated activation (Spec 1 §4.B, §6.4).
+pub fn activation(
+    op: &ActivationOp,
+    x: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if x.rank() != 2 {
+        problems.push(format!(
+            "input x: expected rank 2 [T, Dff], got rank {} with shape {:?}",
+            x.rank(),
+            x.shape()
+        ));
+    }
+    if y.rank() != 2 {
+        problems.push(format!(
+            "output y: expected rank 2 [T, Dff], got rank {} with shape {:?}",
+            y.rank(),
+            y.shape()
+        ));
+    }
+    if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "input x: expected f16, bf16, or f32, got {:?}",
+            x.dtype()
+        ));
+    }
+    if y.dtype() != x.dtype() {
+        problems.push(format!(
+            "output y dtype {:?} does not match input x dtype {:?}",
+            y.dtype(),
+            x.dtype()
+        ));
+    }
+    if x.rank() == 2 && y.rank() == 2 && x.shape() != y.shape() {
+        problems.push(format!(
+            "output y shape {:?} does not match input x shape {:?}",
+            y.shape(),
+            x.shape()
+        ));
+    }
+    if let Some(c) = op.clamp {
+        if !c.is_finite() || c <= 0.0 {
+            problems.push(format!("clamp must be finite and > 0, got {c}"));
+        }
+    }
+
+    T0Error::from_problems("activation", problems)?;
+
+    let num_elem = x.num_elements();
+    for i in 0..num_elem {
+        let val = x.read_f32(i);
+        let mut act_val = eval_activation_f32(val, op.act);
+        if let Some(c) = op.clamp {
+            act_val = act_val.min(c);
+        }
+        y.write_f32(i, act_val);
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+pub fn activation_f64_reference(op: &ActivationOp, x: &[f64]) -> Vec<f64> {
+    x.iter()
+        .map(|&val| {
+            let mut act_val = eval_activation_f64(val, op.act);
+            if let Some(c) = op.clamp {
+                act_val = act_val.min(c as f64);
+            }
+            act_val
+        })
+        .collect()
+}

--- a/crates/r9v-t0/src/buffer.rs
+++ b/crates/r9v-t0/src/buffer.rs
@@ -4,11 +4,12 @@
 use r9v_ir::DType;
 
 use crate::dtype::{
-    bf16_to_f32, f16_to_f32, f32_to_bf16, f32_to_f16, fp8_e4m3_decode, fp8_e4m3_encode,
-    fp8_e5m2_decode, fp8_e5m2_encode, read_f32_at, read_f64_at, write_f32_at,
+    bf16_to_f32, dtype_element_size, f16_to_f32, f32_to_bf16, f32_to_f16, fp8_e4m3_decode,
+    fp8_e4m3_encode, fp8_e5m2_decode, fp8_e5m2_encode, read_f32_at, read_f64_at, write_f32_at,
 };
+use crate::error::T0Error;
 
-/// Borrowed tensor data slice variant without raw pointer conversions.
+/// Borrowed tensor data slice variant without raw pointer conversions (Spec 1 §2.3, Spec 4 §2).
 #[derive(Debug, Clone)]
 pub enum TensorData<'a> {
     /// 32-bit floating point slice.
@@ -25,7 +26,7 @@ pub enum TensorData<'a> {
     Bytes(DType, &'a [u8]),
 }
 
-/// Mutable borrowed tensor data slice variant without raw pointer conversions.
+/// Mutable borrowed tensor data slice variant without raw pointer conversions (Spec 1 §2.3, Spec 4 §2).
 #[derive(Debug)]
 pub enum TensorDataMut<'a> {
     /// Mutable 32-bit floating point slice.
@@ -42,15 +43,15 @@ pub enum TensorDataMut<'a> {
     Bytes(DType, &'a mut [u8]),
 }
 
-/// Immutable view over a multidimensional tensor buffer.
+/// Immutable view over a multidimensional tensor buffer (Spec 1 §2.3, Spec 4 §2).
 #[derive(Debug, Clone)]
 pub struct TensorView<'a> {
-    shape: Vec<usize>,
-    data: TensorData<'a>,
+    pub(crate) shape: Vec<usize>,
+    pub(crate) data: TensorData<'a>,
 }
 
 impl<'a> TensorView<'a> {
-    /// Creates a tensor view from raw bytes with shape and dtype.
+    /// Creates a tensor view from raw bytes with shape and dtype (Spec 1 §2.3, Spec 4 §2).
     pub fn from_bytes(shape: &[usize], dtype: DType, data: &'a [u8]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -58,7 +59,7 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Creates a tensor view from an `f32` slice.
+    /// Creates a tensor view from an `f32` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_f32_slice(shape: &[usize], data: &'a [f32]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -66,7 +67,7 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Creates a tensor view from an `f16` (u16 bits) slice.
+    /// Creates a tensor view from an `f16` (u16 bits) slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_f16_slice(shape: &[usize], data: &'a [u16]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -74,7 +75,7 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Creates a tensor view from an `bf16` (u16 bits) slice.
+    /// Creates a tensor view from an `bf16` (u16 bits) slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_bf16_slice(shape: &[usize], data: &'a [u16]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -82,7 +83,7 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Creates a tensor view from an `i8` slice.
+    /// Creates a tensor view from an `i8` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_i8_slice(shape: &[usize], data: &'a [i8]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -90,7 +91,7 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Creates a tensor view from a `u32` slice.
+    /// Creates a tensor view from a `u32` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_u32_slice(shape: &[usize], data: &'a [u32]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -98,17 +99,17 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Returns tensor shape.
+    /// Returns tensor shape (Spec 1 §2.3, Spec 4 §2).
     pub fn shape(&self) -> &[usize] {
         &self.shape
     }
 
-    /// Returns tensor rank.
+    /// Returns tensor rank (Spec 1 §2.3, Spec 4 §2).
     pub fn rank(&self) -> usize {
         self.shape.len()
     }
 
-    /// Returns tensor data type.
+    /// Returns tensor data type (Spec 1 §2.3, Spec 4 §2).
     pub fn dtype(&self) -> DType {
         match self.data {
             TensorData::F32(_) => DType::F32,
@@ -120,12 +121,82 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Returns total number of elements.
+    /// Returns total number of elements (Spec 1 §2.3, Spec 4 §2).
     pub fn num_elements(&self) -> usize {
         self.shape.iter().product()
     }
 
-    /// Reads one element converted to `f32`.
+    /// Returns the backing storage length in elements or raw bytes (Spec 1 §2.3, Spec 4 §2).
+    pub fn backing_len(&self) -> usize {
+        match self.data {
+            TensorData::F32(slice) => slice.len(),
+            TensorData::F16(slice) => slice.len(),
+            TensorData::Bf16(slice) => slice.len(),
+            TensorData::I8(slice) => slice.len(),
+            TensorData::U32(slice) => slice.len(),
+            TensorData::Bytes(_, slice) => slice.len(),
+        }
+    }
+
+    /// Validates backing buffer capacity against tensor shape and element data type (Spec 1 §2.3, Spec 4 §2).
+    ///
+    /// Refuses undersized buffers and shapes that overflow `usize::MAX`.
+    pub fn validate_backing(&self, tensor: &'static str) -> Result<(), T0Error> {
+        let num_elements = match self
+            .shape
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+        {
+            Some(n) => n,
+            None => {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor,
+                    buffer_len: self.backing_len(),
+                    expected_len: usize::MAX,
+                    shape: self.shape.clone(),
+                });
+            }
+        };
+
+        let (buffer_len, required_len) = match self.data {
+            TensorData::F32(slice) => (slice.len(), num_elements),
+            TensorData::F16(slice) => (slice.len(), num_elements),
+            TensorData::Bf16(slice) => (slice.len(), num_elements),
+            TensorData::I8(slice) => (slice.len(), num_elements),
+            TensorData::U32(slice) => (slice.len(), num_elements),
+            TensorData::Bytes(dtype, slice) => {
+                let required_bytes = if dtype == DType::I4 {
+                    num_elements / 2 + (num_elements % 2)
+                } else {
+                    match num_elements.checked_mul(dtype_element_size(dtype)) {
+                        Some(b) => b,
+                        None => {
+                            return Err(T0Error::BufferLengthMismatch {
+                                tensor,
+                                buffer_len: slice.len(),
+                                expected_len: usize::MAX,
+                                shape: self.shape.clone(),
+                            });
+                        }
+                    }
+                };
+                (slice.len(), required_bytes)
+            }
+        };
+
+        if buffer_len < required_len {
+            return Err(T0Error::BufferLengthMismatch {
+                tensor,
+                buffer_len,
+                expected_len: required_len,
+                shape: self.shape.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Reads one element converted to `f32` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_f32(&self, index: usize) -> f32 {
         match self.data {
             TensorData::F32(slice) => slice[index],
@@ -137,7 +208,7 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Reads one element converted to `f64`.
+    /// Reads one element converted to `f64` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_f64(&self, index: usize) -> f64 {
         match self.data {
             TensorData::F32(slice) => slice[index] as f64,
@@ -149,15 +220,39 @@ impl<'a> TensorView<'a> {
         }
     }
 
-    /// Reads one element as `u32`.
+    /// Reads one element as `u32` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_u32(&self, index: usize) -> u32 {
         match self.data {
             TensorData::U32(slice) => slice[index],
+            TensorData::Bytes(DType::U32, slice) => {
+                let offset = index * 4;
+                u32::from_ne_bytes(slice[offset..offset + 4].try_into().unwrap())
+            }
             _ => self.read_f32(index) as u32,
         }
     }
 
-    /// Reads one element as `i8`.
+    /// Reads one element as `i32` (Spec 1 §2.3, Spec 4 §2).
+    pub fn read_i32(&self, index: usize) -> i32 {
+        match self.data {
+            TensorData::Bytes(DType::I32, slice) => {
+                let offset = index * 4;
+                i32::from_ne_bytes(slice[offset..offset + 4].try_into().unwrap())
+            }
+            _ => self.read_f32(index) as i32,
+        }
+    }
+
+    /// Reads raw byte at index for FP8/byte dtypes (Spec 1 §2.3, Spec 4 §2).
+    pub fn read_byte(&self, index: usize) -> u8 {
+        match self.data {
+            TensorData::Bytes(_, slice) => slice[index],
+            TensorData::I8(slice) => slice[index] as u8,
+            _ => self.read_f32(index) as u8,
+        }
+    }
+
+    /// Reads one element as `i8` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_i8(&self, index: usize) -> i8 {
         match self.data {
             TensorData::I8(slice) => slice[index],
@@ -166,15 +261,15 @@ impl<'a> TensorView<'a> {
     }
 }
 
-/// Mutable view over a multidimensional tensor buffer.
+/// Mutable view over a multidimensional tensor buffer (Spec 1 §2.3, Spec 4 §2).
 #[derive(Debug)]
 pub struct TensorViewMut<'a> {
-    shape: Vec<usize>,
-    data: TensorDataMut<'a>,
+    pub(crate) shape: Vec<usize>,
+    pub(crate) data: TensorDataMut<'a>,
 }
 
 impl<'a> TensorViewMut<'a> {
-    /// Creates a mutable tensor view from raw bytes with shape and dtype.
+    /// Creates a mutable tensor view from raw bytes with shape and dtype (Spec 1 §2.3, Spec 4 §2).
     pub fn from_bytes(shape: &[usize], dtype: DType, data: &'a mut [u8]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -182,7 +277,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Creates a mutable tensor view from an `f32` slice.
+    /// Creates a mutable tensor view from an `f32` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_f32_slice(shape: &[usize], data: &'a mut [f32]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -190,7 +285,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Creates a mutable tensor view from an `f16` (u16 bits) slice.
+    /// Creates a mutable tensor view from an `f16` (u16 bits) slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_f16_slice(shape: &[usize], data: &'a mut [u16]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -198,7 +293,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Creates a mutable tensor view from an `bf16` (u16 bits) slice.
+    /// Creates a mutable tensor view from an `bf16` (u16 bits) slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_bf16_slice(shape: &[usize], data: &'a mut [u16]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -206,7 +301,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Creates a mutable tensor view from an `i8` slice.
+    /// Creates a mutable tensor view from an `i8` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_i8_slice(shape: &[usize], data: &'a mut [i8]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -214,7 +309,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Creates a mutable tensor view from a `u32` slice.
+    /// Creates a mutable tensor view from a `u32` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_u32_slice(shape: &[usize], data: &'a mut [u32]) -> Self {
         Self {
             shape: shape.to_vec(),
@@ -222,17 +317,17 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Returns tensor shape.
+    /// Returns tensor shape (Spec 1 §2.3, Spec 4 §2).
     pub fn shape(&self) -> &[usize] {
         &self.shape
     }
 
-    /// Returns tensor rank.
+    /// Returns tensor rank (Spec 1 §2.3, Spec 4 §2).
     pub fn rank(&self) -> usize {
         self.shape.len()
     }
 
-    /// Returns tensor data type.
+    /// Returns tensor data type (Spec 1 §2.3, Spec 4 §2).
     pub fn dtype(&self) -> DType {
         match self.data {
             TensorDataMut::F32(_) => DType::F32,
@@ -244,12 +339,82 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Returns total number of elements.
+    /// Returns total number of elements (Spec 1 §2.3, Spec 4 §2).
     pub fn num_elements(&self) -> usize {
         self.shape.iter().product()
     }
 
-    /// Reads one element converted to `f32`.
+    /// Returns the backing storage length in elements or raw bytes (Spec 1 §2.3, Spec 4 §2).
+    pub fn backing_len(&self) -> usize {
+        match self.data {
+            TensorDataMut::F32(ref slice) => slice.len(),
+            TensorDataMut::F16(ref slice) => slice.len(),
+            TensorDataMut::Bf16(ref slice) => slice.len(),
+            TensorDataMut::I8(ref slice) => slice.len(),
+            TensorDataMut::U32(ref slice) => slice.len(),
+            TensorDataMut::Bytes(_, ref slice) => slice.len(),
+        }
+    }
+
+    /// Validates backing buffer capacity against tensor shape and element data type (Spec 1 §2.3, Spec 4 §2).
+    ///
+    /// Refuses undersized buffers and shapes that overflow `usize::MAX`.
+    pub fn validate_backing(&self, tensor: &'static str) -> Result<(), T0Error> {
+        let num_elements = match self
+            .shape
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+        {
+            Some(n) => n,
+            None => {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor,
+                    buffer_len: self.backing_len(),
+                    expected_len: usize::MAX,
+                    shape: self.shape.clone(),
+                });
+            }
+        };
+
+        let (buffer_len, required_len) = match self.data {
+            TensorDataMut::F32(ref slice) => (slice.len(), num_elements),
+            TensorDataMut::F16(ref slice) => (slice.len(), num_elements),
+            TensorDataMut::Bf16(ref slice) => (slice.len(), num_elements),
+            TensorDataMut::I8(ref slice) => (slice.len(), num_elements),
+            TensorDataMut::U32(ref slice) => (slice.len(), num_elements),
+            TensorDataMut::Bytes(dtype, ref slice) => {
+                let required_bytes = if dtype == DType::I4 {
+                    num_elements / 2 + (num_elements % 2)
+                } else {
+                    match num_elements.checked_mul(dtype_element_size(dtype)) {
+                        Some(b) => b,
+                        None => {
+                            return Err(T0Error::BufferLengthMismatch {
+                                tensor,
+                                buffer_len: slice.len(),
+                                expected_len: usize::MAX,
+                                shape: self.shape.clone(),
+                            });
+                        }
+                    }
+                };
+                (slice.len(), required_bytes)
+            }
+        };
+
+        if buffer_len < required_len {
+            return Err(T0Error::BufferLengthMismatch {
+                tensor,
+                buffer_len,
+                expected_len: required_len,
+                shape: self.shape.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Reads one element converted to `f32` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_f32(&self, index: usize) -> f32 {
         match self.data {
             TensorDataMut::F32(ref slice) => slice[index],
@@ -261,7 +426,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Reads one element converted to `f64`.
+    /// Reads one element converted to `f64` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_f64(&self, index: usize) -> f64 {
         match self.data {
             TensorDataMut::F32(ref slice) => slice[index] as f64,
@@ -273,7 +438,39 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Writes one `f32` value converted to the destination tensor data type.
+    /// Reads one element as `u32` (Spec 1 §2.3, Spec 4 §2).
+    pub fn read_u32(&self, index: usize) -> u32 {
+        match self.data {
+            TensorDataMut::U32(ref slice) => slice[index],
+            TensorDataMut::Bytes(DType::U32, ref slice) => {
+                let offset = index * 4;
+                u32::from_ne_bytes(slice[offset..offset + 4].try_into().unwrap())
+            }
+            _ => self.read_f32(index) as u32,
+        }
+    }
+
+    /// Reads one element as `i32` (Spec 1 §2.3, Spec 4 §2).
+    pub fn read_i32(&self, index: usize) -> i32 {
+        match self.data {
+            TensorDataMut::Bytes(DType::I32, ref slice) => {
+                let offset = index * 4;
+                i32::from_ne_bytes(slice[offset..offset + 4].try_into().unwrap())
+            }
+            _ => self.read_f32(index) as i32,
+        }
+    }
+
+    /// Reads raw byte at index for FP8/byte dtypes (Spec 1 §2.3, Spec 4 §2).
+    pub fn read_byte(&self, index: usize) -> u8 {
+        match self.data {
+            TensorDataMut::Bytes(_, ref slice) => slice[index],
+            TensorDataMut::I8(ref slice) => slice[index] as u8,
+            _ => self.read_f32(index) as u8,
+        }
+    }
+
+    /// Writes one `f32` value converted to the destination tensor data type (Spec 1 §2.3, Spec 4 §2).
     pub fn write_f32(&mut self, index: usize, val: f32) {
         match self.data {
             TensorDataMut::F32(ref mut slice) => slice[index] = val,
@@ -289,12 +486,12 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Writes one `f64` value converted to the destination tensor data type.
+    /// Writes one `f64` value converted to the destination tensor data type (Spec 1 §2.3, Spec 4 §2).
     pub fn write_f64(&mut self, index: usize, val: f64) {
         self.write_f32(index, val as f32);
     }
 
-    /// Writes raw byte at index (useful for e4m3/e5m2 and custom byte encoding).
+    /// Writes raw byte at index (useful for e4m3/e5m2 and custom byte encoding) (Spec 1 §2.3, Spec 4 §2).
     pub fn write_byte(&mut self, index: usize, val: u8) {
         match self.data {
             TensorDataMut::Bytes(_, ref mut slice) => slice[index] = val,
@@ -303,7 +500,7 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
-    /// Reborrows as an immutable `TensorView`.
+    /// Reborrows as an immutable `TensorView` (Spec 1 §2.3, Spec 4 §2).
     pub fn as_view(&self) -> TensorView<'_> {
         let data = match self.data {
             TensorDataMut::F32(ref slice) => TensorData::F32(slice),
@@ -320,7 +517,7 @@ impl<'a> TensorViewMut<'a> {
     }
 }
 
-/// Owned heap-allocated multidimensional typed tensor buffer.
+/// Owned heap-allocated multidimensional typed tensor buffer (Spec 1 §2.3, Spec 4 §2).
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypedBuffer {
     shape: Vec<usize>,
@@ -334,7 +531,7 @@ pub struct TypedBuffer {
 }
 
 impl TypedBuffer {
-    /// Creates a zero-initialized typed buffer for the given shape and dtype.
+    /// Creates a zero-initialized typed buffer for the given shape and dtype (Spec 1 §2.3, Spec 4 §2).
     pub fn zeros(shape: &[usize], dtype: DType) -> Self {
         let total_elements: usize = shape.iter().product();
         let mut buf = Self {
@@ -367,7 +564,7 @@ impl TypedBuffer {
         buf
     }
 
-    /// Creates a buffer from `f32` slice.
+    /// Creates a buffer from `f32` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_f32(shape: &[usize], values: &[f32]) -> Self {
         let expected: usize = shape.iter().product();
         assert_eq!(values.len(), expected);
@@ -383,7 +580,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Creates a buffer from `f16` (u16 bits) slice.
+    /// Creates a buffer from `f16` (u16 bits) slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_f16(shape: &[usize], values: &[u16]) -> Self {
         let expected: usize = shape.iter().product();
         assert_eq!(values.len(), expected);
@@ -399,7 +596,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Creates a buffer from `bf16` (u16 bits) slice.
+    /// Creates a buffer from `bf16` (u16 bits) slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_bf16(shape: &[usize], values: &[u16]) -> Self {
         let expected: usize = shape.iter().product();
         assert_eq!(values.len(), expected);
@@ -415,7 +612,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Creates a buffer from `i8` slice.
+    /// Creates a buffer from `i8` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_i8(shape: &[usize], values: &[i8]) -> Self {
         let expected: usize = shape.iter().product();
         assert_eq!(values.len(), expected);
@@ -431,7 +628,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Creates a buffer from `u32` slice.
+    /// Creates a buffer from `u32` slice (Spec 1 §2.3, Spec 4 §2).
     pub fn from_u32(shape: &[usize], values: &[u32]) -> Self {
         let expected: usize = shape.iter().product();
         assert_eq!(values.len(), expected);
@@ -447,7 +644,48 @@ impl TypedBuffer {
         }
     }
 
-    /// Creates an E4M3 byte buffer from raw bytes.
+    /// Creates a buffer from an `i32` slice (Spec 1 §2.3, Spec 4 §2).
+    pub fn from_i32(shape: &[usize], values: &[i32]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(values.len(), expected);
+        let mut byte_data = vec![0u8; expected * 4];
+        for (i, &v) in values.iter().enumerate() {
+            byte_data[i * 4..(i + 1) * 4].copy_from_slice(&v.to_ne_bytes());
+        }
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::I32,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data,
+        }
+    }
+
+    /// Creates a typed buffer from raw byte data with shape and dtype (Spec 1 §2.3, Spec 4 §2).
+    pub fn from_bytes(shape: &[usize], dtype: DType, bytes: &[u8]) -> Self {
+        let total_elements: usize = shape.iter().product();
+        let expected_bytes = if dtype == DType::I4 {
+            total_elements.div_ceil(2)
+        } else {
+            total_elements * dtype_element_size(dtype)
+        };
+        assert_eq!(bytes.len(), expected_bytes);
+        Self {
+            shape: shape.to_vec(),
+            dtype,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data: bytes.to_vec(),
+        }
+    }
+
+    /// Creates an E4M3 byte buffer from raw bytes (Spec 1 §2.3, Spec 4 §2).
     pub fn from_e4m3_bytes(shape: &[usize], bytes: &[u8]) -> Self {
         let expected: usize = shape.iter().product();
         assert_eq!(bytes.len(), expected);
@@ -463,27 +701,27 @@ impl TypedBuffer {
         }
     }
 
-    /// Returns tensor shape.
+    /// Returns tensor shape (Spec 1 §2.3, Spec 4 §2).
     pub fn shape(&self) -> &[usize] {
         &self.shape
     }
 
-    /// Returns tensor rank.
+    /// Returns tensor rank (Spec 1 §2.3, Spec 4 §2).
     pub fn rank(&self) -> usize {
         self.shape.len()
     }
 
-    /// Returns tensor data type.
+    /// Returns tensor data type (Spec 1 §2.3, Spec 4 §2).
     pub fn dtype(&self) -> DType {
         self.dtype
     }
 
-    /// Returns total number of elements.
+    /// Returns total number of elements (Spec 1 §2.3, Spec 4 §2).
     pub fn num_elements(&self) -> usize {
         self.shape.iter().product()
     }
 
-    /// Reads one element converted to `f32`.
+    /// Reads one element converted to `f32` (Spec 1 §2.3, Spec 4 §2).
     pub fn read_f32(&self, index: usize) -> f32 {
         match self.dtype {
             DType::F32 => self.f32_data[index],
@@ -497,7 +735,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Writes one `f32` value into buffer at `index`.
+    /// Writes one `f32` value into buffer at `index` (Spec 1 §2.3, Spec 4 §2).
     pub fn write_f32(&mut self, index: usize, val: f32) {
         match self.dtype {
             DType::F32 => self.f32_data[index] = val,
@@ -515,7 +753,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Reads raw byte at index for FP8/byte dtypes.
+    /// Reads raw byte at index for FP8/byte dtypes (Spec 1 §2.3, Spec 4 §2).
     pub fn read_byte(&self, index: usize) -> u8 {
         match self.dtype {
             DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
@@ -526,7 +764,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Writes raw byte at index for FP8/byte dtypes.
+    /// Writes raw byte at index for FP8/byte dtypes (Spec 1 §2.3, Spec 4 §2).
     pub fn write_byte(&mut self, index: usize, val: u8) {
         match self.dtype {
             DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
@@ -537,12 +775,17 @@ impl TypedBuffer {
         }
     }
 
-    /// Copies data out as a vector of `f32`.
+    /// Returns reference to raw byte data for byte-backed buffers (Spec 1 §2.3, Spec 4 §2).
+    pub fn byte_data(&self) -> &[u8] {
+        &self.byte_data
+    }
+
+    /// Copies data out as a vector of `f32` (Spec 1 §2.3, Spec 4 §2).
     pub fn to_f32_vec(&self) -> Vec<f32> {
         (0..self.num_elements()).map(|i| self.read_f32(i)).collect()
     }
 
-    /// Copies data out as a vector of `i8`.
+    /// Copies data out as a vector of `i8` (Spec 1 §2.3, Spec 4 §2).
     pub fn to_i8_vec(&self) -> Vec<i8> {
         match self.dtype {
             DType::I8 => self.i8_data.clone(),
@@ -552,7 +795,43 @@ impl TypedBuffer {
         }
     }
 
-    /// Copies data out as a vector of raw bytes.
+    /// Copies data out as a vector of `u32` (Spec 1 §2.3, Spec 4 §2).
+    pub fn to_u32_vec(&self) -> Vec<u32> {
+        let num_elem = self.num_elements();
+        match self.dtype {
+            DType::U32 => {
+                if !self.u32_data.is_empty() {
+                    self.u32_data.clone()
+                } else {
+                    (0..num_elem)
+                        .map(|i| {
+                            let offset = i * 4;
+                            u32::from_ne_bytes(
+                                self.byte_data[offset..offset + 4].try_into().unwrap(),
+                            )
+                        })
+                        .collect()
+                }
+            }
+            _ => (0..num_elem).map(|i| self.read_f32(i) as u32).collect(),
+        }
+    }
+
+    /// Copies data out as a vector of `i32` (Spec 1 §2.3, Spec 4 §2).
+    pub fn to_i32_vec(&self) -> Vec<i32> {
+        let num_elem = self.num_elements();
+        match self.dtype {
+            DType::I32 => (0..num_elem)
+                .map(|i| {
+                    let offset = i * 4;
+                    i32::from_ne_bytes(self.byte_data[offset..offset + 4].try_into().unwrap())
+                })
+                .collect(),
+            _ => (0..num_elem).map(|i| self.read_f32(i) as i32).collect(),
+        }
+    }
+
+    /// Copies data out as a vector of raw bytes (Spec 1 §2.3, Spec 4 §2).
     pub fn to_byte_vec(&self) -> Vec<u8> {
         match self.dtype {
             DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
@@ -565,7 +844,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Borrows buffer as an immutable `TensorView`.
+    /// Borrows buffer as an immutable `TensorView` (Spec 1 §2.3, Spec 4 §2).
     pub fn as_view(&self) -> TensorView<'_> {
         let data = match self.dtype {
             DType::F32 => TensorData::F32(&self.f32_data),
@@ -583,7 +862,7 @@ impl TypedBuffer {
         }
     }
 
-    /// Borrows buffer as a mutable `TensorViewMut`.
+    /// Borrows buffer as a mutable `TensorViewMut` (Spec 1 §2.3, Spec 4 §2).
     pub fn as_view_mut(&mut self) -> TensorViewMut<'_> {
         let dtype = self.dtype;
         let data = match dtype {

--- a/crates/r9v-t0/src/buffer.rs
+++ b/crates/r9v-t0/src/buffer.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Buffer and view abstractions for scalar T0 tensor operands (Spec 1 §2.3, Spec 4 §2).
+
+use r9v_ir::DType;
+
+use crate::dtype::{
+    bf16_to_f32, f16_to_f32, f32_to_bf16, f32_to_f16, fp8_e4m3_decode, fp8_e4m3_encode,
+    fp8_e5m2_decode, fp8_e5m2_encode, read_f32_at, read_f64_at, write_f32_at,
+};
+
+/// Borrowed tensor data slice variant without raw pointer conversions.
+#[derive(Debug, Clone)]
+pub enum TensorData<'a> {
+    /// 32-bit floating point slice.
+    F32(&'a [f32]),
+    /// 16-bit half precision float slice.
+    F16(&'a [u16]),
+    /// 16-bit bfloat16 slice.
+    Bf16(&'a [u16]),
+    /// 8-bit signed integer slice.
+    I8(&'a [i8]),
+    /// 32-bit unsigned integer slice.
+    U32(&'a [u32]),
+    /// Raw byte slice with associated data type.
+    Bytes(DType, &'a [u8]),
+}
+
+/// Mutable borrowed tensor data slice variant without raw pointer conversions.
+#[derive(Debug)]
+pub enum TensorDataMut<'a> {
+    /// Mutable 32-bit floating point slice.
+    F32(&'a mut [f32]),
+    /// Mutable 16-bit half precision float slice.
+    F16(&'a mut [u16]),
+    /// Mutable 16-bit bfloat16 slice.
+    Bf16(&'a mut [u16]),
+    /// Mutable 8-bit signed integer slice.
+    I8(&'a mut [i8]),
+    /// Mutable 32-bit unsigned integer slice.
+    U32(&'a mut [u32]),
+    /// Mutable raw byte slice with associated data type.
+    Bytes(DType, &'a mut [u8]),
+}
+
+/// Immutable view over a multidimensional tensor buffer.
+#[derive(Debug, Clone)]
+pub struct TensorView<'a> {
+    shape: Vec<usize>,
+    data: TensorData<'a>,
+}
+
+impl<'a> TensorView<'a> {
+    /// Creates a tensor view from raw bytes with shape and dtype.
+    pub fn from_bytes(shape: &[usize], dtype: DType, data: &'a [u8]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorData::Bytes(dtype, data),
+        }
+    }
+
+    /// Creates a tensor view from an `f32` slice.
+    pub fn from_f32_slice(shape: &[usize], data: &'a [f32]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorData::F32(data),
+        }
+    }
+
+    /// Creates a tensor view from an `f16` (u16 bits) slice.
+    pub fn from_f16_slice(shape: &[usize], data: &'a [u16]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorData::F16(data),
+        }
+    }
+
+    /// Creates a tensor view from an `bf16` (u16 bits) slice.
+    pub fn from_bf16_slice(shape: &[usize], data: &'a [u16]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorData::Bf16(data),
+        }
+    }
+
+    /// Creates a tensor view from an `i8` slice.
+    pub fn from_i8_slice(shape: &[usize], data: &'a [i8]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorData::I8(data),
+        }
+    }
+
+    /// Creates a tensor view from a `u32` slice.
+    pub fn from_u32_slice(shape: &[usize], data: &'a [u32]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorData::U32(data),
+        }
+    }
+
+    /// Returns tensor shape.
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Returns tensor rank.
+    pub fn rank(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Returns tensor data type.
+    pub fn dtype(&self) -> DType {
+        match self.data {
+            TensorData::F32(_) => DType::F32,
+            TensorData::F16(_) => DType::F16,
+            TensorData::Bf16(_) => DType::Bf16,
+            TensorData::I8(_) => DType::I8,
+            TensorData::U32(_) => DType::U32,
+            TensorData::Bytes(dtype, _) => dtype,
+        }
+    }
+
+    /// Returns total number of elements.
+    pub fn num_elements(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    /// Reads one element converted to `f32`.
+    pub fn read_f32(&self, index: usize) -> f32 {
+        match self.data {
+            TensorData::F32(slice) => slice[index],
+            TensorData::F16(slice) => f16_to_f32(slice[index]),
+            TensorData::Bf16(slice) => bf16_to_f32(slice[index]),
+            TensorData::I8(slice) => slice[index] as f32,
+            TensorData::U32(slice) => slice[index] as f32,
+            TensorData::Bytes(dtype, slice) => read_f32_at(dtype, slice, index),
+        }
+    }
+
+    /// Reads one element converted to `f64`.
+    pub fn read_f64(&self, index: usize) -> f64 {
+        match self.data {
+            TensorData::F32(slice) => slice[index] as f64,
+            TensorData::F16(slice) => f16_to_f32(slice[index]) as f64,
+            TensorData::Bf16(slice) => bf16_to_f32(slice[index]) as f64,
+            TensorData::I8(slice) => slice[index] as f64,
+            TensorData::U32(slice) => slice[index] as f64,
+            TensorData::Bytes(dtype, slice) => read_f64_at(dtype, slice, index),
+        }
+    }
+
+    /// Reads one element as `u32`.
+    pub fn read_u32(&self, index: usize) -> u32 {
+        match self.data {
+            TensorData::U32(slice) => slice[index],
+            _ => self.read_f32(index) as u32,
+        }
+    }
+
+    /// Reads one element as `i8`.
+    pub fn read_i8(&self, index: usize) -> i8 {
+        match self.data {
+            TensorData::I8(slice) => slice[index],
+            _ => self.read_f32(index) as i8,
+        }
+    }
+}
+
+/// Mutable view over a multidimensional tensor buffer.
+#[derive(Debug)]
+pub struct TensorViewMut<'a> {
+    shape: Vec<usize>,
+    data: TensorDataMut<'a>,
+}
+
+impl<'a> TensorViewMut<'a> {
+    /// Creates a mutable tensor view from raw bytes with shape and dtype.
+    pub fn from_bytes(shape: &[usize], dtype: DType, data: &'a mut [u8]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorDataMut::Bytes(dtype, data),
+        }
+    }
+
+    /// Creates a mutable tensor view from an `f32` slice.
+    pub fn from_f32_slice(shape: &[usize], data: &'a mut [f32]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorDataMut::F32(data),
+        }
+    }
+
+    /// Creates a mutable tensor view from an `f16` (u16 bits) slice.
+    pub fn from_f16_slice(shape: &[usize], data: &'a mut [u16]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorDataMut::F16(data),
+        }
+    }
+
+    /// Creates a mutable tensor view from an `bf16` (u16 bits) slice.
+    pub fn from_bf16_slice(shape: &[usize], data: &'a mut [u16]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorDataMut::Bf16(data),
+        }
+    }
+
+    /// Creates a mutable tensor view from an `i8` slice.
+    pub fn from_i8_slice(shape: &[usize], data: &'a mut [i8]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorDataMut::I8(data),
+        }
+    }
+
+    /// Creates a mutable tensor view from a `u32` slice.
+    pub fn from_u32_slice(shape: &[usize], data: &'a mut [u32]) -> Self {
+        Self {
+            shape: shape.to_vec(),
+            data: TensorDataMut::U32(data),
+        }
+    }
+
+    /// Returns tensor shape.
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Returns tensor rank.
+    pub fn rank(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Returns tensor data type.
+    pub fn dtype(&self) -> DType {
+        match self.data {
+            TensorDataMut::F32(_) => DType::F32,
+            TensorDataMut::F16(_) => DType::F16,
+            TensorDataMut::Bf16(_) => DType::Bf16,
+            TensorDataMut::I8(_) => DType::I8,
+            TensorDataMut::U32(_) => DType::U32,
+            TensorDataMut::Bytes(dtype, _) => dtype,
+        }
+    }
+
+    /// Returns total number of elements.
+    pub fn num_elements(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    /// Reads one element converted to `f32`.
+    pub fn read_f32(&self, index: usize) -> f32 {
+        match self.data {
+            TensorDataMut::F32(ref slice) => slice[index],
+            TensorDataMut::F16(ref slice) => f16_to_f32(slice[index]),
+            TensorDataMut::Bf16(ref slice) => bf16_to_f32(slice[index]),
+            TensorDataMut::I8(ref slice) => slice[index] as f32,
+            TensorDataMut::U32(ref slice) => slice[index] as f32,
+            TensorDataMut::Bytes(dtype, ref slice) => read_f32_at(dtype, slice, index),
+        }
+    }
+
+    /// Reads one element converted to `f64`.
+    pub fn read_f64(&self, index: usize) -> f64 {
+        match self.data {
+            TensorDataMut::F32(ref slice) => slice[index] as f64,
+            TensorDataMut::F16(ref slice) => f16_to_f32(slice[index]) as f64,
+            TensorDataMut::Bf16(ref slice) => bf16_to_f32(slice[index]) as f64,
+            TensorDataMut::I8(ref slice) => slice[index] as f64,
+            TensorDataMut::U32(ref slice) => slice[index] as f64,
+            TensorDataMut::Bytes(dtype, ref slice) => read_f64_at(dtype, slice, index),
+        }
+    }
+
+    /// Writes one `f32` value converted to the destination tensor data type.
+    pub fn write_f32(&mut self, index: usize, val: f32) {
+        match self.data {
+            TensorDataMut::F32(ref mut slice) => slice[index] = val,
+            TensorDataMut::F16(ref mut slice) => slice[index] = f32_to_f16(val),
+            TensorDataMut::Bf16(ref mut slice) => slice[index] = f32_to_bf16(val),
+            TensorDataMut::I8(ref mut slice) => {
+                slice[index] = val.round_ties_even().clamp(-128.0, 127.0) as i8;
+            }
+            TensorDataMut::U32(ref mut slice) => {
+                slice[index] = val.round_ties_even().clamp(0.0, u32::MAX as f32) as u32;
+            }
+            TensorDataMut::Bytes(dtype, ref mut slice) => write_f32_at(dtype, slice, index, val),
+        }
+    }
+
+    /// Writes one `f64` value converted to the destination tensor data type.
+    pub fn write_f64(&mut self, index: usize, val: f64) {
+        self.write_f32(index, val as f32);
+    }
+
+    /// Writes raw byte at index (useful for e4m3/e5m2 and custom byte encoding).
+    pub fn write_byte(&mut self, index: usize, val: u8) {
+        match self.data {
+            TensorDataMut::Bytes(_, ref mut slice) => slice[index] = val,
+            TensorDataMut::I8(ref mut slice) => slice[index] = val as i8,
+            _ => self.write_f32(index, val as f32),
+        }
+    }
+
+    /// Reborrows as an immutable `TensorView`.
+    pub fn as_view(&self) -> TensorView<'_> {
+        let data = match self.data {
+            TensorDataMut::F32(ref slice) => TensorData::F32(slice),
+            TensorDataMut::F16(ref slice) => TensorData::F16(slice),
+            TensorDataMut::Bf16(ref slice) => TensorData::Bf16(slice),
+            TensorDataMut::I8(ref slice) => TensorData::I8(slice),
+            TensorDataMut::U32(ref slice) => TensorData::U32(slice),
+            TensorDataMut::Bytes(dtype, ref slice) => TensorData::Bytes(dtype, slice),
+        };
+        TensorView {
+            shape: self.shape.clone(),
+            data,
+        }
+    }
+}
+
+/// Owned heap-allocated multidimensional typed tensor buffer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypedBuffer {
+    shape: Vec<usize>,
+    dtype: DType,
+    f32_data: Vec<f32>,
+    f16_data: Vec<u16>,
+    bf16_data: Vec<u16>,
+    i8_data: Vec<i8>,
+    u32_data: Vec<u32>,
+    byte_data: Vec<u8>,
+}
+
+impl TypedBuffer {
+    /// Creates a zero-initialized typed buffer for the given shape and dtype.
+    pub fn zeros(shape: &[usize], dtype: DType) -> Self {
+        let total_elements: usize = shape.iter().product();
+        let mut buf = Self {
+            shape: shape.to_vec(),
+            dtype,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data: Vec::new(),
+        };
+        match dtype {
+            DType::F32 => buf.f32_data = vec![0.0f32; total_elements],
+            DType::F16 => buf.f16_data = vec![0u16; total_elements],
+            DType::Bf16 => buf.bf16_data = vec![0u16; total_elements],
+            DType::I8 => buf.i8_data = vec![0i8; total_elements],
+            DType::U32 => buf.u32_data = vec![0u32; total_elements],
+            DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
+                let bytes = if dtype == DType::I4 {
+                    total_elements.div_ceil(2)
+                } else if dtype == DType::I32 {
+                    total_elements * 4
+                } else {
+                    total_elements
+                };
+                buf.byte_data = vec![0u8; bytes];
+            }
+        }
+        buf
+    }
+
+    /// Creates a buffer from `f32` slice.
+    pub fn from_f32(shape: &[usize], values: &[f32]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(values.len(), expected);
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::F32,
+            f32_data: values.to_vec(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data: Vec::new(),
+        }
+    }
+
+    /// Creates a buffer from `f16` (u16 bits) slice.
+    pub fn from_f16(shape: &[usize], values: &[u16]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(values.len(), expected);
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::F16,
+            f32_data: Vec::new(),
+            f16_data: values.to_vec(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data: Vec::new(),
+        }
+    }
+
+    /// Creates a buffer from `bf16` (u16 bits) slice.
+    pub fn from_bf16(shape: &[usize], values: &[u16]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(values.len(), expected);
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::Bf16,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: values.to_vec(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data: Vec::new(),
+        }
+    }
+
+    /// Creates a buffer from `i8` slice.
+    pub fn from_i8(shape: &[usize], values: &[i8]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(values.len(), expected);
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::I8,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: values.to_vec(),
+            u32_data: Vec::new(),
+            byte_data: Vec::new(),
+        }
+    }
+
+    /// Creates a buffer from `u32` slice.
+    pub fn from_u32(shape: &[usize], values: &[u32]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(values.len(), expected);
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::U32,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: values.to_vec(),
+            byte_data: Vec::new(),
+        }
+    }
+
+    /// Creates an E4M3 byte buffer from raw bytes.
+    pub fn from_e4m3_bytes(shape: &[usize], bytes: &[u8]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(bytes.len(), expected);
+        Self {
+            shape: shape.to_vec(),
+            dtype: DType::E4m3,
+            f32_data: Vec::new(),
+            f16_data: Vec::new(),
+            bf16_data: Vec::new(),
+            i8_data: Vec::new(),
+            u32_data: Vec::new(),
+            byte_data: bytes.to_vec(),
+        }
+    }
+
+    /// Returns tensor shape.
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Returns tensor rank.
+    pub fn rank(&self) -> usize {
+        self.shape.len()
+    }
+
+    /// Returns tensor data type.
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    /// Returns total number of elements.
+    pub fn num_elements(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    /// Reads one element converted to `f32`.
+    pub fn read_f32(&self, index: usize) -> f32 {
+        match self.dtype {
+            DType::F32 => self.f32_data[index],
+            DType::F16 => f16_to_f32(self.f16_data[index]),
+            DType::Bf16 => bf16_to_f32(self.bf16_data[index]),
+            DType::I8 => self.i8_data[index] as f32,
+            DType::U32 => self.u32_data[index] as f32,
+            DType::E4m3 => fp8_e4m3_decode(self.byte_data[index]),
+            DType::E5m2 => fp8_e5m2_decode(self.byte_data[index]),
+            DType::Bool | DType::I4 | DType::I32 => read_f32_at(self.dtype, &self.byte_data, index),
+        }
+    }
+
+    /// Writes one `f32` value into buffer at `index`.
+    pub fn write_f32(&mut self, index: usize, val: f32) {
+        match self.dtype {
+            DType::F32 => self.f32_data[index] = val,
+            DType::F16 => self.f16_data[index] = f32_to_f16(val),
+            DType::Bf16 => self.bf16_data[index] = f32_to_bf16(val),
+            DType::I8 => self.i8_data[index] = val.round_ties_even().clamp(-128.0, 127.0) as i8,
+            DType::U32 => {
+                self.u32_data[index] = val.round_ties_even().clamp(0.0, u32::MAX as f32) as u32;
+            }
+            DType::E4m3 => self.byte_data[index] = fp8_e4m3_encode(val),
+            DType::E5m2 => self.byte_data[index] = fp8_e5m2_encode(val),
+            DType::Bool | DType::I4 | DType::I32 => {
+                write_f32_at(self.dtype, &mut self.byte_data, index, val);
+            }
+        }
+    }
+
+    /// Reads raw byte at index for FP8/byte dtypes.
+    pub fn read_byte(&self, index: usize) -> u8 {
+        match self.dtype {
+            DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
+                self.byte_data[index]
+            }
+            DType::I8 => self.i8_data[index] as u8,
+            _ => self.read_f32(index) as u8,
+        }
+    }
+
+    /// Writes raw byte at index for FP8/byte dtypes.
+    pub fn write_byte(&mut self, index: usize, val: u8) {
+        match self.dtype {
+            DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
+                self.byte_data[index] = val;
+            }
+            DType::I8 => self.i8_data[index] = val as i8,
+            _ => self.write_f32(index, val as f32),
+        }
+    }
+
+    /// Copies data out as a vector of `f32`.
+    pub fn to_f32_vec(&self) -> Vec<f32> {
+        (0..self.num_elements()).map(|i| self.read_f32(i)).collect()
+    }
+
+    /// Copies data out as a vector of `i8`.
+    pub fn to_i8_vec(&self) -> Vec<i8> {
+        match self.dtype {
+            DType::I8 => self.i8_data.clone(),
+            _ => (0..self.num_elements())
+                .map(|i| self.read_f32(i) as i8)
+                .collect(),
+        }
+    }
+
+    /// Copies data out as a vector of raw bytes.
+    pub fn to_byte_vec(&self) -> Vec<u8> {
+        match self.dtype {
+            DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
+                self.byte_data.clone()
+            }
+            DType::I8 => self.i8_data.iter().map(|&x| x as u8).collect(),
+            _ => (0..self.num_elements())
+                .map(|i| self.read_f32(i) as u8)
+                .collect(),
+        }
+    }
+
+    /// Borrows buffer as an immutable `TensorView`.
+    pub fn as_view(&self) -> TensorView<'_> {
+        let data = match self.dtype {
+            DType::F32 => TensorData::F32(&self.f32_data),
+            DType::F16 => TensorData::F16(&self.f16_data),
+            DType::Bf16 => TensorData::Bf16(&self.bf16_data),
+            DType::I8 => TensorData::I8(&self.i8_data),
+            DType::U32 => TensorData::U32(&self.u32_data),
+            DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
+                TensorData::Bytes(self.dtype, &self.byte_data)
+            }
+        };
+        TensorView {
+            shape: self.shape.clone(),
+            data,
+        }
+    }
+
+    /// Borrows buffer as a mutable `TensorViewMut`.
+    pub fn as_view_mut(&mut self) -> TensorViewMut<'_> {
+        let dtype = self.dtype;
+        let data = match dtype {
+            DType::F32 => TensorDataMut::F32(&mut self.f32_data),
+            DType::F16 => TensorDataMut::F16(&mut self.f16_data),
+            DType::Bf16 => TensorDataMut::Bf16(&mut self.bf16_data),
+            DType::I8 => TensorDataMut::I8(&mut self.i8_data),
+            DType::U32 => TensorDataMut::U32(&mut self.u32_data),
+            DType::E4m3 | DType::E5m2 | DType::Bool | DType::I4 | DType::I32 => {
+                TensorDataMut::Bytes(dtype, &mut self.byte_data)
+            }
+        };
+        TensorViewMut {
+            shape: self.shape.clone(),
+            data,
+        }
+    }
+}

--- a/crates/r9v-t0/src/cast.rs
+++ b/crates/r9v-t0/src/cast.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Scalar T0 implementation of precision cast op (Spec 1 §4.A, §6.4, Spec 4 §2).
 
-use r9v_ir::CastOp;
+use r9v_ir::{CastOp, DType};
 
-use crate::buffer::{TensorView, TensorViewMut};
+use crate::buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut};
+use crate::dtype::dtype_element_size;
 use crate::error::T0Error;
 
 /// Executes scalar T0 precision cast: `x -> y` with `y.dtype == op.dtype` (Spec 1 §4.A, Spec 1 §6.4, Spec 4 §2).
@@ -30,6 +31,14 @@ pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resul
 
     T0Error::from_problems("cast", problems)?;
 
+    // Identity casts copy raw storage bit-exactly instead of round-tripping through `f32`,
+    // which cannot represent U32/I32 magnitudes beyond 2^24 and would normalize FP8 NaN
+    // payloads (Spec 1 §2.1, Spec 1 §6.4).
+    if x.dtype() == y.dtype() {
+        copy_identity(x, y);
+        return Ok(());
+    }
+
     let num_elem = x.num_elements();
     for i in 0..num_elem {
         let val = x.read_f32(i);
@@ -37,6 +46,95 @@ pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resul
     }
 
     Ok(())
+}
+
+/// Copies one tensor to another with the same dtype without value conversion (Spec 1 §2.1, Spec 4 §2).
+///
+/// Every storage representation pair for the shared dtype moves raw bits, so large integers,
+/// NaN payloads, and packed nibbles survive unchanged. Any unexpected representation pair
+/// falls back to the `f32` value path.
+fn copy_identity(x: &TensorView<'_>, y: &mut TensorViewMut<'_>) {
+    let num_elem = x.num_elements();
+    match (&x.data, &mut y.data) {
+        (TensorData::F32(src), TensorDataMut::F32(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::F16(src), TensorDataMut::F16(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::Bf16(src), TensorDataMut::Bf16(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::I8(src), TensorDataMut::I8(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::U32(src), TensorDataMut::U32(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::Bytes(dtype_x, src), TensorDataMut::Bytes(_, dst)) => {
+            let byte_count = if *dtype_x == DType::I4 {
+                num_elem / 2 + (num_elem % 2)
+            } else {
+                num_elem * dtype_element_size(*dtype_x)
+            };
+            dst[..byte_count].copy_from_slice(&src[..byte_count]);
+        }
+        (TensorData::U32(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 4..(i + 1) * 4].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::U32(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = u32::from_ne_bytes(src[i * 4..(i + 1) * 4].try_into().unwrap());
+            }
+        }
+        (TensorData::F32(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 4..(i + 1) * 4].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::F32(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = f32::from_ne_bytes(src[i * 4..(i + 1) * 4].try_into().unwrap());
+            }
+        }
+        (TensorData::F16(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 2..(i + 1) * 2].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::F16(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = u16::from_ne_bytes(src[i * 2..(i + 1) * 2].try_into().unwrap());
+            }
+        }
+        (TensorData::Bf16(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 2..(i + 1) * 2].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::Bf16(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = u16::from_ne_bytes(src[i * 2..(i + 1) * 2].try_into().unwrap());
+            }
+        }
+        (TensorData::I8(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i] = val as u8;
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::I8(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = src[i] as i8;
+            }
+        }
+        _ => {
+            for i in 0..num_elem {
+                y.write_f32(i, x.read_f32(i));
+            }
+        }
+    }
 }
 
 /// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.A, Spec 4 §2).

--- a/crates/r9v-t0/src/cast.rs
+++ b/crates/r9v-t0/src/cast.rs
@@ -35,7 +35,7 @@ pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resul
     // which cannot represent U32/I32 magnitudes beyond 2^24 and would normalize FP8 NaN
     // payloads (Spec 1 §2.1, Spec 1 §6.4).
     if x.dtype() == y.dtype() {
-        copy_identity(x, y);
+        copy_identity(x, y)?;
         return Ok(());
     }
 
@@ -52,8 +52,8 @@ pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resul
 ///
 /// Every storage representation pair for the shared dtype moves raw bits, so large integers,
 /// NaN payloads, and packed nibbles survive unchanged. Any unexpected representation pair
-/// falls back to the `f32` value path.
-fn copy_identity(x: &TensorView<'_>, y: &mut TensorViewMut<'_>) {
+/// fails closed instead of silently converting through a lossy value path.
+fn copy_identity(x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
     let num_elem = x.num_elements();
     match (&x.data, &mut y.data) {
         (TensorData::F32(src), TensorDataMut::F32(dst)) => {
@@ -130,11 +130,14 @@ fn copy_identity(x: &TensorView<'_>, y: &mut TensorViewMut<'_>) {
             }
         }
         _ => {
-            for i in 0..num_elem {
-                y.write_f32(i, x.read_f32(i));
-            }
+            return Err(T0Error::BackingRepresentationMismatch {
+                op: "cast",
+                dtype: x.dtype(),
+            });
         }
     }
+
+    Ok(())
 }
 
 /// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.A, Spec 4 §2).

--- a/crates/r9v-t0/src/cast.rs
+++ b/crates/r9v-t0/src/cast.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of precision cast op (Spec 1 §4.A, §6.4, Spec 4 §2).
+
+use r9v_ir::CastOp;
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Executes scalar T0 precision cast: `x -> y` with `y.dtype == op.dtype` (Spec 1 §4.A).
+pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if x.shape() != y.shape() {
+        problems.push(format!(
+            "output y shape {:?} does not match input x shape {:?}",
+            y.shape(),
+            x.shape()
+        ));
+    }
+    if y.dtype() != op.dtype {
+        problems.push(format!(
+            "output y dtype {:?} does not match op target dtype {:?}",
+            y.dtype(),
+            op.dtype
+        ));
+    }
+
+    T0Error::from_problems("cast", problems)?;
+
+    let num_elem = x.num_elements();
+    for i in 0..num_elem {
+        let val = x.read_f32(i);
+        y.write_f32(i, val);
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+pub fn cast_f64_reference(x: &[f64]) -> Vec<f64> {
+    x.to_vec()
+}

--- a/crates/r9v-t0/src/cast.rs
+++ b/crates/r9v-t0/src/cast.rs
@@ -6,8 +6,11 @@ use r9v_ir::CastOp;
 use crate::buffer::{TensorView, TensorViewMut};
 use crate::error::T0Error;
 
-/// Executes scalar T0 precision cast: `x -> y` with `y.dtype == op.dtype` (Spec 1 §4.A).
+/// Executes scalar T0 precision cast: `x -> y` with `y.dtype == op.dtype` (Spec 1 §4.A, Spec 1 §6.4, Spec 4 §2).
 pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
 
     if x.shape() != y.shape() {
@@ -36,7 +39,7 @@ pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resul
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.A, Spec 4 §2).
 pub fn cast_f64_reference(x: &[f64]) -> Vec<f64> {
     x.to_vec()
 }

--- a/crates/r9v-t0/src/copy.rs
+++ b/crates/r9v-t0/src/copy.rs
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Scalar T0 implementation of memory copy and contiguization op (Spec 1 §4.A, Spec 4 §2).
 
-use r9v_ir::CopyOp;
+use r9v_ir::{CopyOp, DType};
 
-use crate::buffer::{TensorView, TensorViewMut};
+use crate::buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut};
+use crate::dtype::dtype_element_size;
 use crate::error::T0Error;
 
-/// Executes scalar T0 tensor copy / contiguization (Spec 1 §4.A).
+/// Executes scalar T0 tensor copy / contiguization (Spec 1 §4.A, Spec 4 §2).
+///
+/// Performs bit-exact copying through raw typed storage without floating point conversions.
 pub fn copy(_op: &CopyOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
 
     if x.shape() != y.shape() {
@@ -28,10 +34,91 @@ pub fn copy(_op: &CopyOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resu
     T0Error::from_problems("copy", problems)?;
 
     let num_elem = x.num_elements();
-    for i in 0..num_elem {
-        let val = x.read_f32(i);
-        y.write_f32(i, val);
+    match (&x.data, &mut y.data) {
+        (TensorData::F32(src), TensorDataMut::F32(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::F16(src), TensorDataMut::F16(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::Bf16(src), TensorDataMut::Bf16(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::I8(src), TensorDataMut::I8(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::U32(src), TensorDataMut::U32(dst)) => {
+            dst[..num_elem].copy_from_slice(&src[..num_elem]);
+        }
+        (TensorData::Bytes(dtype_x, src), TensorDataMut::Bytes(_dtype_y, dst)) => {
+            let byte_count = if *dtype_x == DType::I4 {
+                num_elem / 2 + (num_elem % 2)
+            } else {
+                num_elem * dtype_element_size(*dtype_x)
+            };
+            dst[..byte_count].copy_from_slice(&src[..byte_count]);
+        }
+        (TensorData::U32(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 4..(i + 1) * 4].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::U32(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = u32::from_ne_bytes(src[i * 4..(i + 1) * 4].try_into().unwrap());
+            }
+        }
+        (TensorData::F32(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 4..(i + 1) * 4].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::F32(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = f32::from_ne_bytes(src[i * 4..(i + 1) * 4].try_into().unwrap());
+            }
+        }
+        (TensorData::F16(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 2..(i + 1) * 2].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::F16(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = u16::from_ne_bytes(src[i * 2..(i + 1) * 2].try_into().unwrap());
+            }
+        }
+        (TensorData::Bf16(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i * 2..(i + 1) * 2].copy_from_slice(&val.to_ne_bytes());
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::Bf16(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = u16::from_ne_bytes(src[i * 2..(i + 1) * 2].try_into().unwrap());
+            }
+        }
+        (TensorData::I8(src), TensorDataMut::Bytes(_, dst)) => {
+            for (i, &val) in src[..num_elem].iter().enumerate() {
+                dst[i] = val as u8;
+            }
+        }
+        (TensorData::Bytes(_, src), TensorDataMut::I8(dst)) => {
+            for (i, item) in dst[..num_elem].iter_mut().enumerate() {
+                *item = src[i] as i8;
+            }
+        }
+        _ => {
+            for i in 0..num_elem {
+                y.write_f32(i, x.read_f32(i));
+            }
+        }
     }
 
     Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.A, Spec 4 §2).
+pub fn copy_f64_reference(_op: &CopyOp, x: &[f64]) -> Vec<f64> {
+    x.to_vec()
 }

--- a/crates/r9v-t0/src/copy.rs
+++ b/crates/r9v-t0/src/copy.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of memory copy and contiguization op (Spec 1 §4.A, Spec 4 §2).
+
+use r9v_ir::CopyOp;
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Executes scalar T0 tensor copy / contiguization (Spec 1 §4.A).
+pub fn copy(_op: &CopyOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if x.shape() != y.shape() {
+        problems.push(format!(
+            "output y shape {:?} does not match input x shape {:?}",
+            y.shape(),
+            x.shape()
+        ));
+    }
+    if y.dtype() != x.dtype() {
+        problems.push(format!(
+            "output y dtype {:?} does not match input x dtype {:?}",
+            y.dtype(),
+            x.dtype()
+        ));
+    }
+
+    T0Error::from_problems("copy", problems)?;
+
+    let num_elem = x.num_elements();
+    for i in 0..num_elem {
+        let val = x.read_f32(i);
+        y.write_f32(i, val);
+    }
+
+    Ok(())
+}

--- a/crates/r9v-t0/src/copy.rs
+++ b/crates/r9v-t0/src/copy.rs
@@ -109,9 +109,10 @@ pub fn copy(_op: &CopyOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resu
             }
         }
         _ => {
-            for i in 0..num_elem {
-                y.write_f32(i, x.read_f32(i));
-            }
+            return Err(T0Error::BackingRepresentationMismatch {
+                op: "copy",
+                dtype: x.dtype(),
+            });
         }
     }
 

--- a/crates/r9v-t0/src/dtype.rs
+++ b/crates/r9v-t0/src/dtype.rs
@@ -3,7 +3,7 @@
 
 use r9v_ir::DType;
 
-/// Converts IEEE 754 single precision float (`f32`) to IEEE 754 half precision float (`f16`) bits.
+/// Converts IEEE 754 single precision float (`f32`) to IEEE 754 half precision float (`f16`) bits (Spec 1 §2.1, Spec 4 §2).
 ///
 /// Uses round-to-nearest-even and handles subnormals, infinities, and NaNs.
 pub fn f32_to_f16(val: f32) -> u16 {
@@ -66,7 +66,7 @@ pub fn f32_to_f16(val: f32) -> u16 {
     }
 }
 
-/// Converts IEEE 754 half precision float (`f16`) bits to IEEE 754 single precision float (`f32`).
+/// Converts IEEE 754 half precision float (`f16`) bits to IEEE 754 single precision float (`f32`) (Spec 1 §2.1, Spec 4 §2).
 pub fn f16_to_f32(bits: u16) -> f32 {
     let sign = ((bits >> 15) & 1) as u32;
     let exp = ((bits >> 10) & 0x1F) as u32;
@@ -98,7 +98,7 @@ pub fn f16_to_f32(bits: u16) -> f32 {
     }
 }
 
-/// Converts IEEE 754 single precision float (`f32`) to bfloat16 (`bf16`) bits with round-to-nearest-even.
+/// Converts IEEE 754 single precision float (`f32`) to bfloat16 (`bf16`) bits with round-to-nearest-even (Spec 1 §2.1, Spec 4 §2).
 pub fn f32_to_bf16(val: f32) -> u16 {
     let u = val.to_bits();
     if val.is_nan() {
@@ -110,12 +110,12 @@ pub fn f32_to_bf16(val: f32) -> u16 {
     (rounded >> 16) as u16
 }
 
-/// Converts bfloat16 (`bf16`) bits to IEEE 754 single precision float (`f32`).
+/// Converts bfloat16 (`bf16`) bits to IEEE 754 single precision float (`f32`) (Spec 1 §2.1, Spec 4 §2).
 pub fn bf16_to_f32(bits: u16) -> f32 {
     f32::from_bits((bits as u32) << 16)
 }
 
-/// Decodes OCP FP8 E4M3 byte to single precision float (`f32`) (Spec 1 §2.1, spikes/fp8-wmma/fp8_wmma.hip).
+/// Decodes OCP FP8 E4M3 byte to single precision float (`f32`) (Spec 1 §2.1, Spec 4 §2, spikes/fp8-wmma/fp8_wmma.hip).
 pub fn fp8_e4m3_decode(b: u8) -> f32 {
     let s = (b >> 7) & 1;
     let e = (b >> 3) & 0x0F;
@@ -135,7 +135,7 @@ pub fn fp8_e4m3_decode(b: u8) -> f32 {
     }
 }
 
-/// Encodes single precision float (`f32`) to OCP FP8 E4M3 byte with saturation to ±448 (spikes/fp8-wmma/fp8_wmma.hip).
+/// Encodes single precision float (`f32`) to OCP FP8 E4M3 byte with saturation to ±448 (Spec 1 §2.1, Spec 4 §2, spikes/fp8-wmma/fp8_wmma.hip).
 pub fn fp8_e4m3_encode(v: f32) -> u8 {
     if v.is_nan() {
         return 0x7F;
@@ -164,7 +164,7 @@ pub fn fp8_e4m3_encode(v: f32) -> u8 {
     best
 }
 
-/// Decodes OCP FP8 E5M2 byte to single precision float (`f32`) (Spec 1 §2.1).
+/// Decodes OCP FP8 E5M2 byte to single precision float (`f32`) (Spec 1 §2.1, Spec 4 §2).
 pub fn fp8_e5m2_decode(b: u8) -> f32 {
     let s = (b >> 7) & 1;
     let e = (b >> 2) & 0x1F;
@@ -190,7 +190,7 @@ pub fn fp8_e5m2_decode(b: u8) -> f32 {
     }
 }
 
-/// Encodes single precision float (`f32`) to OCP FP8 E5M2 byte with saturation to ±57344.
+/// Encodes single precision float (`f32`) to OCP FP8 E5M2 byte with saturation to ±57344 (Spec 1 §2.1, Spec 4 §2).
 pub fn fp8_e5m2_encode(v: f32) -> u8 {
     if v.is_nan() {
         return 0x7F;
@@ -220,7 +220,7 @@ pub fn fp8_e5m2_encode(v: f32) -> u8 {
     best
 }
 
-/// Reads one element from a raw byte buffer at `index` and returns it as `f32`.
+/// Reads one element from a raw byte buffer at `index` and returns it as `f32` (Spec 1 §2.1, Spec 4 §2).
 pub fn read_f32_at(dtype: DType, slice: &[u8], index: usize) -> f32 {
     match dtype {
         DType::F32 => {
@@ -293,12 +293,12 @@ pub fn read_f32_at(dtype: DType, slice: &[u8], index: usize) -> f32 {
     }
 }
 
-/// Reads one element from a raw byte buffer at `index` and returns it as `f64`.
+/// Reads one element from a raw byte buffer at `index` and returns it as `f64` (Spec 1 §2.1, Spec 4 §2).
 pub fn read_f64_at(dtype: DType, slice: &[u8], index: usize) -> f64 {
     read_f32_at(dtype, slice, index) as f64
 }
 
-/// Writes one `f32` value into a raw byte buffer at `index` converted to `dtype`.
+/// Writes one `f32` value into a raw byte buffer at `index` converted to `dtype` (Spec 1 §2.1, Spec 4 §2).
 pub fn write_f32_at(dtype: DType, slice: &mut [u8], index: usize, val: f32) {
     match dtype {
         DType::F32 => {
@@ -356,7 +356,7 @@ pub fn write_f32_at(dtype: DType, slice: &mut [u8], index: usize, val: f32) {
     }
 }
 
-/// Returns the element size in bytes for a `DType`. Returns 1 for sub-byte `I4` (packed).
+/// Returns the element size in bytes for a `DType`. Returns 1 for sub-byte `I4` (packed) (Spec 1 §2.1, Spec 4 §2).
 pub fn dtype_element_size(dtype: DType) -> usize {
     match dtype {
         DType::F32 | DType::I32 | DType::U32 => 4,

--- a/crates/r9v-t0/src/dtype.rs
+++ b/crates/r9v-t0/src/dtype.rs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Element data type conversions and scalar operations for T0 (Spec 1 §2.1, Spec 4 §2).
+
+use r9v_ir::DType;
+
+/// Converts IEEE 754 single precision float (`f32`) to IEEE 754 half precision float (`f16`) bits.
+///
+/// Uses round-to-nearest-even and handles subnormals, infinities, and NaNs.
+pub fn f32_to_f16(val: f32) -> u16 {
+    let u = val.to_bits();
+    let sign = ((u >> 31) & 1) as u16;
+    let exp = ((u >> 23) & 0xFF) as i32;
+    let mant = u & 0x7F_FFFF;
+
+    if exp == 0xFF {
+        // NaN or Infinity
+        if mant != 0 {
+            // Quiet NaN
+            (sign << 15) | 0x7E00 | ((mant >> 13) as u16).max(1)
+        } else {
+            // Infinity
+            (sign << 15) | 0x7C00
+        }
+    } else if exp == 0 {
+        // Zero or subnormal f32 -> zero f16
+        sign << 15
+    } else {
+        let unbiased_exp = exp - 127;
+        let new_exp = unbiased_exp + 15;
+
+        if new_exp >= 31 {
+            // Overflow -> Infinity
+            (sign << 15) | 0x7C00
+        } else if new_exp <= 0 {
+            // Subnormal or underflow in f16
+            if new_exp < -10 {
+                // Underflow to zero
+                sign << 15
+            } else {
+                let shift = 14 - new_exp;
+                let full_mant = mant | 0x80_0000;
+                let half = 1 << (shift - 1);
+                let lsb = (full_mant >> shift) & 1;
+                let rounded = full_mant + half - 1 + lsb;
+                let final_mant = (rounded >> shift) as u16;
+                (sign << 15) | final_mant
+            }
+        } else {
+            // Normal f16
+            let lsb = (mant >> 13) & 1;
+            let rounding_bias = 0x0FFF + lsb;
+            let rounded_mant = mant + rounding_bias;
+
+            if rounded_mant >= 0x80_0000 {
+                // Mantissa overflow
+                let final_exp = new_exp + 1;
+                if final_exp >= 31 {
+                    (sign << 15) | 0x7C00
+                } else {
+                    (sign << 15) | ((final_exp as u16) << 10)
+                }
+            } else {
+                (sign << 15) | ((new_exp as u16) << 10) | ((rounded_mant >> 13) as u16)
+            }
+        }
+    }
+}
+
+/// Converts IEEE 754 half precision float (`f16`) bits to IEEE 754 single precision float (`f32`).
+pub fn f16_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 1) as u32;
+    let exp = ((bits >> 10) & 0x1F) as u32;
+    let mant = (bits & 0x03FF) as u32;
+
+    if exp == 0x1F {
+        if mant == 0 {
+            // Infinity
+            f32::from_bits((sign << 31) | 0x7F80_0000)
+        } else {
+            // NaN
+            f32::from_bits((sign << 31) | 0x7FC0_0000 | (mant << 13))
+        }
+    } else if exp == 0 {
+        if mant == 0 {
+            // Zero
+            f32::from_bits(sign << 31)
+        } else {
+            // Subnormal
+            let shift = mant.leading_zeros() - 21;
+            let normalized_mant = (mant << shift) & 0x03FF;
+            let final_exp = 113 - shift;
+            f32::from_bits((sign << 31) | (final_exp << 23) | (normalized_mant << 13))
+        }
+    } else {
+        // Normal
+        let final_exp = exp + 112;
+        f32::from_bits((sign << 31) | (final_exp << 23) | (mant << 13))
+    }
+}
+
+/// Converts IEEE 754 single precision float (`f32`) to bfloat16 (`bf16`) bits with round-to-nearest-even.
+pub fn f32_to_bf16(val: f32) -> u16 {
+    let u = val.to_bits();
+    if val.is_nan() {
+        return ((u >> 16) | 0x0040) as u16;
+    }
+    let lsb = (u >> 16) & 1;
+    let rounding_bias = 0x7FFF + lsb;
+    let rounded = u.wrapping_add(rounding_bias);
+    (rounded >> 16) as u16
+}
+
+/// Converts bfloat16 (`bf16`) bits to IEEE 754 single precision float (`f32`).
+pub fn bf16_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
+}
+
+/// Decodes OCP FP8 E4M3 byte to single precision float (`f32`) (Spec 1 §2.1, spikes/fp8-wmma/fp8_wmma.hip).
+pub fn fp8_e4m3_decode(b: u8) -> f32 {
+    let s = (b >> 7) & 1;
+    let e = (b >> 3) & 0x0F;
+    let m = b & 0x07;
+    let sign = if s != 0 { -1.0f32 } else { 1.0f32 };
+    if e == 0 {
+        // subnormal: (-1)^s * 2^-6 * (m / 8)
+        sign * (m as f32 / 8.0) * 0.015625f32
+    } else if e == 15 && m == 7 {
+        // NaN
+        f32::NAN
+    } else {
+        // normal
+        let exp = (e as i32) - 7;
+        let scale = 2.0f32.powi(exp);
+        sign * (1.0 + m as f32 / 8.0) * scale
+    }
+}
+
+/// Encodes single precision float (`f32`) to OCP FP8 E4M3 byte with saturation to ±448 (spikes/fp8-wmma/fp8_wmma.hip).
+pub fn fp8_e4m3_encode(v: f32) -> u8 {
+    if v.is_nan() {
+        return 0x7F;
+    }
+    let av = v.abs();
+    if av > 448.0 {
+        return if v < 0.0 { 0xFE } else { 0x7E };
+    }
+    if av == 0.0 {
+        return if v.is_sign_negative() { 0x80 } else { 0x00 };
+    }
+    let mut best: u8 = 0x00;
+    let mut best_d = 1e30f32;
+    for c in 0u16..256u16 {
+        let b = c as u8;
+        if b == 0x7F || b == 0xFF {
+            continue;
+        }
+        let dec = fp8_e4m3_decode(b);
+        let d = (dec - v).abs();
+        if d < best_d || (d == best_d && (b & 1) == 0 && (best & 1) == 1) {
+            best_d = d;
+            best = b;
+        }
+    }
+    best
+}
+
+/// Decodes OCP FP8 E5M2 byte to single precision float (`f32`) (Spec 1 §2.1).
+pub fn fp8_e5m2_decode(b: u8) -> f32 {
+    let s = (b >> 7) & 1;
+    let e = (b >> 2) & 0x1F;
+    let m = b & 0x03;
+    let sign = if s != 0 { -1.0f32 } else { 1.0f32 };
+    if e == 0 {
+        // subnormal: (-1)^s * 2^-14 * (m / 4)
+        sign * (m as f32 / 4.0) * (2.0f32.powi(-14))
+    } else if e == 31 {
+        if m == 0 {
+            if s != 0 {
+                f32::NEG_INFINITY
+            } else {
+                f32::INFINITY
+            }
+        } else {
+            f32::NAN
+        }
+    } else {
+        let exp = (e as i32) - 15;
+        let scale = 2.0f32.powi(exp);
+        sign * (1.0 + m as f32 / 4.0) * scale
+    }
+}
+
+/// Encodes single precision float (`f32`) to OCP FP8 E5M2 byte with saturation to ±57344.
+pub fn fp8_e5m2_encode(v: f32) -> u8 {
+    if v.is_nan() {
+        return 0x7F;
+    }
+    let av = v.abs();
+    if av > 57344.0 {
+        return if v < 0.0 { 0xFC } else { 0x7C };
+    }
+    if av == 0.0 {
+        return if v.is_sign_negative() { 0x80 } else { 0x00 };
+    }
+    let mut best: u8 = 0x00;
+    let mut best_d = 1e30f32;
+    for c in 0u16..256u16 {
+        let b = c as u8;
+        if (b & 0x7C) == 0x7C && (b & 0x03) != 0 {
+            // NaN codes excluded
+            continue;
+        }
+        let dec = fp8_e5m2_decode(b);
+        let d = (dec - v).abs();
+        if d < best_d || (d == best_d && (b & 1) == 0 && (best & 1) == 1) {
+            best_d = d;
+            best = b;
+        }
+    }
+    best
+}
+
+/// Reads one element from a raw byte buffer at `index` and returns it as `f32`.
+pub fn read_f32_at(dtype: DType, slice: &[u8], index: usize) -> f32 {
+    match dtype {
+        DType::F32 => {
+            let offset = index * 4;
+            let bytes = [
+                slice[offset],
+                slice[offset + 1],
+                slice[offset + 2],
+                slice[offset + 3],
+            ];
+            f32::from_ne_bytes(bytes)
+        }
+        DType::F16 => {
+            let offset = index * 2;
+            let bytes = [slice[offset], slice[offset + 1]];
+            let bits = u16::from_ne_bytes(bytes);
+            f16_to_f32(bits)
+        }
+        DType::Bf16 => {
+            let offset = index * 2;
+            let bytes = [slice[offset], slice[offset + 1]];
+            let bits = u16::from_ne_bytes(bytes);
+            bf16_to_f32(bits)
+        }
+        DType::E4m3 => fp8_e4m3_decode(slice[index]),
+        DType::E5m2 => fp8_e5m2_decode(slice[index]),
+        DType::I8 => slice[index] as i8 as f32,
+        DType::I32 => {
+            let offset = index * 4;
+            let bytes = [
+                slice[offset],
+                slice[offset + 1],
+                slice[offset + 2],
+                slice[offset + 3],
+            ];
+            i32::from_ne_bytes(bytes) as f32
+        }
+        DType::U32 => {
+            let offset = index * 4;
+            let bytes = [
+                slice[offset],
+                slice[offset + 1],
+                slice[offset + 2],
+                slice[offset + 3],
+            ];
+            u32::from_ne_bytes(bytes) as f32
+        }
+        DType::Bool => {
+            if slice[index] != 0 {
+                1.0f32
+            } else {
+                0.0f32
+            }
+        }
+        DType::I4 => {
+            let byte = slice[index / 2];
+            let nibble = if index.is_multiple_of(2) {
+                byte & 0x0F
+            } else {
+                (byte >> 4) & 0x0F
+            };
+            // Sign extend 4-bit signed int
+            let val = if nibble >= 8 {
+                (nibble as i8) - 16
+            } else {
+                nibble as i8
+            };
+            val as f32
+        }
+    }
+}
+
+/// Reads one element from a raw byte buffer at `index` and returns it as `f64`.
+pub fn read_f64_at(dtype: DType, slice: &[u8], index: usize) -> f64 {
+    read_f32_at(dtype, slice, index) as f64
+}
+
+/// Writes one `f32` value into a raw byte buffer at `index` converted to `dtype`.
+pub fn write_f32_at(dtype: DType, slice: &mut [u8], index: usize, val: f32) {
+    match dtype {
+        DType::F32 => {
+            let offset = index * 4;
+            let bytes = val.to_ne_bytes();
+            slice[offset..offset + 4].copy_from_slice(&bytes);
+        }
+        DType::F16 => {
+            let offset = index * 2;
+            let bits = f32_to_f16(val);
+            slice[offset..offset + 2].copy_from_slice(&bits.to_ne_bytes());
+        }
+        DType::Bf16 => {
+            let offset = index * 2;
+            let bits = f32_to_bf16(val);
+            slice[offset..offset + 2].copy_from_slice(&bits.to_ne_bytes());
+        }
+        DType::E4m3 => {
+            slice[index] = fp8_e4m3_encode(val);
+        }
+        DType::E5m2 => {
+            slice[index] = fp8_e5m2_encode(val);
+        }
+        DType::I8 => {
+            let rounded = val.round_ties_even();
+            let clamped = rounded.clamp(-128.0, 127.0) as i8;
+            slice[index] = clamped as u8;
+        }
+        DType::I32 => {
+            let offset = index * 4;
+            let rounded = val.round_ties_even();
+            let clamped = rounded.clamp(i32::MIN as f32, i32::MAX as f32) as i32;
+            slice[offset..offset + 4].copy_from_slice(&clamped.to_ne_bytes());
+        }
+        DType::U32 => {
+            let offset = index * 4;
+            let rounded = val.round_ties_even();
+            let clamped = rounded.clamp(0.0, u32::MAX as f32) as u32;
+            slice[offset..offset + 4].copy_from_slice(&clamped.to_ne_bytes());
+        }
+        DType::Bool => {
+            slice[index] = if val != 0.0 && !val.is_nan() { 1 } else { 0 };
+        }
+        DType::I4 => {
+            let rounded = val.round_ties_even();
+            let clamped = rounded.clamp(-8.0, 7.0) as i8;
+            let nibble = (clamped as u8) & 0x0F;
+            let byte_idx = index / 2;
+            if index.is_multiple_of(2) {
+                slice[byte_idx] = (slice[byte_idx] & 0xF0) | nibble;
+            } else {
+                slice[byte_idx] = (slice[byte_idx] & 0x0F) | (nibble << 4);
+            }
+        }
+    }
+}
+
+/// Returns the element size in bytes for a `DType`. Returns 1 for sub-byte `I4` (packed).
+pub fn dtype_element_size(dtype: DType) -> usize {
+    match dtype {
+        DType::F32 | DType::I32 | DType::U32 => 4,
+        DType::F16 | DType::Bf16 => 2,
+        DType::E4m3 | DType::E5m2 | DType::I8 | DType::Bool => 1,
+        DType::I4 => 1, // Packed 2 per byte
+    }
+}

--- a/crates/r9v-t0/src/error.rs
+++ b/crates/r9v-t0/src/error.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Error types for the R9V T0 CPU reference implementation (Spec 4 §2, CONVENTIONS.md §1).
+
+use r9v_ir::DType;
+
+/// Domain error enum for T0 reference op execution (CONVENTIONS.md §1.1).
+#[derive(Debug, thiserror::Error)]
+pub enum T0Error {
+    /// Wrapping an IR-level error from `r9v-ir`.
+    #[error(transparent)]
+    Ir(#[from] r9v_ir::IrError),
+
+    /// Tensor rank mismatch.
+    #[error("tensor `{tensor}`: expected rank {expected}, got {got} with shape {shape:?}")]
+    RankMismatch {
+        /// Name of the affected tensor operand.
+        tensor: &'static str,
+        /// Expected tensor rank.
+        expected: usize,
+        /// Observed tensor rank.
+        got: usize,
+        /// Observed full shape.
+        shape: Vec<usize>,
+    },
+
+    /// Tensor element data type mismatch.
+    #[error("tensor `{tensor}`: expected dtype {expected:?}, got {got:?}")]
+    DTypeMismatch {
+        /// Name of the affected tensor operand.
+        tensor: &'static str,
+        /// Expected legal data types.
+        expected: Vec<DType>,
+        /// Observed data type.
+        got: DType,
+    },
+
+    /// Buffer length in bytes or elements does not match expected extent.
+    #[error("tensor `{tensor}`: buffer element count {buffer_len} does not match expected element count {expected_len} for shape {shape:?}")]
+    BufferLengthMismatch {
+        /// Name of the affected tensor operand.
+        tensor: &'static str,
+        /// Number of elements available in buffer.
+        buffer_len: usize,
+        /// Number of elements required by the shape.
+        expected_len: usize,
+        /// Tensor shape.
+        shape: Vec<usize>,
+    },
+
+    /// Shape dimension mismatch between related tensors.
+    #[error("dimension mismatch on `{dim_name}`: expected {expected} (from `{expected_from}`), got {got} in `{tensor}`")]
+    DimensionMismatch {
+        /// Symbolic or named dimension (e.g. "T", "N", "Dff", "D").
+        dim_name: &'static str,
+        /// Source operand setting the expected dimension extent.
+        expected_from: &'static str,
+        /// Expected dimension size.
+        expected: usize,
+        /// Failing tensor operand name.
+        tensor: &'static str,
+        /// Observed dimension size.
+        got: usize,
+    },
+
+    /// Operation attribute invalid for execution.
+    #[error("invalid attribute `{attribute}` for op `{op}`: {reason}")]
+    InvalidAttribute {
+        /// Name of the operation.
+        op: &'static str,
+        /// Name of the attribute.
+        attribute: &'static str,
+        /// Detailed reason.
+        reason: String,
+    },
+
+    /// Missing required optional operand.
+    #[error("op `{op}` requires missing operand `{operand}`: {detail}")]
+    MissingOperand {
+        /// Name of the operation.
+        op: &'static str,
+        /// Missing operand name.
+        operand: &'static str,
+        /// Contextual reason.
+        detail: String,
+    },
+
+    /// Unsupported precision cast.
+    #[error("unsupported cast from `{from:?}` to `{to:?}`")]
+    UnsupportedCast {
+        /// Source data type.
+        from: DType,
+        /// Destination data type.
+        to: DType,
+    },
+
+    /// Multiple validation errors collected together (CONVENTIONS.md §1.4).
+    #[error("{count} validation error(s) in op `{op}`: {problems:?}")]
+    Multiple {
+        /// Name of the failing op.
+        op: &'static str,
+        /// Count of collected problems.
+        count: usize,
+        /// Vector of formatted problem descriptions.
+        problems: Vec<String>,
+    },
+}
+
+impl T0Error {
+    /// Helper to produce a `Multiple` error if problems were collected (CONVENTIONS.md §1.4).
+    pub fn from_problems(op: &'static str, problems: Vec<String>) -> Result<(), Self> {
+        if problems.is_empty() {
+            Ok(())
+        } else {
+            Err(Self::Multiple {
+                op,
+                count: problems.len(),
+                problems,
+            })
+        }
+    }
+}

--- a/crates/r9v-t0/src/error.rs
+++ b/crates/r9v-t0/src/error.rs
@@ -93,6 +93,15 @@ pub enum T0Error {
         to: DType,
     },
 
+    /// Validated same-dtype operands use incompatible backing representations.
+    #[error("op `{op}` has no bit-exact backing conversion for dtype `{dtype:?}`")]
+    BackingRepresentationMismatch {
+        /// Operation that requires a bit-exact transfer.
+        op: &'static str,
+        /// Shared logical data type of the operands.
+        dtype: DType,
+    },
+
     /// Multiple validation errors collected together (CONVENTIONS.md §1.4).
     #[error("{count} validation error(s) in op `{op}`: {problems:?}")]
     Multiple {

--- a/crates/r9v-t0/src/error.rs
+++ b/crates/r9v-t0/src/error.rs
@@ -3,7 +3,7 @@
 
 use r9v_ir::DType;
 
-/// Domain error enum for T0 reference op execution (CONVENTIONS.md §1.1).
+/// Domain error enum for T0 reference op execution (Spec 4 §2, CONVENTIONS.md §1.1).
 #[derive(Debug, thiserror::Error)]
 pub enum T0Error {
     /// Wrapping an IR-level error from `r9v-ir`.
@@ -106,7 +106,7 @@ pub enum T0Error {
 }
 
 impl T0Error {
-    /// Helper to produce a `Multiple` error if problems were collected (CONVENTIONS.md §1.4).
+    /// Helper to produce a `Multiple` error if problems were collected (Spec 4 §2, CONVENTIONS.md §1.4).
     pub fn from_problems(op: &'static str, problems: Vec<String>) -> Result<(), Self> {
         if problems.is_empty() {
             Ok(())

--- a/crates/r9v-t0/src/lib.rs
+++ b/crates/r9v-t0/src/lib.rs
@@ -14,6 +14,7 @@ pub mod dtype;
 pub mod error;
 pub mod norm;
 pub mod quant_act;
+pub mod residual_add;
 pub mod rope;
 pub mod tolerance;
 
@@ -24,7 +25,7 @@ pub use activation::{
 };
 pub use buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut, TypedBuffer};
 pub use cast::{cast, cast_f64_reference};
-pub use copy::copy;
+pub use copy::{copy, copy_f64_reference};
 pub use dtype::{
     bf16_to_f32, dtype_element_size, f16_to_f32, f32_to_bf16, f32_to_f16, fp8_e4m3_decode,
     fp8_e4m3_encode, fp8_e5m2_decode, fp8_e5m2_encode, read_f32_at, read_f64_at, write_f32_at,
@@ -36,11 +37,11 @@ pub use residual_add::{residual_add, residual_add_f64_reference};
 pub use rope::{rope, rope_f64_reference};
 pub use tolerance::Tolerance;
 
-pub mod residual_add;
-
 use r9v_ir::Op;
 
-/// Dispatches and executes an elementwise op using scalar T0 reference implementations.
+/// Dispatches and executes an elementwise op using scalar T0 reference implementations (Spec 1 §4.B, Spec 4 §2).
+///
+/// Enforces exact input and output operand arity for each supported elementwise op.
 pub fn execute_elementwise_op(
     op: &Op,
     inputs: &[TensorView<'_>],
@@ -48,7 +49,7 @@ pub fn execute_elementwise_op(
 ) -> Result<(), T0Error> {
     match op {
         Op::Norm(norm_op) => {
-            if inputs.len() < 2 || outputs.is_empty() {
+            if (inputs.len() != 2 && inputs.len() != 3) || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "norm",
                     attribute: "inputs/outputs",
@@ -61,7 +62,7 @@ pub fn execute_elementwise_op(
             }
             let x = &inputs[0];
             let weight = &inputs[1];
-            let bias = if inputs.len() >= 3 {
+            let bias = if inputs.len() == 3 {
                 Some(&inputs[2])
             } else {
                 None
@@ -69,7 +70,7 @@ pub fn execute_elementwise_op(
             norm(norm_op, x, weight, bias, &mut outputs[0])
         }
         Op::ResidualAdd(res_op) => {
-            if inputs.len() < 2 || outputs.is_empty() {
+            if inputs.len() != 2 || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "residual_add",
                     attribute: "inputs/outputs",
@@ -83,7 +84,7 @@ pub fn execute_elementwise_op(
             residual_add(res_op, &inputs[0], &inputs[1], &mut outputs[0])
         }
         Op::ActMul(act_mul_op) => {
-            if inputs.len() < 2 || outputs.is_empty() {
+            if inputs.len() != 2 || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "act_mul",
                     attribute: "inputs/outputs",
@@ -97,7 +98,7 @@ pub fn execute_elementwise_op(
             act_mul(act_mul_op, &inputs[0], &inputs[1], &mut outputs[0])
         }
         Op::Activation(act_op) => {
-            if inputs.is_empty() || outputs.is_empty() {
+            if inputs.len() != 1 || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "activation",
                     attribute: "inputs/outputs",
@@ -111,7 +112,7 @@ pub fn execute_elementwise_op(
             activation(act_op, &inputs[0], &mut outputs[0])
         }
         Op::Rope(rope_op) => {
-            if inputs.len() < 2 || outputs.is_empty() {
+            if inputs.len() != 2 || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "rope",
                     attribute: "inputs/outputs",
@@ -125,7 +126,7 @@ pub fn execute_elementwise_op(
             rope(rope_op, &inputs[0], &inputs[1], &mut outputs[0])
         }
         Op::Cast(cast_op) => {
-            if inputs.is_empty() || outputs.is_empty() {
+            if inputs.len() != 1 || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "cast",
                     attribute: "inputs/outputs",
@@ -139,7 +140,7 @@ pub fn execute_elementwise_op(
             cast(cast_op, &inputs[0], &mut outputs[0])
         }
         Op::Copy(copy_op) => {
-            if inputs.is_empty() || outputs.is_empty() {
+            if inputs.len() != 1 || outputs.len() != 1 {
                 return Err(T0Error::InvalidAttribute {
                     op: "copy",
                     attribute: "inputs/outputs",
@@ -153,7 +154,7 @@ pub fn execute_elementwise_op(
             copy(copy_op, &inputs[0], &mut outputs[0])
         }
         Op::QuantAct(quant_op) => {
-            if inputs.is_empty() || outputs.len() < 2 {
+            if inputs.len() != 1 || outputs.len() != 2 {
                 return Err(T0Error::InvalidAttribute {
                     op: "quant_act",
                     attribute: "inputs/outputs",

--- a/crates/r9v-t0/src/lib.rs
+++ b/crates/r9v-t0/src/lib.rs
@@ -1,1 +1,179 @@
-//! R9V CPU reference scalar T0 and SIMD T0v implementations (Spec 4, Spec 14 §2).
+// SPDX-License-Identifier: Apache-2.0
+//! R9V CPU reference scalar T0 implementations (Spec 1 §4.B, §6.4, Spec 4 §2, Card A1.5).
+//!
+//! T0 serves as the primary ground-truth oracle for all engine operations.
+//! Implementations are scalar, strictly deterministic, accumulate in f32 (or i32),
+//! and cast once on output according to the IR contract.
+
+pub mod act_mul;
+pub mod activation;
+pub mod buffer;
+pub mod cast;
+pub mod copy;
+pub mod dtype;
+pub mod error;
+pub mod norm;
+pub mod quant_act;
+pub mod rope;
+pub mod tolerance;
+
+pub use act_mul::{act_mul, act_mul_f64_reference};
+pub use activation::{
+    activation, activation_f64_reference, erf_f32, erf_f64, eval_activation_f32,
+    eval_activation_f64,
+};
+pub use buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut, TypedBuffer};
+pub use cast::{cast, cast_f64_reference};
+pub use copy::copy;
+pub use dtype::{
+    bf16_to_f32, dtype_element_size, f16_to_f32, f32_to_bf16, f32_to_f16, fp8_e4m3_decode,
+    fp8_e4m3_encode, fp8_e5m2_decode, fp8_e5m2_encode, read_f32_at, read_f64_at, write_f32_at,
+};
+pub use error::T0Error;
+pub use norm::{norm, norm_f64_reference};
+pub use quant_act::{quant_act, quant_act_f64_reference};
+pub use residual_add::{residual_add, residual_add_f64_reference};
+pub use rope::{rope, rope_f64_reference};
+pub use tolerance::Tolerance;
+
+pub mod residual_add;
+
+use r9v_ir::Op;
+
+/// Dispatches and executes an elementwise op using scalar T0 reference implementations.
+pub fn execute_elementwise_op(
+    op: &Op,
+    inputs: &[TensorView<'_>],
+    outputs: &mut [TensorViewMut<'_>],
+) -> Result<(), T0Error> {
+    match op {
+        Op::Norm(norm_op) => {
+            if inputs.len() < 2 || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "norm",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "norm requires 2 or 3 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            let x = &inputs[0];
+            let weight = &inputs[1];
+            let bias = if inputs.len() >= 3 {
+                Some(&inputs[2])
+            } else {
+                None
+            };
+            norm(norm_op, x, weight, bias, &mut outputs[0])
+        }
+        Op::ResidualAdd(res_op) => {
+            if inputs.len() < 2 || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "residual_add",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "residual_add requires 2 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            residual_add(res_op, &inputs[0], &inputs[1], &mut outputs[0])
+        }
+        Op::ActMul(act_mul_op) => {
+            if inputs.len() < 2 || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "act_mul",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "act_mul requires 2 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            act_mul(act_mul_op, &inputs[0], &inputs[1], &mut outputs[0])
+        }
+        Op::Activation(act_op) => {
+            if inputs.is_empty() || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "activation",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "activation requires 1 input and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            activation(act_op, &inputs[0], &mut outputs[0])
+        }
+        Op::Rope(rope_op) => {
+            if inputs.len() < 2 || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "rope requires 2 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            rope(rope_op, &inputs[0], &inputs[1], &mut outputs[0])
+        }
+        Op::Cast(cast_op) => {
+            if inputs.is_empty() || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "cast",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "cast requires 1 input and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            cast(cast_op, &inputs[0], &mut outputs[0])
+        }
+        Op::Copy(copy_op) => {
+            if inputs.is_empty() || outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "copy",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "copy requires 1 input and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            copy(copy_op, &inputs[0], &mut outputs[0])
+        }
+        Op::QuantAct(quant_op) => {
+            if inputs.is_empty() || outputs.len() < 2 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "quant_act",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "quant_act requires 1 input and 2 outputs, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            let (xq, rest) = outputs.split_at_mut(1);
+            quant_act(quant_op, &inputs[0], &mut xq[0], &mut rest[0])
+        }
+        other => Err(T0Error::InvalidAttribute {
+            op: other.op_name(),
+            attribute: "op",
+            reason: format!(
+                "op `{}` is not in the A1.5 elementwise group",
+                other.op_name()
+            ),
+        }),
+    }
+}

--- a/crates/r9v-t0/src/lib.rs
+++ b/crates/r9v-t0/src/lib.rs
@@ -32,7 +32,7 @@ pub use dtype::{
 };
 pub use error::T0Error;
 pub use norm::{norm, norm_f64_reference};
-pub use quant_act::{quant_act, quant_act_f64_reference};
+pub use quant_act::{fp8_e4m3_encode_f64_oracle, quant_act, quant_act_f64_reference};
 pub use residual_add::{residual_add, residual_add_f64_reference};
 pub use rope::{rope, rope_f64_reference};
 pub use tolerance::Tolerance;

--- a/crates/r9v-t0/src/norm.rs
+++ b/crates/r9v-t0/src/norm.rs
@@ -6,7 +6,7 @@ use r9v_ir::{DType, NormAxis, NormKind, NormOp};
 use crate::buffer::{TensorView, TensorViewMut};
 use crate::error::T0Error;
 
-/// Executes scalar T0 normalization (RMS or LayerNorm) per Spec 1 §4.B and §6.4.
+/// Executes scalar T0 normalization (RMS or LayerNorm) per Spec 1 §4.B, §6.4, Spec 4 §2.
 ///
 /// Accumulates mean/variance in f32 in ascending index order and casts once on output.
 pub fn norm(
@@ -16,7 +16,35 @@ pub fn norm(
     bias: Option<&TensorView<'_>>,
     y: &mut TensorViewMut<'_>,
 ) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    weight.validate_backing("weight")?;
+    if let Some(b) = bias {
+        b.validate_backing("bias")?;
+    }
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
+
+    if !op.eps.is_finite() || op.eps <= 0.0 {
+        problems.push(format!("eps must be finite and > 0, got {}", op.eps));
+    }
+    if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "out_dtype must be f16, bf16, or f32, got {:?}",
+            op.out_dtype
+        ));
+    }
+    if !op.weight_offset.is_finite() {
+        problems.push(format!(
+            "weight_offset must be finite, got {}",
+            op.weight_offset
+        ));
+    }
+    if let NormAxis::Head(d) = op.axis {
+        if d == 0 {
+            problems.push("NormAxis::Head(d): d must be > 0".to_string());
+        }
+    }
 
     if x.rank() != 2 {
         problems.push(format!(
@@ -225,7 +253,7 @@ pub fn norm(
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.B, Spec 4 §2).
 pub fn norm_f64_reference(
     op: &NormOp,
     x: &[f64],

--- a/crates/r9v-t0/src/norm.rs
+++ b/crates/r9v-t0/src/norm.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of normalization ops (RMS and LayerNorm) (Spec 1 §4.B, §6.4, Spec 4 §2).
+
+use r9v_ir::{DType, NormAxis, NormKind, NormOp};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Executes scalar T0 normalization (RMS or LayerNorm) per Spec 1 §4.B and §6.4.
+///
+/// Accumulates mean/variance in f32 in ascending index order and casts once on output.
+pub fn norm(
+    op: &NormOp,
+    x: &TensorView<'_>,
+    weight: &TensorView<'_>,
+    bias: Option<&TensorView<'_>>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if x.rank() != 2 {
+        problems.push(format!(
+            "input x: expected rank 2 [T, N], got rank {} with shape {:?}",
+            x.rank(),
+            x.shape()
+        ));
+    }
+    if weight.rank() != 1 {
+        problems.push(format!(
+            "weight: expected rank 1 [N], got rank {} with shape {:?}",
+            weight.rank(),
+            weight.shape()
+        ));
+    }
+    if y.rank() != 2 {
+        problems.push(format!(
+            "output y: expected rank 2 [T, N], got rank {} with shape {:?}",
+            y.rank(),
+            y.shape()
+        ));
+    }
+    if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "input x: expected f16, bf16, or f32, got {:?}",
+            x.dtype()
+        ));
+    }
+    if weight.dtype() != DType::F32 {
+        problems.push(format!("weight: expected f32, got {:?}", weight.dtype()));
+    }
+    if y.dtype() != op.out_dtype {
+        problems.push(format!(
+            "output y: expected out_dtype {:?}, got {:?}",
+            op.out_dtype,
+            y.dtype()
+        ));
+    }
+
+    if let Some(b) = bias {
+        if b.rank() != 1 {
+            problems.push(format!(
+                "bias: expected rank 1 [N], got rank {} with shape {:?}",
+                b.rank(),
+                b.shape()
+            ));
+        }
+        if b.dtype() != DType::F32 {
+            problems.push(format!("bias: expected f32, got {:?}", b.dtype()));
+        }
+    }
+
+    if x.rank() == 2 && weight.rank() == 1 {
+        let n = x.shape()[1];
+        if weight.shape()[0] != n {
+            problems.push(format!(
+                "weight dimension {} does not match x feature dimension N={}",
+                weight.shape()[0],
+                n
+            ));
+        }
+        if let Some(b) = bias {
+            if b.rank() == 1 && b.shape()[0] != n {
+                problems.push(format!(
+                    "bias dimension {} does not match x feature dimension N={}",
+                    b.shape()[0],
+                    n
+                ));
+            }
+        }
+        if let NormAxis::Head(d) = op.axis {
+            if d == 0 {
+                problems.push("NormAxis::Head(d): d must be > 0".to_string());
+            } else if !n.is_multiple_of(d as usize) {
+                problems.push(format!(
+                    "feature dimension N={n} is not divisible by head dimension d={d}"
+                ));
+            }
+        }
+    }
+
+    if x.rank() == 2 && y.rank() == 2 && y.shape() != x.shape() {
+        problems.push(format!(
+            "output y shape {:?} does not match input x shape {:?}",
+            y.shape(),
+            x.shape()
+        ));
+    }
+
+    T0Error::from_problems("norm", problems)?;
+
+    let t = x.shape()[0];
+    let n = x.shape()[1];
+
+    match op.axis {
+        NormAxis::Last => {
+            for row in 0..t {
+                let row_offset = row * n;
+                match op.kind {
+                    NormKind::Rms => {
+                        let mut sum_sq = 0.0f32;
+                        for i in 0..n {
+                            let val = x.read_f32(row_offset + i);
+                            sum_sq += val * val;
+                        }
+                        let mean_sq = sum_sq / (n as f32);
+                        let inv_rms = 1.0f32 / (mean_sq + op.eps).sqrt();
+
+                        for i in 0..n {
+                            let val = x.read_f32(row_offset + i);
+                            let w = weight.read_f32(i) + op.weight_offset;
+                            let b = bias.map(|b_view| b_view.read_f32(i)).unwrap_or(0.0f32);
+                            let normalized = val * inv_rms;
+                            let out = normalized * w + b;
+                            y.write_f32(row_offset + i, out);
+                        }
+                    }
+                    NormKind::Layer => {
+                        let mut sum = 0.0f32;
+                        for i in 0..n {
+                            sum += x.read_f32(row_offset + i);
+                        }
+                        let mean = sum / (n as f32);
+
+                        let mut var_sum = 0.0f32;
+                        for i in 0..n {
+                            let diff = x.read_f32(row_offset + i) - mean;
+                            var_sum += diff * diff;
+                        }
+                        let var = var_sum / (n as f32);
+                        let inv_sd = 1.0f32 / (var + op.eps).sqrt();
+
+                        for i in 0..n {
+                            let diff = x.read_f32(row_offset + i) - mean;
+                            let w = weight.read_f32(i) + op.weight_offset;
+                            let b = bias.map(|b_view| b_view.read_f32(i)).unwrap_or(0.0f32);
+                            let normalized = diff * inv_sd;
+                            let out = normalized * w + b;
+                            y.write_f32(row_offset + i, out);
+                        }
+                    }
+                }
+            }
+        }
+        NormAxis::Head(d_u32) => {
+            let d = d_u32 as usize;
+            let num_heads = n / d;
+
+            for row in 0..t {
+                let row_offset = row * n;
+                for h in 0..num_heads {
+                    let head_offset = row_offset + h * d;
+                    match op.kind {
+                        NormKind::Rms => {
+                            let mut sum_sq = 0.0f32;
+                            for j in 0..d {
+                                let val = x.read_f32(head_offset + j);
+                                sum_sq += val * val;
+                            }
+                            let mean_sq = sum_sq / (d as f32);
+                            let inv_rms = 1.0f32 / (mean_sq + op.eps).sqrt();
+
+                            for j in 0..d {
+                                let idx = head_offset + j;
+                                let w_idx = h * d + j;
+                                let val = x.read_f32(idx);
+                                let w = weight.read_f32(w_idx) + op.weight_offset;
+                                let b = bias.map(|b_view| b_view.read_f32(w_idx)).unwrap_or(0.0f32);
+                                let normalized = val * inv_rms;
+                                let out = normalized * w + b;
+                                y.write_f32(idx, out);
+                            }
+                        }
+                        NormKind::Layer => {
+                            let mut sum = 0.0f32;
+                            for j in 0..d {
+                                sum += x.read_f32(head_offset + j);
+                            }
+                            let mean = sum / (d as f32);
+
+                            let mut var_sum = 0.0f32;
+                            for j in 0..d {
+                                let diff = x.read_f32(head_offset + j) - mean;
+                                var_sum += diff * diff;
+                            }
+                            let var = var_sum / (d as f32);
+                            let inv_sd = 1.0f32 / (var + op.eps).sqrt();
+
+                            for j in 0..d {
+                                let idx = head_offset + j;
+                                let w_idx = h * d + j;
+                                let diff = x.read_f32(idx) - mean;
+                                let w = weight.read_f32(w_idx) + op.weight_offset;
+                                let b = bias.map(|b_view| b_view.read_f32(w_idx)).unwrap_or(0.0f32);
+                                let normalized = diff * inv_sd;
+                                let out = normalized * w + b;
+                                y.write_f32(idx, out);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+pub fn norm_f64_reference(
+    op: &NormOp,
+    x: &[f64],
+    shape: [usize; 2],
+    weight: &[f64],
+    bias: Option<&[f64]>,
+    weight_offset: f64,
+    eps: f64,
+) -> Vec<f64> {
+    let [t, n] = shape;
+    assert_eq!(x.len(), t * n);
+    assert_eq!(weight.len(), n);
+    if let Some(b) = bias {
+        assert_eq!(b.len(), n);
+    }
+    let mut out = vec![0.0f64; t * n];
+
+    match op.axis {
+        NormAxis::Last => {
+            for row in 0..t {
+                let row_offset = row * n;
+                match op.kind {
+                    NormKind::Rms => {
+                        let mut sum_sq = 0.0f64;
+                        for i in 0..n {
+                            let v = x[row_offset + i];
+                            sum_sq += v * v;
+                        }
+                        let mean_sq = sum_sq / (n as f64);
+                        let inv_rms = 1.0f64 / (mean_sq + eps).sqrt();
+                        for i in 0..n {
+                            let v = x[row_offset + i];
+                            let w = weight[i] + weight_offset;
+                            let b = bias.map(|b_slice| b_slice[i]).unwrap_or(0.0f64);
+                            out[row_offset + i] = (v * inv_rms) * w + b;
+                        }
+                    }
+                    NormKind::Layer => {
+                        let mut sum = 0.0f64;
+                        for i in 0..n {
+                            sum += x[row_offset + i];
+                        }
+                        let mean = sum / (n as f64);
+                        let mut var_sum = 0.0f64;
+                        for i in 0..n {
+                            let diff = x[row_offset + i] - mean;
+                            var_sum += diff * diff;
+                        }
+                        let var = var_sum / (n as f64);
+                        let inv_sd = 1.0f64 / (var + eps).sqrt();
+                        for i in 0..n {
+                            let diff = x[row_offset + i] - mean;
+                            let w = weight[i] + weight_offset;
+                            let b = bias.map(|b_slice| b_slice[i]).unwrap_or(0.0f64);
+                            out[row_offset + i] = (diff * inv_sd) * w + b;
+                        }
+                    }
+                }
+            }
+        }
+        NormAxis::Head(d_u32) => {
+            let d = d_u32 as usize;
+            let num_heads = n / d;
+            for row in 0..t {
+                let row_offset = row * n;
+                for h in 0..num_heads {
+                    let head_offset = row_offset + h * d;
+                    match op.kind {
+                        NormKind::Rms => {
+                            let mut sum_sq = 0.0f64;
+                            for j in 0..d {
+                                let v = x[head_offset + j];
+                                sum_sq += v * v;
+                            }
+                            let mean_sq = sum_sq / (d as f64);
+                            let inv_rms = 1.0f64 / (mean_sq + eps).sqrt();
+                            for j in 0..d {
+                                let idx = head_offset + j;
+                                let w_idx = h * d + j;
+                                let v = x[idx];
+                                let w = weight[w_idx] + weight_offset;
+                                let b = bias.map(|b_slice| b_slice[w_idx]).unwrap_or(0.0f64);
+                                out[idx] = (v * inv_rms) * w + b;
+                            }
+                        }
+                        NormKind::Layer => {
+                            let mut sum = 0.0f64;
+                            for j in 0..d {
+                                sum += x[head_offset + j];
+                            }
+                            let mean = sum / (d as f64);
+                            let mut var_sum = 0.0f64;
+                            for j in 0..d {
+                                let diff = x[head_offset + j] - mean;
+                                var_sum += diff * diff;
+                            }
+                            let var = var_sum / (d as f64);
+                            let inv_sd = 1.0f64 / (var + eps).sqrt();
+                            for j in 0..d {
+                                let idx = head_offset + j;
+                                let w_idx = h * d + j;
+                                let diff = x[idx] - mean;
+                                let w = weight[w_idx] + weight_offset;
+                                let b = bias.map(|b_slice| b_slice[w_idx]).unwrap_or(0.0f64);
+                                out[idx] = (diff * inv_sd) * w + b;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}

--- a/crates/r9v-t0/src/quant_act.rs
+++ b/crates/r9v-t0/src/quant_act.rs
@@ -210,6 +210,55 @@ pub fn quant_act(
     Ok(())
 }
 
+/// Independent 64-bit oracle encoding of an `f64` value to an OCP FP8 E4M3 byte (Spec 1 §2.1, Spec 4 §2).
+///
+/// Implemented directly from the E4M3 grid definition in `f64` arithmetic without calling the
+/// production [`crate::dtype::fp8_e4m3_encode`] (or [`crate::dtype::fp8_e4m3_decode`]), so the
+/// [`quant_act_f64_reference`] E4M3 path stays an independent check on the production encoder:
+/// magnitudes above 448.0 saturate to ±448, NaN maps to `0x7F`, signed zero is preserved, and
+/// all other values round to the nearest grid value with ties to even.
+pub fn fp8_e4m3_encode_f64_oracle(v: f64) -> u8 {
+    if v.is_nan() {
+        return 0x7F;
+    }
+    if v.abs() > 448.0 {
+        return if v < 0.0 { 0xFE } else { 0x7E };
+    }
+    if v == 0.0 {
+        return if v.is_sign_negative() { 0x80 } else { 0x00 };
+    }
+    let mut best: u8 = 0x00;
+    let mut best_d = f64::INFINITY;
+    for code in 0u16..256u16 {
+        let b = code as u8;
+        if b == 0x7F || b == 0xFF {
+            continue;
+        }
+        let grid = fp8_e4m3_grid_value_f64(b);
+        let d = (grid - v).abs();
+        if d < best_d || (d == best_d && (b & 1) == 0 && (best & 1) == 1) {
+            best_d = d;
+            best = b;
+        }
+    }
+    best
+}
+
+/// Exact `f64` value of a finite OCP FP8 E4M3 code from the format definition (Spec 1 §2.1).
+///
+/// Callers skip the two NaN codes (`0x7F`, `0xFF`); exponent zero denotes subnormals at 2^-6.
+fn fp8_e4m3_grid_value_f64(b: u8) -> f64 {
+    let s = (b >> 7) & 1;
+    let e = (b >> 3) & 0x0F;
+    let m = b & 0x07;
+    let sign = if s == 1 { -1.0f64 } else { 1.0f64 };
+    if e == 0 {
+        sign * (f64::from(m) / 8.0) * 2.0f64.powi(-6)
+    } else {
+        sign * (1.0 + f64::from(m) / 8.0) * 2.0f64.powi(i32::from(e) - 7)
+    }
+}
+
 /// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.A, Spec 2 §3.4, Spec 4 §2).
 pub fn quant_act_f64_reference(
     op: &QuantActOp,
@@ -257,7 +306,7 @@ pub fn quant_act_f64_reference(
                                 xq[idx] = 0.0f64;
                             } else {
                                 let unquant = x[idx] / s;
-                                let code = fp8_e4m3_encode(unquant as f32);
+                                let code = fp8_e4m3_encode_f64_oracle(unquant);
                                 xq[idx] = code as f64;
                             }
                         }

--- a/crates/r9v-t0/src/quant_act.rs
+++ b/crates/r9v-t0/src/quant_act.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of activation quantization op (Spec 1 §4.A, Spec 2 §3.4, Spec 4 §2).
+
+use r9v_ir::{DType, QuantActOp, QuantScheme};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::dtype::fp8_e4m3_encode;
+use crate::error::T0Error;
+
+/// Executes scalar T0 activation quantization (Spec 1 §4.A, Spec 2 §3.4).
+pub fn quant_act(
+    op: &QuantActOp,
+    x: &TensorView<'_>,
+    xq: &mut TensorViewMut<'_>,
+    scale: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if x.rank() != 2 {
+        problems.push(format!(
+            "input x: expected rank 2 [T, N], got rank {} with shape {:?}",
+            x.rank(),
+            x.shape()
+        ));
+    }
+    if xq.rank() != 2 {
+        problems.push(format!(
+            "output xq: expected rank 2 [T, N], got rank {} with shape {:?}",
+            xq.rank(),
+            xq.shape()
+        ));
+    }
+    if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "input x: expected f16, bf16, or f32, got {:?}",
+            x.dtype()
+        ));
+    }
+    if xq.dtype() != op.target {
+        problems.push(format!(
+            "output xq dtype {:?} does not match op target {:?}",
+            xq.dtype(),
+            op.target
+        ));
+    }
+    if scale.dtype() != DType::F32 {
+        problems.push(format!(
+            "output scale: expected f32, got {:?}",
+            scale.dtype()
+        ));
+    }
+
+    if x.rank() == 2 && xq.rank() == 2 && x.shape() != xq.shape() {
+        problems.push(format!(
+            "output xq shape {:?} does not match input x shape {:?}",
+            xq.shape(),
+            x.shape()
+        ));
+    }
+
+    if x.rank() == 2 {
+        let t = x.shape()[0];
+        let n = x.shape()[1];
+
+        match op.scheme {
+            QuantScheme::PerToken => {
+                if scale.rank() != 1 || scale.shape()[0] != t {
+                    problems.push(format!(
+                        "PerToken scale: expected rank 1 [{t}], got rank {} with shape {:?}",
+                        scale.rank(),
+                        scale.shape()
+                    ));
+                }
+            }
+            QuantScheme::PerBlock32 => {
+                if op.target != DType::I8 {
+                    problems.push(format!(
+                        "PerBlock32 only supports i8 target, got {:?}",
+                        op.target
+                    ));
+                }
+                if !n.is_multiple_of(32) {
+                    problems.push(format!("PerBlock32 requires N={n} divisible by 32"));
+                } else {
+                    let expected_blocks = n / 32;
+                    if scale.rank() != 2 || scale.shape() != [t, expected_blocks] {
+                        problems.push(format!(
+                            "PerBlock32 scale: expected shape [{t}, {expected_blocks}], got shape {:?}",
+                            scale.shape()
+                        ));
+                    }
+                }
+            }
+            _ => {
+                problems.push(format!(
+                    "quant_act only supports PerToken or PerBlock32, got {:?}",
+                    op.scheme
+                ));
+            }
+        }
+    }
+
+    T0Error::from_problems("quant_act", problems)?;
+
+    let t = x.shape()[0];
+    let n = x.shape()[1];
+
+    match op.scheme {
+        QuantScheme::PerToken => {
+            for row in 0..t {
+                let row_offset = row * n;
+                let mut absmax = 0.0f32;
+                for i in 0..n {
+                    let v = x.read_f32(row_offset + i).abs();
+                    if v > absmax {
+                        absmax = v;
+                    }
+                }
+
+                // DECISION(A1.5): for quant_act with zero absmax (all-zero row or block), scale is emitted as 0.0 and quantized elements as 0 (or 0x00 for e4m3); rejected emitting scale 1.0 or NaN to avoid artificial scale inflation on empty/zero padding tokens.
+                match op.target {
+                    DType::I8 => {
+                        let s = absmax / 127.0f32;
+                        scale.write_f32(row, s);
+
+                        // DECISION(A1.5): for symmetric i8 quantization in quant_act, scaled values are rounded with round_ties_even and clamped to [-127, 127]; rejected [-128, 127] because Spec 1 §6.2 specifies accumulation bound 127·127·K assuming symmetric bounds.
+                        for i in 0..n {
+                            let idx = row_offset + i;
+                            if s == 0.0f32 {
+                                xq.write_f32(idx, 0.0f32);
+                            } else {
+                                let val = x.read_f32(idx);
+                                let unquant = val / s;
+                                let q = unquant.round_ties_even().clamp(-127.0f32, 127.0f32);
+                                xq.write_f32(idx, q);
+                            }
+                        }
+                    }
+                    DType::E4m3 => {
+                        let s = absmax / 448.0f32;
+                        scale.write_f32(row, s);
+
+                        for i in 0..n {
+                            let idx = row_offset + i;
+                            if s == 0.0f32 {
+                                xq.write_byte(idx, 0x00);
+                            } else {
+                                let val = x.read_f32(idx);
+                                let unquant = val / s;
+                                let code = fp8_e4m3_encode(unquant);
+                                xq.write_byte(idx, code);
+                            }
+                        }
+                    }
+                    _ => unreachable!("validated target"),
+                }
+            }
+        }
+        QuantScheme::PerBlock32 => {
+            let num_blocks = n / 32;
+            for row in 0..t {
+                let row_offset = row * n;
+                for b in 0..num_blocks {
+                    let block_offset = row_offset + b * 32;
+                    let mut absmax = 0.0f32;
+                    for j in 0..32 {
+                        let v = x.read_f32(block_offset + j).abs();
+                        if v > absmax {
+                            absmax = v;
+                        }
+                    }
+
+                    let s = absmax / 127.0f32;
+                    scale.write_f32(row * num_blocks + b, s);
+
+                    for j in 0..32 {
+                        let idx = block_offset + j;
+                        if s == 0.0f32 {
+                            xq.write_f32(idx, 0.0f32);
+                        } else {
+                            let val = x.read_f32(idx);
+                            let unquant = val / s;
+                            let q = unquant.round_ties_even().clamp(-127.0f32, 127.0f32);
+                            xq.write_f32(idx, q);
+                        }
+                    }
+                }
+            }
+        }
+        _ => unreachable!("validated scheme"),
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+pub fn quant_act_f64_reference(
+    op: &QuantActOp,
+    x: &[f64],
+    shape: [usize; 2],
+) -> (Vec<f64>, Vec<f64>) {
+    let [t, n] = shape;
+    assert_eq!(x.len(), t * n);
+
+    match op.scheme {
+        QuantScheme::PerToken => {
+            let mut scales = vec![0.0f64; t];
+            let mut xq = vec![0.0f64; t * n];
+
+            for (row, scale_out) in scales.iter_mut().enumerate().take(t) {
+                let row_offset = row * n;
+                let mut absmax = 0.0f64;
+                for i in 0..n {
+                    let v = x[row_offset + i].abs();
+                    if v > absmax {
+                        absmax = v;
+                    }
+                }
+
+                match op.target {
+                    DType::I8 => {
+                        let s = absmax / 127.0f64;
+                        *scale_out = s;
+                        for i in 0..n {
+                            let idx = row_offset + i;
+                            if s == 0.0f64 {
+                                xq[idx] = 0.0f64;
+                            } else {
+                                let unquant = x[idx] / s;
+                                xq[idx] = unquant.round_ties_even().clamp(-127.0f64, 127.0f64);
+                            }
+                        }
+                    }
+                    DType::E4m3 => {
+                        let s = absmax / 448.0f64;
+                        *scale_out = s;
+                        for i in 0..n {
+                            let idx = row_offset + i;
+                            if s == 0.0f64 {
+                                xq[idx] = 0.0f64;
+                            } else {
+                                let unquant = x[idx] / s;
+                                let code = fp8_e4m3_encode(unquant as f32);
+                                xq[idx] = code as f64;
+                            }
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            (xq, scales)
+        }
+        QuantScheme::PerBlock32 => {
+            let num_blocks = n / 32;
+            let mut scales = vec![0.0f64; t * num_blocks];
+            let mut xq = vec![0.0f64; t * n];
+
+            for row in 0..t {
+                let row_offset = row * n;
+                for b in 0..num_blocks {
+                    let block_offset = row_offset + b * 32;
+                    let mut absmax = 0.0f64;
+                    for j in 0..32 {
+                        let v = x[block_offset + j].abs();
+                        if v > absmax {
+                            absmax = v;
+                        }
+                    }
+
+                    let s = absmax / 127.0f64;
+                    scales[row * num_blocks + b] = s;
+
+                    for j in 0..32 {
+                        let idx = block_offset + j;
+                        if s == 0.0f64 {
+                            xq[idx] = 0.0f64;
+                        } else {
+                            let unquant = x[idx] / s;
+                            xq[idx] = unquant.round_ties_even().clamp(-127.0f64, 127.0f64);
+                        }
+                    }
+                }
+            }
+            (xq, scales)
+        }
+        _ => unreachable!(),
+    }
+}

--- a/crates/r9v-t0/src/quant_act.rs
+++ b/crates/r9v-t0/src/quant_act.rs
@@ -7,14 +7,25 @@ use crate::buffer::{TensorView, TensorViewMut};
 use crate::dtype::fp8_e4m3_encode;
 use crate::error::T0Error;
 
-/// Executes scalar T0 activation quantization (Spec 1 §4.A, Spec 2 §3.4).
+/// Executes scalar T0 activation quantization (Spec 1 §4.A, Spec 2 §3.4, Spec 4 §2).
 pub fn quant_act(
     op: &QuantActOp,
     x: &TensorView<'_>,
     xq: &mut TensorViewMut<'_>,
     scale: &mut TensorViewMut<'_>,
 ) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    xq.validate_backing("xq")?;
+    scale.validate_backing("scale")?;
+
     let mut problems = Vec::new();
+
+    if op.target != DType::I8 && op.target != DType::E4m3 {
+        problems.push(format!(
+            "quant_act target must be i8 or e4m3, got {:?}",
+            op.target
+        ));
+    }
 
     if x.rank() != 2 {
         problems.push(format!(
@@ -64,6 +75,12 @@ pub fn quant_act(
 
         match op.scheme {
             QuantScheme::PerToken => {
+                if op.target != DType::I8 && op.target != DType::E4m3 {
+                    problems.push(format!(
+                        "PerToken only supports i8 or e4m3 target, got {:?}",
+                        op.target
+                    ));
+                }
                 if scale.rank() != 1 || scale.shape()[0] != t {
                     problems.push(format!(
                         "PerToken scale: expected rank 1 [{t}], got rank {} with shape {:?}",
@@ -193,7 +210,7 @@ pub fn quant_act(
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.A, Spec 2 §3.4, Spec 4 §2).
 pub fn quant_act_f64_reference(
     op: &QuantActOp,
     x: &[f64],

--- a/crates/r9v-t0/src/residual_add.rs
+++ b/crates/r9v-t0/src/residual_add.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of elementwise residual addition (Spec 1 §4.B, §6.1, Spec 4 §2).
+
+use r9v_ir::{DType, ResidualAddOp};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Executes scalar T0 residual addition: `a + b` in f32, cast to `out_dtype` (Spec 1 §4.B).
+pub fn residual_add(
+    op: &ResidualAddOp,
+    a: &TensorView<'_>,
+    b: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if a.shape() != b.shape() {
+        problems.push(format!(
+            "operand b shape {:?} does not match operand a shape {:?}",
+            b.shape(),
+            a.shape()
+        ));
+    }
+    if a.shape() != y.shape() {
+        problems.push(format!(
+            "output y shape {:?} does not match operand a shape {:?}",
+            y.shape(),
+            a.shape()
+        ));
+    }
+    if !matches!(a.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "operand a: expected f16, bf16, or f32, got {:?}",
+            a.dtype()
+        ));
+    }
+    if !matches!(b.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "operand b: expected f16, bf16, or f32, got {:?}",
+            b.dtype()
+        ));
+    }
+    if y.dtype() != op.out_dtype {
+        problems.push(format!(
+            "output y: expected out_dtype {:?}, got {:?}",
+            op.out_dtype,
+            y.dtype()
+        ));
+    }
+
+    T0Error::from_problems("residual_add", problems)?;
+
+    let num_elem = a.num_elements();
+    for i in 0..num_elem {
+        let val_a = a.read_f32(i);
+        let val_b = b.read_f32(i);
+        let sum = val_a + val_b;
+        y.write_f32(i, sum);
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+pub fn residual_add_f64_reference(a: &[f64], b: &[f64]) -> Vec<f64> {
+    assert_eq!(a.len(), b.len());
+    a.iter().zip(b.iter()).map(|(&x, &y)| x + y).collect()
+}

--- a/crates/r9v-t0/src/residual_add.rs
+++ b/crates/r9v-t0/src/residual_add.rs
@@ -6,13 +6,17 @@ use r9v_ir::{DType, ResidualAddOp};
 use crate::buffer::{TensorView, TensorViewMut};
 use crate::error::T0Error;
 
-/// Executes scalar T0 residual addition: `a + b` in f32, cast to `out_dtype` (Spec 1 §4.B).
+/// Executes scalar T0 residual addition: `a + b` in f32, cast to `out_dtype` (Spec 1 §4.B, Spec 1 §6.1, Spec 1 §6.4, Spec 4 §2).
 pub fn residual_add(
     op: &ResidualAddOp,
     a: &TensorView<'_>,
     b: &TensorView<'_>,
     y: &mut TensorViewMut<'_>,
 ) -> Result<(), T0Error> {
+    a.validate_backing("a")?;
+    b.validate_backing("b")?;
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
 
     if a.shape() != b.shape() {
@@ -62,7 +66,7 @@ pub fn residual_add(
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.B, Spec 4 §2).
 pub fn residual_add_f64_reference(a: &[f64], b: &[f64]) -> Vec<f64> {
     assert_eq!(a.len(), b.len());
     a.iter().zip(b.iter()).map(|(&x, &y)| x + y).collect()

--- a/crates/r9v-t0/src/rope.rs
+++ b/crates/r9v-t0/src/rope.rs
@@ -103,14 +103,116 @@ fn compute_freqs_and_phases_f32(
     (phases, eff_mscale)
 }
 
-/// Executes scalar T0 Rotary Position Embedding (RoPE) (Spec 1 §4.B, §6.4).
+/// Executes scalar T0 Rotary Position Embedding (RoPE) (Spec 1 §4.B, Spec 1 §6.4, Spec 4 §2).
 pub fn rope(
     op: &RopeOp,
     x: &TensorView<'_>,
     positions: &TensorView<'_>,
     y: &mut TensorViewMut<'_>,
 ) -> Result<(), T0Error> {
+    if positions.rank() == 0 {
+        return Err(T0Error::RankMismatch {
+            tensor: "positions",
+            expected: if op.mrope_sections.is_some() { 2 } else { 1 },
+            got: 0,
+            shape: positions.shape().to_vec(),
+        });
+    }
+
+    x.validate_backing("x")?;
+    positions.validate_backing("positions")?;
+    y.validate_backing("y")?;
+
     let mut problems = Vec::new();
+
+    if op.rot_dim == 0 || !op.rot_dim.is_multiple_of(2) {
+        problems.push(format!(
+            "rot_dim must be positive and even, got {}",
+            op.rot_dim
+        ));
+    }
+    if !op.theta.is_finite() || op.theta <= 0.0 {
+        problems.push(format!("theta must be finite and > 0, got {}", op.theta));
+    }
+    if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "out_dtype must be f16, bf16, or f32, got {:?}",
+            op.out_dtype
+        ));
+    }
+    if let Some(sections) = op.mrope_sections {
+        if sections.contains(&0) {
+            problems.push("mrope sections must be positive".to_string());
+        }
+        if sections.iter().any(|&s| s % 2 != 0) {
+            problems.push("mrope section dimensions must be even".to_string());
+        }
+        match sections.iter().try_fold(0u32, |sum, &s| sum.checked_add(s)) {
+            Some(total) if total > op.rot_dim => {
+                problems.push(format!(
+                    "sum of mrope sections {total} exceeds rot_dim {}",
+                    op.rot_dim
+                ));
+            }
+            None => {
+                problems.push("sum of mrope sections exceeds u32::MAX".to_string());
+            }
+            Some(_) => {}
+        }
+    }
+    match op.scaling {
+        RopeScaling::None => {}
+        RopeScaling::Linear(factor) => {
+            if !factor.is_finite() || factor <= 0.0 {
+                problems.push(format!(
+                    "scaling factor must be finite and > 0, got {factor}"
+                ));
+            }
+        }
+        RopeScaling::Yarn {
+            factor,
+            beta_fast,
+            beta_slow,
+            orig_ctx,
+            mscale,
+        } => {
+            if !factor.is_finite() || factor <= 0.0 {
+                problems.push(format!(
+                    "scaling factor must be finite and > 0, got {factor}"
+                ));
+            }
+            if !beta_fast.is_finite() || beta_fast <= 0.0 {
+                problems.push(format!(
+                    "scaling beta_fast must be finite and > 0, got {beta_fast}"
+                ));
+            }
+            if !beta_slow.is_finite() || beta_slow <= 0.0 {
+                problems.push(format!(
+                    "scaling beta_slow must be finite and > 0, got {beta_slow}"
+                ));
+            }
+            if beta_slow > beta_fast {
+                problems.push(format!(
+                    "scaling beta_slow ({beta_slow}) cannot exceed beta_fast ({beta_fast})"
+                ));
+            }
+            if orig_ctx == 0 {
+                problems.push("scaling orig_ctx must be > 0".to_string());
+            }
+            if !mscale.is_finite() || mscale <= 0.0 {
+                problems.push(format!(
+                    "scaling mscale must be finite and > 0, got {mscale}"
+                ));
+            }
+        }
+        RopeScaling::Dynamic => {
+            if op.rot_dim == 2 {
+                problems.push(
+                    "rot_dim 2 is invalid for Dynamic RoPE: exponent rot_dim / (rot_dim - 2) requires rot_dim > 2 to avoid division by zero".to_string(),
+                );
+            }
+        }
+    }
 
     if x.rank() != 3 {
         problems.push(format!(
@@ -176,12 +278,6 @@ pub fn rope(
             problems.push(format!(
                 "rot_dim {} exceeds head dimension D={}",
                 op.rot_dim, d
-            ));
-        }
-        if op.rot_dim == 0 || !op.rot_dim.is_multiple_of(2) {
-            problems.push(format!(
-                "rot_dim must be positive and even, got {}",
-                op.rot_dim
             ));
         }
         if y.rank() == 3 && y.shape() != x.shape() {
@@ -262,7 +358,7 @@ pub fn rope(
     Ok(())
 }
 
-/// Straightforward 64-bit floating point reference implementation for testing against T0.
+/// Straightforward 64-bit floating point reference implementation for testing against T0 (Spec 1 §4.B, Spec 4 §2).
 #[allow(clippy::needless_range_loop)]
 pub fn rope_f64_reference(
     op: &RopeOp,
@@ -271,6 +367,13 @@ pub fn rope_f64_reference(
     positions: &[u32],
     positions_is_2d: bool,
 ) -> Vec<f64> {
+    if op.scaling == RopeScaling::Dynamic {
+        assert!(
+            op.rot_dim > 2,
+            "rot_dim {} is invalid for Dynamic RoPE scaling: requires rot_dim > 2",
+            op.rot_dim
+        );
+    }
     let [t, h, d] = shape;
     assert_eq!(x.len(), t * h * d);
     let mut out = vec![0.0f64; t * h * d];

--- a/crates/r9v-t0/src/rope.rs
+++ b/crates/r9v-t0/src/rope.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Scalar T0 implementation of Rotary Position Embedding (RoPE) (Spec 1 §4.B, §6.4, Spec 4 §2).
+
+use r9v_ir::{DType, RopeOp, RopeScaling, RopeStyle};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Precomputes RoPE frequencies for a given token position and rotary dimension.
+#[allow(clippy::needless_range_loop)]
+fn compute_freqs_and_phases_f32(
+    op: &RopeOp,
+    token_idx: usize,
+    positions: &TensorView<'_>,
+) -> (Vec<f32>, f32) {
+    let m = (op.rot_dim / 2) as usize;
+    let mut phases = vec![0.0f32; m];
+    let mut eff_mscale = 1.0f32;
+
+    // DECISION(A1.5): for mrope with mrope_sections [s0, s1, s2], section dimensions represent channel counts where section i allocates si/2 frequency pairs (Spec 1 §4.B, r9v-ir RopeOp); frequency pair k uses coordinate positions[t, 0] for k < s0/2, positions[t, 1] for s0/2 <= k < (s0+s1)/2, positions[t, 2] for (s0+s1)/2 <= k < (s0+s1+s2)/2, and positions[t, 0] for any remaining pairs up to rot_dim/2; rejected resetting frequency indices to 0 per section because RoPE frequencies form a single monotonic spectrum across rot_dim.
+    let mrope_bounds = op.mrope_sections.map(|sections| {
+        let m0 = (sections[0] / 2) as usize;
+        let m1 = (sections[1] / 2) as usize;
+        let m2 = (sections[2] / 2) as usize;
+        (m0, m0 + m1, m0 + m1 + m2)
+    });
+
+    let get_pos = |pair_idx: usize| -> f32 {
+        if let Some((b0, b1, b2)) = mrope_bounds {
+            let coord_idx = if pair_idx < b0 {
+                0
+            } else if pair_idx < b1 {
+                1
+            } else if pair_idx < b2 {
+                2
+            } else {
+                0
+            };
+            positions.read_u32(token_idx * 3 + coord_idx) as f32
+        } else {
+            positions.read_u32(token_idx) as f32
+        }
+    };
+
+    match op.scaling {
+        RopeScaling::None => {
+            for k in 0..m {
+                let inv_freq = 1.0f32 / op.theta.powf((2 * k) as f32 / op.rot_dim as f32);
+                let pos = get_pos(k);
+                phases[k] = pos * inv_freq;
+            }
+        }
+        RopeScaling::Linear(factor) => {
+            for k in 0..m {
+                let inv_freq =
+                    (1.0f32 / op.theta.powf((2 * k) as f32 / op.rot_dim as f32)) / factor;
+                let pos = get_pos(k);
+                phases[k] = pos * inv_freq;
+            }
+        }
+        RopeScaling::Yarn {
+            factor,
+            beta_fast,
+            beta_slow,
+            orig_ctx,
+            mscale,
+        } => {
+            eff_mscale = mscale;
+            for k in 0..m {
+                let inv_freq = 1.0f32 / op.theta.powf((2 * k) as f32 / op.rot_dim as f32);
+                let r_k = (orig_ctx as f32 * inv_freq) / (2.0f32 * std::f32::consts::PI);
+                let gamma = if beta_fast == beta_slow {
+                    if r_k >= beta_fast {
+                        1.0f32
+                    } else {
+                        0.0f32
+                    }
+                } else {
+                    ((r_k - beta_slow) / (beta_fast - beta_slow)).clamp(0.0f32, 1.0f32)
+                };
+                let scaled_inv_freq = inv_freq * ((1.0f32 - gamma) / factor + gamma);
+                let pos = get_pos(k);
+                phases[k] = pos * scaled_inv_freq;
+            }
+        }
+        RopeScaling::Dynamic => {
+            // DECISION(A1.5): for RopeScaling::Dynamic, since RopeOp carries no context or threshold parameters in the IR (Spec 1 §4.B, r9v-ir RopeScaling::Dynamic) and Spec 1 §6.1 batch invariance prohibits deriving context from the batch's max sequence length, dynamic NTK scaling uses a reference context length of 2048; for pos < 2048, scale is 1.0 (unscaled), and for pos >= 2048, s = (pos + 1) / 2048.0 with base theta scaled by s^(rot_dim / (rot_dim - 2)); rejected batch-wide max_pos (breaks Spec 1 §6.1 batch invariance) and rejected panic/stub.
+            let exponent = (op.rot_dim as f32) / ((op.rot_dim - 2) as f32);
+            for k in 0..m {
+                let pos = get_pos(k);
+                let theta_eff = if pos >= 2048.0 {
+                    let s = (pos + 1.0) / 2048.0;
+                    op.theta * s.powf(exponent)
+                } else {
+                    op.theta
+                };
+                let inv_freq = 1.0f32 / theta_eff.powf((2 * k) as f32 / op.rot_dim as f32);
+                phases[k] = pos * inv_freq;
+            }
+        }
+    }
+
+    (phases, eff_mscale)
+}
+
+/// Executes scalar T0 Rotary Position Embedding (RoPE) (Spec 1 §4.B, §6.4).
+pub fn rope(
+    op: &RopeOp,
+    x: &TensorView<'_>,
+    positions: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+
+    if x.rank() != 3 {
+        problems.push(format!(
+            "input x: expected rank 3 [T, H, D], got rank {} with shape {:?}",
+            x.rank(),
+            x.shape()
+        ));
+    }
+    if y.rank() != 3 {
+        problems.push(format!(
+            "output y: expected rank 3 [T, H, D], got rank {} with shape {:?}",
+            y.rank(),
+            y.shape()
+        ));
+    }
+    if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(format!(
+            "input x: expected f16, bf16, or f32, got {:?}",
+            x.dtype()
+        ));
+    }
+    if y.dtype() != op.out_dtype {
+        problems.push(format!(
+            "output y: expected out_dtype {:?}, got {:?}",
+            op.out_dtype,
+            y.dtype()
+        ));
+    }
+    if positions.dtype() != DType::U32 {
+        problems.push(format!(
+            "positions: expected u32, got {:?}",
+            positions.dtype()
+        ));
+    }
+
+    if op.mrope_sections.is_some() {
+        if positions.rank() != 2 || (positions.rank() == 2 && positions.shape()[1] != 3) {
+            problems.push(format!(
+                "mrope requires positions with rank 2 [T, 3], got rank {} with shape {:?}",
+                positions.rank(),
+                positions.shape()
+            ));
+        }
+    } else if positions.rank() != 1 {
+        problems.push(format!(
+            "standard rope requires positions with rank 1 [T], got rank {} with shape {:?}",
+            positions.rank(),
+            positions.shape()
+        ));
+    }
+
+    if x.rank() == 3 {
+        let t = x.shape()[0];
+        let d = x.shape()[2];
+        if positions.shape()[0] != t {
+            problems.push(format!(
+                "positions token dimension {} does not match input x token dimension T={}",
+                positions.shape()[0],
+                t
+            ));
+        }
+        if (op.rot_dim as usize) > d {
+            problems.push(format!(
+                "rot_dim {} exceeds head dimension D={}",
+                op.rot_dim, d
+            ));
+        }
+        if op.rot_dim == 0 || !op.rot_dim.is_multiple_of(2) {
+            problems.push(format!(
+                "rot_dim must be positive and even, got {}",
+                op.rot_dim
+            ));
+        }
+        if y.rank() == 3 && y.shape() != x.shape() {
+            problems.push(format!(
+                "output y shape {:?} does not match input x shape {:?}",
+                y.shape(),
+                x.shape()
+            ));
+        }
+    }
+
+    T0Error::from_problems("rope", problems)?;
+
+    let t = x.shape()[0];
+    let h = x.shape()[1];
+    let d = x.shape()[2];
+    let rot_dim = op.rot_dim as usize;
+    let m = rot_dim / 2;
+
+    for token in 0..t {
+        let (phases, eff_mscale) = compute_freqs_and_phases_f32(op, token, positions);
+        let mut cos_table = vec![0.0f32; m];
+        let mut sin_table = vec![0.0f32; m];
+        for k in 0..m {
+            cos_table[k] = eff_mscale * phases[k].cos();
+            sin_table[k] = eff_mscale * phases[k].sin();
+        }
+
+        for head in 0..h {
+            let offset = (token * h + head) * d;
+
+            match op.style {
+                RopeStyle::Neox => {
+                    // Coordinates [0..m) paired with [m..2m)
+                    for k in 0..m {
+                        let idx1 = offset + k;
+                        let idx2 = offset + k + m;
+                        let x1 = x.read_f32(idx1);
+                        let x2 = x.read_f32(idx2);
+                        let cos = cos_table[k];
+                        let sin = sin_table[k];
+
+                        let rotated1 = x1 * cos - x2 * sin;
+                        let rotated2 = x2 * cos + x1 * sin;
+
+                        y.write_f32(idx1, rotated1);
+                        y.write_f32(idx2, rotated2);
+                    }
+                }
+                RopeStyle::Interleaved => {
+                    // Coordinates [2k] paired with [2k+1]
+                    for k in 0..m {
+                        let idx1 = offset + 2 * k;
+                        let idx2 = offset + 2 * k + 1;
+                        let x1 = x.read_f32(idx1);
+                        let x2 = x.read_f32(idx2);
+                        let cos = cos_table[k];
+                        let sin = sin_table[k];
+
+                        let rotated1 = x1 * cos - x2 * sin;
+                        let rotated2 = x1 * sin + x2 * cos;
+
+                        y.write_f32(idx1, rotated1);
+                        y.write_f32(idx2, rotated2);
+                    }
+                }
+            }
+
+            // Unrotated tail: pass through untouched
+            for j in rot_dim..d {
+                let idx = offset + j;
+                let val = x.read_f32(idx);
+                y.write_f32(idx, val);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Straightforward 64-bit floating point reference implementation for testing against T0.
+#[allow(clippy::needless_range_loop)]
+pub fn rope_f64_reference(
+    op: &RopeOp,
+    x: &[f64],
+    shape: [usize; 3],
+    positions: &[u32],
+    positions_is_2d: bool,
+) -> Vec<f64> {
+    let [t, h, d] = shape;
+    assert_eq!(x.len(), t * h * d);
+    let mut out = vec![0.0f64; t * h * d];
+    let rot_dim = op.rot_dim as usize;
+    let m = rot_dim / 2;
+
+    let mrope_bounds = op.mrope_sections.map(|sections| {
+        let m0 = (sections[0] / 2) as usize;
+        let m1 = (sections[1] / 2) as usize;
+        let m2 = (sections[2] / 2) as usize;
+        (m0, m0 + m1, m0 + m1 + m2)
+    });
+
+    let get_pos = |token_idx: usize, pair_idx: usize| -> f64 {
+        if positions_is_2d {
+            let coord_idx = if let Some((b0, b1, b2)) = mrope_bounds {
+                if pair_idx < b0 {
+                    0
+                } else if pair_idx < b1 {
+                    1
+                } else if pair_idx < b2 {
+                    2
+                } else {
+                    0
+                }
+            } else {
+                0
+            };
+            positions[token_idx * 3 + coord_idx] as f64
+        } else {
+            positions[token_idx] as f64
+        }
+    };
+
+    for token in 0..t {
+        let mut cos_table = vec![0.0f64; m];
+        let mut sin_table = vec![0.0f64; m];
+
+        let (phases, eff_mscale) = match op.scaling {
+            RopeScaling::None => {
+                let mut ph = vec![0.0f64; m];
+                for k in 0..m {
+                    let inv_freq =
+                        1.0f64 / (op.theta as f64).powf((2 * k) as f64 / op.rot_dim as f64);
+                    let pos = get_pos(token, k);
+                    ph[k] = pos * inv_freq;
+                }
+                (ph, 1.0f64)
+            }
+            RopeScaling::Linear(factor) => {
+                let mut ph = vec![0.0f64; m];
+                for k in 0..m {
+                    let inv_freq = (1.0f64
+                        / (op.theta as f64).powf((2 * k) as f64 / op.rot_dim as f64))
+                        / (factor as f64);
+                    let pos = get_pos(token, k);
+                    ph[k] = pos * inv_freq;
+                }
+                (ph, 1.0f64)
+            }
+            RopeScaling::Yarn {
+                factor,
+                beta_fast,
+                beta_slow,
+                orig_ctx,
+                mscale,
+            } => {
+                let mut ph = vec![0.0f64; m];
+                for k in 0..m {
+                    let inv_freq =
+                        1.0f64 / (op.theta as f64).powf((2 * k) as f64 / op.rot_dim as f64);
+                    let r_k = (orig_ctx as f64 * inv_freq) / (2.0f64 * std::f64::consts::PI);
+                    let gamma = if beta_fast == beta_slow {
+                        if r_k >= (beta_fast as f64) {
+                            1.0f64
+                        } else {
+                            0.0f64
+                        }
+                    } else {
+                        ((r_k - beta_slow as f64) / (beta_fast as f64 - beta_slow as f64))
+                            .clamp(0.0f64, 1.0f64)
+                    };
+                    let scaled_inv_freq = inv_freq * ((1.0f64 - gamma) / (factor as f64) + gamma);
+                    let pos = get_pos(token, k);
+                    ph[k] = pos * scaled_inv_freq;
+                }
+                (ph, mscale as f64)
+            }
+            RopeScaling::Dynamic => {
+                let exponent = (op.rot_dim as f64) / ((op.rot_dim - 2) as f64);
+                let mut ph = vec![0.0f64; m];
+                for k in 0..m {
+                    let pos = get_pos(token, k);
+                    let theta_eff = if pos >= 2048.0 {
+                        let s = (pos + 1.0) / 2048.0;
+                        (op.theta as f64) * s.powf(exponent)
+                    } else {
+                        op.theta as f64
+                    };
+                    let inv_freq = 1.0f64 / theta_eff.powf((2 * k) as f64 / op.rot_dim as f64);
+                    ph[k] = pos * inv_freq;
+                }
+                (ph, 1.0f64)
+            }
+        };
+
+        for k in 0..m {
+            cos_table[k] = eff_mscale * phases[k].cos();
+            sin_table[k] = eff_mscale * phases[k].sin();
+        }
+
+        for head in 0..h {
+            let offset = (token * h + head) * d;
+            match op.style {
+                RopeStyle::Neox => {
+                    for k in 0..m {
+                        let idx1 = offset + k;
+                        let idx2 = offset + k + m;
+                        let x1 = x[idx1];
+                        let x2 = x[idx2];
+                        let cos = cos_table[k];
+                        let sin = sin_table[k];
+                        out[idx1] = x1 * cos - x2 * sin;
+                        out[idx2] = x2 * cos + x1 * sin;
+                    }
+                }
+                RopeStyle::Interleaved => {
+                    for k in 0..m {
+                        let idx1 = offset + 2 * k;
+                        let idx2 = offset + 2 * k + 1;
+                        let x1 = x[idx1];
+                        let x2 = x[idx2];
+                        let cos = cos_table[k];
+                        let sin = sin_table[k];
+                        out[idx1] = x1 * cos - x2 * sin;
+                        out[idx2] = x1 * sin + x2 * cos;
+                    }
+                }
+            }
+
+            for j in rot_dim..d {
+                let idx = offset + j;
+                out[idx] = x[idx];
+            }
+        }
+    }
+
+    out
+}

--- a/crates/r9v-t0/src/tolerance.rs
+++ b/crates/r9v-t0/src/tolerance.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tolerance table per Spec 1 §6.1 loaded as data (CONVENTIONS.md §4.3).
 
-/// Numeric tolerances from Spec 1 §6.1.
+/// Numeric tolerances from Spec 1 §6.1 (Spec 1 §6.1, Spec 4 §10, Spec 1 App. B).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Tolerance {
     /// Absolute error tolerance.
@@ -40,7 +40,7 @@ impl Tolerance {
         Self { abs: 0.0, rel: 0.0 }
     }
 
-    /// Asserts that `actual` and `expected` are within tolerance.
+    /// Asserts that `actual` and `expected` are within tolerance (Spec 1 §6.1, Spec 4 §10).
     pub fn assert_within(&self, actual: f64, expected: f64, context: &str) {
         let diff = (actual - expected).abs();
         let limit = self.abs + self.rel * expected.abs();

--- a/crates/r9v-t0/src/tolerance.rs
+++ b/crates/r9v-t0/src/tolerance.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tolerance table per Spec 1 §6.1 loaded as data (CONVENTIONS.md §4.3).
+
+/// Numeric tolerances from Spec 1 §6.1.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Tolerance {
+    /// Absolute error tolerance.
+    pub abs: f64,
+    /// Relative error tolerance.
+    pub rel: f64,
+}
+
+impl Tolerance {
+    /// Default tolerance for f16/bf16 operations (Spec 1 §6.1: abs 2e-3 / rel 1e-2).
+    pub const fn f16_bf16() -> Self {
+        Self {
+            abs: 2e-3,
+            rel: 1e-2,
+        }
+    }
+
+    /// Default tolerance for f32 operations against f64 reference (Spec 1 §6.1, §6.4).
+    pub const fn f32() -> Self {
+        Self {
+            abs: 2e-4,
+            rel: 1e-3,
+        }
+    }
+
+    /// Default tolerance for i8 weight operations (Spec 1 §6.1: abs 5e-3 / rel 2e-2).
+    pub const fn i8_weight() -> Self {
+        Self {
+            abs: 5e-3,
+            rel: 2e-2,
+        }
+    }
+
+    /// Exact bitwise tolerance (L0 determinism, Spec 1 App. B).
+    pub const fn exact() -> Self {
+        Self { abs: 0.0, rel: 0.0 }
+    }
+
+    /// Asserts that `actual` and `expected` are within tolerance.
+    pub fn assert_within(&self, actual: f64, expected: f64, context: &str) {
+        let diff = (actual - expected).abs();
+        let limit = self.abs + self.rel * expected.abs();
+        assert!(
+            diff <= limit || (actual.is_nan() && expected.is_nan()),
+            "{context}: diff {diff} exceeds limit {limit} (actual={actual}, expected={expected}, tol_abs={}, tol_rel={})",
+            self.abs,
+            self.rel
+        );
+    }
+}

--- a/crates/r9v-t0/tests/act_mul_tests.rs
+++ b/crates/r9v-t0/tests/act_mul_tests.rs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 act_mul (Spec 1 §4.B, §6.1, §6.4, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{ActMulOp, ActivationKind, DType};
+use r9v_t0::{act_mul, act_mul_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn act_mul_all_activations_match_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5020);
+    let tol = Tolerance::f32();
+    let (t, dff) = (3, 128);
+    let num_elem = t * dff;
+
+    let kinds = [
+        ActivationKind::Silu,
+        ActivationKind::Gelu,
+        ActivationKind::GeluTanh,
+        ActivationKind::Relu2,
+        ActivationKind::Identity,
+    ];
+
+    for &kind in &kinds {
+        for &clamp in &[None, Some(4.0)] {
+            let op = ActMulOp { act: kind, clamp };
+
+            let gate_data = generate_f32_data(&mut rng, num_elem, 3.0);
+            let up_data = generate_f32_data(&mut rng, num_elem, 2.0);
+
+            let gate_buf = TypedBuffer::from_f32(&[t, dff], &gate_data);
+            let up_buf = TypedBuffer::from_f32(&[t, dff], &up_data);
+            let mut y_buf = TypedBuffer::zeros(&[t, dff], DType::F32);
+
+            act_mul(
+                &op,
+                &gate_buf.as_view(),
+                &up_buf.as_view(),
+                &mut y_buf.as_view_mut(),
+            )
+            .unwrap();
+
+            let gate_f64: Vec<f64> = gate_data.iter().map(|&v| v as f64).collect();
+            let up_f64: Vec<f64> = up_data.iter().map(|&v| v as f64).collect();
+            let ref_f64 = act_mul_f64_reference(&op, &gate_f64, &up_f64);
+
+            for i in 0..num_elem {
+                let actual = y_buf.read_f32(i) as f64;
+                let expected = ref_f64[i];
+                tol.assert_within(
+                    actual,
+                    expected,
+                    &format!("act_mul {kind:?} clamp={clamp:?} at {i}"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn act_mul_f16_and_bf16_precision_paths() {
+    let mut rng = SeededRng::new(0xA1_5021);
+    let tol = Tolerance::f16_bf16();
+    let (t, dff) = (2, 64);
+    let num_elem = t * dff;
+
+    let gate_data = generate_f32_data(&mut rng, num_elem, 2.5);
+    let up_data = generate_f32_data(&mut rng, num_elem, 1.5);
+
+    for &dt in &[DType::F16, DType::Bf16] {
+        let op = ActMulOp {
+            act: ActivationKind::Silu,
+            clamp: None,
+        };
+
+        let mut gate_buf = TypedBuffer::zeros(&[t, dff], dt);
+        let mut up_buf = TypedBuffer::zeros(&[t, dff], dt);
+        let mut y_buf = TypedBuffer::zeros(&[t, dff], dt);
+
+        for i in 0..num_elem {
+            gate_buf.write_f32(i, gate_data[i]);
+            up_buf.write_f32(i, up_data[i]);
+        }
+
+        act_mul(
+            &op,
+            &gate_buf.as_view(),
+            &up_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let gate_f64: Vec<f64> = (0..num_elem).map(|i| gate_buf.read_f32(i) as f64).collect();
+        let up_f64: Vec<f64> = (0..num_elem).map(|i| up_buf.read_f32(i) as f64).collect();
+        let ref_f64 = act_mul_f64_reference(&op, &gate_f64, &up_f64);
+
+        for i in 0..num_elem {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(actual, expected, &format!("act_mul_{dt} at {i}"));
+        }
+    }
+}
+
+#[test]
+fn act_mul_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5022);
+    let dff = 128;
+
+    let target_gate = generate_f32_data(&mut rng, dff, 3.0);
+    let target_up = generate_f32_data(&mut rng, dff, 2.0);
+
+    let op = ActMulOp {
+        act: ActivationKind::Silu,
+        clamp: Some(3.5),
+    };
+
+    // 1. Alone (T = 1)
+    let g_alone = TypedBuffer::from_f32(&[1, dff], &target_gate);
+    let u_alone = TypedBuffer::from_f32(&[1, dff], &target_up);
+    let mut y_alone = TypedBuffer::zeros(&[1, dff], DType::F32);
+    act_mul(
+        &op,
+        &g_alone.as_view(),
+        &u_alone.as_view(),
+        &mut y_alone.as_view_mut(),
+    )
+    .unwrap();
+    let out_alone = y_alone.to_f32_vec();
+
+    // 2. Padded (T = 4)
+    let mut g_pad = target_gate.clone();
+    g_pad.extend(vec![0.0f32; 3 * dff]);
+    let mut u_pad = target_up.clone();
+    u_pad.extend(vec![0.0f32; 3 * dff]);
+    let g_pad_buf = TypedBuffer::from_f32(&[4, dff], &g_pad);
+    let u_pad_buf = TypedBuffer::from_f32(&[4, dff], &u_pad);
+    let mut y_padded = TypedBuffer::zeros(&[4, dff], DType::F32);
+    act_mul(
+        &op,
+        &g_pad_buf.as_view(),
+        &u_pad_buf.as_view(),
+        &mut y_padded.as_view_mut(),
+    )
+    .unwrap();
+    let out_padded = &y_padded.to_f32_vec()[..dff];
+
+    // 3. Embedded (T = 4, index 2)
+    let other_g = generate_f32_data(&mut rng, 3 * dff, 4.0);
+    let other_u = generate_f32_data(&mut rng, 3 * dff, 4.0);
+    let mut g_emb = Vec::with_capacity(4 * dff);
+    let mut u_emb = Vec::with_capacity(4 * dff);
+    g_emb.extend_from_slice(&other_g[..2 * dff]);
+    g_emb.extend_from_slice(&target_gate);
+    g_emb.extend_from_slice(&other_g[2 * dff..]);
+    u_emb.extend_from_slice(&other_u[..2 * dff]);
+    u_emb.extend_from_slice(&target_up);
+    u_emb.extend_from_slice(&other_u[2 * dff..]);
+
+    let g_emb_buf = TypedBuffer::from_f32(&[4, dff], &g_emb);
+    let u_emb_buf = TypedBuffer::from_f32(&[4, dff], &u_emb);
+    let mut y_emb = TypedBuffer::zeros(&[4, dff], DType::F32);
+    act_mul(
+        &op,
+        &g_emb_buf.as_view(),
+        &u_emb_buf.as_view(),
+        &mut y_emb.as_view_mut(),
+    )
+    .unwrap();
+    let out_emb = &y_emb.to_f32_vec()[2 * dff..3 * dff];
+
+    for i in 0..dff {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_padded[i].to_bits(),
+            "batch invariance alone vs padded at {i}"
+        );
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_emb[i].to_bits(),
+            "batch invariance alone vs embedded at {i}"
+        );
+    }
+}
+
+#[test]
+fn act_mul_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5023);
+    let (t, dff) = (4, 128);
+    let num_elem = t * dff;
+
+    let op = ActMulOp {
+        act: ActivationKind::GeluTanh,
+        clamp: Some(5.0),
+    };
+
+    let gate_data = generate_f32_data(&mut rng, num_elem, 3.0);
+    let up_data = generate_f32_data(&mut rng, num_elem, 3.0);
+
+    let gate_buf = TypedBuffer::from_f32(&[t, dff], &gate_data);
+    let up_buf = TypedBuffer::from_f32(&[t, dff], &up_data);
+
+    let mut y1 = TypedBuffer::zeros(&[t, dff], DType::F32);
+    let mut y2 = TypedBuffer::zeros(&[t, dff], DType::F32);
+
+    act_mul(
+        &op,
+        &gate_buf.as_view(),
+        &up_buf.as_view(),
+        &mut y1.as_view_mut(),
+    )
+    .unwrap();
+    act_mul(
+        &op,
+        &gate_buf.as_view(),
+        &up_buf.as_view(),
+        &mut y2.as_view_mut(),
+    )
+    .unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+
+    for i in 0..num_elem {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn act_mul_rejects_malformed_operands() {
+    let op = ActMulOp {
+        act: ActivationKind::Silu,
+        clamp: Some(-1.0), // invalid clamp
+    };
+
+    let gate_buf = TypedBuffer::zeros(&[2, 64], DType::F32);
+    let up_buf = TypedBuffer::zeros(&[2, 128], DType::F32); // shape mismatch
+    let mut y_buf = TypedBuffer::zeros(&[2, 64], DType::F32);
+
+    let err = act_mul(
+        &op,
+        &gate_buf.as_view(),
+        &up_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("clamp must be finite and > 0"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/activation_tests.rs
+++ b/crates/r9v-t0/tests/activation_tests.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 activation (Spec 1 §4.B, §6.1, §6.4, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{ActivationKind, ActivationOp, DType};
+use r9v_t0::{activation, activation_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn activation_all_activations_match_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5030);
+    let tol = Tolerance::f32();
+    let (t, dff) = (3, 128);
+    let num_elem = t * dff;
+
+    let kinds = [
+        ActivationKind::Silu,
+        ActivationKind::Gelu,
+        ActivationKind::GeluTanh,
+        ActivationKind::Relu2,
+        ActivationKind::Identity,
+    ];
+
+    for &kind in &kinds {
+        for &clamp in &[None, Some(5.0)] {
+            let op = ActivationOp { act: kind, clamp };
+
+            let x_data = generate_f32_data(&mut rng, num_elem, 3.5);
+            let x_buf = TypedBuffer::from_f32(&[t, dff], &x_data);
+            let mut y_buf = TypedBuffer::zeros(&[t, dff], DType::F32);
+
+            activation(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap();
+
+            let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+            let ref_f64 = activation_f64_reference(&op, &x_f64);
+
+            for i in 0..num_elem {
+                let actual = y_buf.read_f32(i) as f64;
+                let expected = ref_f64[i];
+                tol.assert_within(
+                    actual,
+                    expected,
+                    &format!("activation {kind:?} clamp={clamp:?} at {i}"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn activation_f16_and_bf16_precision_paths() {
+    let mut rng = SeededRng::new(0xA1_5031);
+    let tol = Tolerance::f16_bf16();
+    let (t, dff) = (2, 64);
+    let num_elem = t * dff;
+
+    let x_data = generate_f32_data(&mut rng, num_elem, 2.5);
+
+    for &dt in &[DType::F16, DType::Bf16] {
+        let op = ActivationOp {
+            act: ActivationKind::Gelu,
+            clamp: None,
+        };
+
+        let mut x_buf = TypedBuffer::zeros(&[t, dff], dt);
+        let mut y_buf = TypedBuffer::zeros(&[t, dff], dt);
+
+        for i in 0..num_elem {
+            x_buf.write_f32(i, x_data[i]);
+        }
+
+        activation(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap();
+
+        let x_f64: Vec<f64> = (0..num_elem).map(|i| x_buf.read_f32(i) as f64).collect();
+        let ref_f64 = activation_f64_reference(&op, &x_f64);
+
+        for i in 0..num_elem {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(actual, expected, &format!("activation_{dt} at {i}"));
+        }
+    }
+}
+
+#[test]
+fn activation_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5032);
+    let dff = 128;
+
+    let target_row = generate_f32_data(&mut rng, dff, 4.0);
+    let op = ActivationOp {
+        act: ActivationKind::GeluTanh,
+        clamp: Some(4.0),
+    };
+
+    // 1. Alone (T = 1)
+    let x_alone = TypedBuffer::from_f32(&[1, dff], &target_row);
+    let mut y_alone = TypedBuffer::zeros(&[1, dff], DType::F32);
+    activation(&op, &x_alone.as_view(), &mut y_alone.as_view_mut()).unwrap();
+    let out_alone = y_alone.to_f32_vec();
+
+    // 2. Padded (T = 4)
+    let mut x_pad = target_row.clone();
+    x_pad.extend(vec![0.0f32; 3 * dff]);
+    let x_pad_buf = TypedBuffer::from_f32(&[4, dff], &x_pad);
+    let mut y_padded = TypedBuffer::zeros(&[4, dff], DType::F32);
+    activation(&op, &x_pad_buf.as_view(), &mut y_padded.as_view_mut()).unwrap();
+    let out_padded = &y_padded.to_f32_vec()[..dff];
+
+    // 3. Embedded (T = 4, index 2)
+    let other_rows = generate_f32_data(&mut rng, 3 * dff, 5.0);
+    let mut x_emb = Vec::with_capacity(4 * dff);
+    x_emb.extend_from_slice(&other_rows[..2 * dff]);
+    x_emb.extend_from_slice(&target_row);
+    x_emb.extend_from_slice(&other_rows[2 * dff..]);
+
+    let x_emb_buf = TypedBuffer::from_f32(&[4, dff], &x_emb);
+    let mut y_emb = TypedBuffer::zeros(&[4, dff], DType::F32);
+    activation(&op, &x_emb_buf.as_view(), &mut y_emb.as_view_mut()).unwrap();
+    let out_emb = &y_emb.to_f32_vec()[2 * dff..3 * dff];
+
+    for i in 0..dff {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_padded[i].to_bits(),
+            "batch invariance alone vs padded at {i}"
+        );
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_emb[i].to_bits(),
+            "batch invariance alone vs embedded at {i}"
+        );
+    }
+}
+
+#[test]
+fn activation_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5033);
+    let (t, dff) = (4, 128);
+    let num_elem = t * dff;
+
+    let op = ActivationOp {
+        act: ActivationKind::Relu2,
+        clamp: Some(6.0),
+    };
+
+    let x_data = generate_f32_data(&mut rng, num_elem, 3.0);
+    let x_buf = TypedBuffer::from_f32(&[t, dff], &x_data);
+
+    let mut y1 = TypedBuffer::zeros(&[t, dff], DType::F32);
+    let mut y2 = TypedBuffer::zeros(&[t, dff], DType::F32);
+
+    activation(&op, &x_buf.as_view(), &mut y1.as_view_mut()).unwrap();
+    activation(&op, &x_buf.as_view(), &mut y2.as_view_mut()).unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+
+    for i in 0..num_elem {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn activation_rejects_malformed_operands() {
+    let op = ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: Some(0.0), // invalid clamp <= 0
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 64], DType::F32);
+    let mut y_buf = TypedBuffer::zeros(&[2, 128], DType::F32); // shape mismatch
+
+    let err = activation(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("clamp must be finite and > 0"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/activation_tests.rs
+++ b/crates/r9v-t0/tests/activation_tests.rs
@@ -191,3 +191,26 @@ fn activation_rejects_malformed_operands() {
     assert!(msg.contains("clamp must be finite and > 0"));
     assert!(msg.contains("does not match"));
 }
+
+#[test]
+fn erf_f32_all_f32_arithmetic_and_matches_f64_oracle() {
+    use r9v_t0::{erf_f32, erf_f64};
+
+    assert_eq!(erf_f32(0.0f32), 0.0f32);
+    assert!(erf_f32(f32::NAN).is_nan());
+
+    let test_points = [
+        -4.0f32, -2.5, -1.8, -1.5, -1.2, -0.8, -0.5, -0.1, 0.0, 0.1, 0.5, 0.8, 1.2, 1.5, 1.8, 2.5,
+        4.0,
+    ];
+
+    for &x in &test_points {
+        let actual = erf_f32(x);
+        let expected = erf_f64(x as f64) as f32;
+        let diff = (actual - expected).abs();
+        assert!(
+            diff <= 1e-5,
+            "erf_f32({x}) = {actual}, expected {expected}, diff {diff}"
+        );
+    }
+}

--- a/crates/r9v-t0/tests/api_shape.rs
+++ b/crates/r9v-t0/tests/api_shape.rs
@@ -44,3 +44,215 @@ fn test_execute_elementwise_op_dispatch() {
 
     assert_eq!(y.to_f32_vec(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
 }
+
+#[test]
+fn test_execute_elementwise_op_exact_arity_enforcement() {
+    use r9v_ir::{
+        ActMulOp, ActivationKind, ActivationOp, CastOp, CopyKind, CopyOp, DType, NormAxis,
+        NormKind, NormOp, Op, QuantActOp, QuantScheme, ResidualAddOp, RopeOp, RopeScaling,
+        RopeStyle, Smoothing,
+    };
+
+    let x = TypedBuffer::zeros(&[2, 4], DType::F32);
+    let mut y = TypedBuffer::zeros(&[2, 4], DType::F32);
+    let mut y2 = TypedBuffer::zeros(&[2, 4], DType::F32);
+    let mut y3 = TypedBuffer::zeros(&[2, 4], DType::F32);
+
+    // Norm: requires 2 or 3 inputs and 1 output
+    let norm_op = Op::Norm(NormOp {
+        kind: NormKind::Rms,
+        axis: NormAxis::Last,
+        eps: 1e-5,
+        weight_offset: 0.0,
+        out_dtype: DType::F32,
+    });
+    assert!(execute_elementwise_op(&norm_op, &[], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(&norm_op, &[x.as_view()], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &norm_op,
+        &[x.as_view(), x.as_view(), x.as_view(), x.as_view()],
+        &mut [y.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(
+        &norm_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // ResidualAdd: requires 2 inputs and 1 output
+    let res_op = Op::ResidualAdd(ResidualAddOp {
+        out_dtype: DType::F32,
+    });
+    assert!(execute_elementwise_op(&res_op, &[x.as_view()], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &res_op,
+        &[x.as_view(), x.as_view(), x.as_view()],
+        &mut [y.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(
+        &res_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // ActMul: requires 2 inputs and 1 output
+    let act_mul_op = Op::ActMul(ActMulOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    assert!(execute_elementwise_op(&act_mul_op, &[x.as_view()], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &act_mul_op,
+        &[x.as_view(), x.as_view(), x.as_view()],
+        &mut [y.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(
+        &act_mul_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // Activation: requires 1 input and 1 output
+    let act_op = Op::Activation(ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    });
+    assert!(execute_elementwise_op(&act_op, &[], &mut [y.as_view_mut()]).is_err());
+    assert!(
+        execute_elementwise_op(&act_op, &[x.as_view(), x.as_view()], &mut [y.as_view_mut()])
+            .is_err()
+    );
+    assert!(execute_elementwise_op(
+        &act_op,
+        &[x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // Rope: requires 2 inputs and 1 output
+    let rope_op = Op::Rope(RopeOp {
+        rot_dim: 4,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+        out_dtype: DType::F32,
+    });
+    assert!(execute_elementwise_op(&rope_op, &[x.as_view()], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &rope_op,
+        &[x.as_view(), x.as_view(), x.as_view()],
+        &mut [y.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(
+        &rope_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // Cast: requires 1 input and 1 output
+    let cast_op = Op::Cast(CastOp { dtype: DType::F32 });
+    assert!(execute_elementwise_op(&cast_op, &[], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &cast_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(
+        &cast_op,
+        &[x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // Copy: requires 1 input and 1 output
+    let copy_op = Op::Copy(CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    });
+    assert!(execute_elementwise_op(&copy_op, &[], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &copy_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(
+        &copy_op,
+        &[x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+
+    // QuantAct: requires 1 input and 2 outputs
+    let quant_op = Op::QuantAct(QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    });
+    assert!(
+        execute_elementwise_op(&quant_op, &[], &mut [y.as_view_mut(), y2.as_view_mut()]).is_err()
+    );
+    assert!(execute_elementwise_op(
+        &quant_op,
+        &[x.as_view(), x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut()]
+    )
+    .is_err());
+    assert!(execute_elementwise_op(&quant_op, &[x.as_view()], &mut [y.as_view_mut()]).is_err());
+    assert!(execute_elementwise_op(
+        &quant_op,
+        &[x.as_view()],
+        &mut [y.as_view_mut(), y2.as_view_mut(), y3.as_view_mut()]
+    )
+    .is_err());
+}
+
+#[test]
+fn test_backing_length_validation_rejects_undersized_and_overflowed_storage() {
+    use r9v_ir::{ActivationKind, ActivationOp, DType};
+
+    let op = ActivationOp {
+        act: ActivationKind::Silu,
+        clamp: None,
+    };
+
+    // Undersized backing slice: shape claims [2, 4] (8 elements) but slice has only 4 elements
+    let short_data = [1.0f32, 2.0, 3.0, 4.0];
+    let view = TensorView::from_f32_slice(&[2, 4], &short_data);
+    let mut y = TypedBuffer::zeros(&[2, 4], DType::F32);
+
+    let err = activation(&op, &view, &mut y.as_view_mut()).unwrap_err();
+    match err {
+        T0Error::BufferLengthMismatch {
+            tensor,
+            buffer_len,
+            expected_len,
+            shape,
+        } => {
+            assert_eq!(tensor, "x");
+            assert_eq!(buffer_len, 4);
+            assert_eq!(expected_len, 8);
+            assert_eq!(shape, vec![2, 4]);
+        }
+        other => panic!("expected BufferLengthMismatch, got {other:?}"),
+    }
+
+    // Overflowed shape elements: shape dimensions whose product overflows usize::MAX
+    let overflow_view = TensorView::from_f32_slice(&[usize::MAX, 2], &[]);
+    let overflow_err = overflow_view.validate_backing("overflow").unwrap_err();
+    match overflow_err {
+        T0Error::BufferLengthMismatch { tensor, .. } => {
+            assert_eq!(tensor, "overflow");
+        }
+        other => panic!("expected BufferLengthMismatch, got {other:?}"),
+    }
+}

--- a/crates/r9v-t0/tests/api_shape.rs
+++ b/crates/r9v-t0/tests/api_shape.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! API shape verification for r9v-t0 crate (CONVENTIONS.md §3).
+
+use r9v_t0::*;
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+
+#[test]
+fn test_trait_bounds_and_api_shapes() {
+    assert_send::<T0Error>();
+    assert_sync::<T0Error>();
+
+    assert_send::<Tolerance>();
+    assert_sync::<Tolerance>();
+
+    assert_send::<TypedBuffer>();
+    assert_sync::<TypedBuffer>();
+
+    assert_send::<TensorView<'_>>();
+    assert_sync::<TensorView<'_>>();
+
+    assert_send::<TensorViewMut<'_>>();
+    assert_sync::<TensorViewMut<'_>>();
+}
+
+#[test]
+fn test_execute_elementwise_op_dispatch() {
+    use r9v_ir::{ActivationKind, ActivationOp, DType, Op};
+
+    let op = Op::Activation(ActivationOp {
+        act: ActivationKind::Identity,
+        clamp: None,
+    });
+
+    let x = TypedBuffer::from_f32(&[2, 4], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+    let mut y = TypedBuffer::zeros(&[2, 4], DType::F32);
+
+    let inputs = [x.as_view()];
+    let mut outputs = [y.as_view_mut()];
+
+    execute_elementwise_op(&op, &inputs, &mut outputs).unwrap();
+
+    assert_eq!(y.to_f32_vec(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+}

--- a/crates/r9v-t0/tests/cast_tests.rs
+++ b/crates/r9v-t0/tests/cast_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{CastOp, DType};
-use r9v_t0::{cast, cast_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{bf16_to_f32, cast, cast_f64_reference, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -171,4 +171,219 @@ fn cast_rejects_shape_and_dtype_mismatches() {
     let msg = err.to_string();
     assert!(msg.contains("validation error(s)"));
     assert!(msg.contains("does not match"));
+}
+
+/// Identity casts preserve `u32` values beyond 2^24 exactly (Spec 1 §2.1, Spec 1 §6.4).
+///
+/// `f32` cannot represent every `u32` above 2^24, so a round-trip through `f32` corrupts
+/// values like `16_777_217`; the identity path must move raw storage instead.
+#[test]
+fn cast_identity_u32_beyond_f32_precision_is_bit_exact() {
+    let values: Vec<u32> = vec![
+        0,
+        1,
+        16_777_215,
+        16_777_216,
+        16_777_217,
+        123_456_789,
+        3_000_000_000,
+        u32::MAX - 1,
+        u32::MAX,
+    ];
+    let shape = [1, values.len()];
+    let x_buf = TypedBuffer::from_u32(&shape, &values);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::U32);
+    cast(
+        &CastOp { dtype: DType::U32 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_u32_vec(), values);
+}
+
+/// Identity casts preserve `i32` magnitudes beyond 2^24 exactly (Spec 1 §2.1, Spec 1 §6.4).
+#[test]
+fn cast_identity_i32_large_magnitudes_is_bit_exact() {
+    let values: Vec<i32> = vec![
+        0,
+        1,
+        -1,
+        16_777_217,
+        -16_777_217,
+        123_456_789,
+        -123_456_789,
+        i32::MAX,
+        i32::MIN,
+    ];
+    let shape = [1, values.len()];
+    let x_buf = TypedBuffer::from_i32(&shape, &values);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::I32);
+    cast(
+        &CastOp { dtype: DType::I32 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_i32_vec(), values);
+}
+
+/// Identity casts preserve E4M3 bytes including both NaN payloads (Spec 1 §2.1).
+///
+/// `0x7F` and `0xFF` both decode to NaN, so a value round-trip normalizes `0xFF` to `0x7F`;
+/// the identity path must keep every byte unchanged.
+#[test]
+fn cast_identity_e4m3_preserves_nan_payloads() {
+    let bytes: Vec<u8> = vec![0x00, 0x80, 0x38, 0xB8, 0x7E, 0xFE, 0x7F, 0xFF, 0x01, 0x07];
+    let shape = [1, bytes.len()];
+    let x_buf = TypedBuffer::from_bytes(&shape, DType::E4m3, &bytes);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::E4m3);
+    cast(
+        &CastOp { dtype: DType::E4m3 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_byte_vec(), bytes);
+}
+
+/// Identity casts preserve E5M2 bytes including infinities and all NaN payloads (Spec 1 §2.1).
+#[test]
+fn cast_identity_e5m2_preserves_nan_payloads_and_infinities() {
+    let bytes: Vec<u8> = vec![
+        0x00, 0x80, 0x3C, 0x7C, 0xFC, 0x7D, 0x7E, 0x7F, 0xFD, 0xFE, 0xFF, 0x01,
+    ];
+    let shape = [1, bytes.len()];
+    let x_buf = TypedBuffer::from_bytes(&shape, DType::E5m2, &bytes);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::E5m2);
+    cast(
+        &CastOp { dtype: DType::E5m2 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_byte_vec(), bytes);
+}
+
+/// Identity casts preserve packed I4 nibbles for even and odd element counts (Spec 1 §2.1).
+#[test]
+fn cast_identity_i4_packed_nibbles_are_bit_exact() {
+    for values in [
+        vec![-8, -5, -1, 0, 1, 4, 7, -7],
+        vec![-8, -1, 0, 1, 7, -7, 3],
+    ] {
+        let shape = [1, values.len()];
+        let mut x_buf = TypedBuffer::zeros(&shape, DType::I4);
+        for (i, &v) in values.iter().enumerate() {
+            x_buf.write_f32(i, v as f32);
+        }
+        let expected = x_buf.to_byte_vec();
+        let mut y_buf = TypedBuffer::zeros(&shape, DType::I4);
+        cast(
+            &CastOp { dtype: DType::I4 },
+            &x_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+        assert_eq!(y_buf.to_byte_vec(), expected);
+    }
+}
+
+/// Identity casts preserve `f16` bits including NaN payloads (Spec 1 §2.1).
+///
+/// Compared as whole buffers: `f16` decode folds NaN payload bit 9, so comparing
+/// decoded values would not catch a payload change.
+#[test]
+fn cast_identity_f16_preserves_bits_including_nan_payloads() {
+    let bits: Vec<u16> = vec![
+        0x0000, 0x8000, 0x3C00, 0xBC00, 0x7C00, 0xFC00, 0x7C01, 0x7E00, 0x7FFF, 0x0400,
+    ];
+    let shape = [1, bits.len()];
+    let x_buf = TypedBuffer::from_f16(&shape, &bits);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::F16);
+    cast(
+        &CastOp { dtype: DType::F16 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf, x_buf);
+}
+
+/// Identity casts preserve `bf16`, `f32`, `i8`, and `bool` storage exactly (Spec 1 §2.1).
+///
+/// `bool` bytes beyond `0`/`1` are included: a value conversion would normalize them to `1`.
+#[test]
+fn cast_identity_scalar_dtypes_are_bit_exact() {
+    let f32_vals: Vec<f32> = vec![0.0, -0.0, 1.5, f32::from_bits(0x7FC0_0001), f32::INFINITY];
+    let shape = [1, f32_vals.len()];
+    let x_buf = TypedBuffer::from_f32(&shape, &f32_vals);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::F32);
+    cast(
+        &CastOp { dtype: DType::F32 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let out = y_buf.to_f32_vec();
+    for (i, &v) in f32_vals.iter().enumerate() {
+        assert_eq!(
+            out[i].to_bits(),
+            v.to_bits(),
+            "f32 identity changed bits at {i}"
+        );
+    }
+
+    let bf16_bits: Vec<u16> = vec![0x0000, 0x3F80, 0x7F80, 0x7FC1, 0xFF80];
+    let shape = [1, bf16_bits.len()];
+    let x_buf = TypedBuffer::from_bf16(&shape, &bf16_bits);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::Bf16);
+    cast(
+        &CastOp { dtype: DType::Bf16 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let out = y_buf.to_f32_vec();
+    for (i, &b) in bf16_bits.iter().enumerate() {
+        assert_eq!(
+            out[i].to_bits(),
+            bf16_to_f32(b).to_bits(),
+            "bf16 identity changed bits at {i}"
+        );
+    }
+
+    let i8_vals: Vec<i8> = vec![-128, -1, 0, 1, 127];
+    let shape = [1, i8_vals.len()];
+    let x_buf = TypedBuffer::from_i8(&shape, &i8_vals);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::I8);
+    cast(
+        &CastOp { dtype: DType::I8 },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_i8_vec(), i8_vals);
+
+    let bool_bytes: Vec<u8> = vec![0, 1, 2, 255];
+    let shape = [1, bool_bytes.len()];
+    let x_buf = TypedBuffer::from_bytes(&shape, DType::Bool, &bool_bytes);
+    let mut y_buf = TypedBuffer::zeros(&shape, DType::Bool);
+    cast(
+        &CastOp { dtype: DType::Bool },
+        &x_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_byte_vec(), bool_bytes);
+}
+
+/// Identity casts keep typed validation: mismatched shapes are still refused (Spec 1 §4.A).
+#[test]
+fn cast_identity_rejects_shape_mismatch() {
+    let op = CastOp { dtype: DType::U32 };
+    let x_buf = TypedBuffer::zeros(&[2, 64], DType::U32);
+    let mut y_buf = TypedBuffer::zeros(&[2, 32], DType::U32);
+    let err = cast(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
+    assert!(err.to_string().contains("does not match"));
 }

--- a/crates/r9v-t0/tests/cast_tests.rs
+++ b/crates/r9v-t0/tests/cast_tests.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 cast (Spec 1 §4.A, §6.1, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{CastOp, DType};
+use r9v_t0::{cast, cast_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn cast_across_dtypes_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5050);
+    let tol = Tolerance::f16_bf16();
+    let shape = [4, 32];
+    let num_elem = 128;
+
+    let test_dtypes = [
+        DType::F32,
+        DType::F16,
+        DType::Bf16,
+        DType::I8,
+        DType::I32,
+        DType::U32,
+        DType::Bool,
+    ];
+
+    let raw_f32 = generate_f32_data(&mut rng, num_elem, 10.0);
+
+    for &src_dt in &test_dtypes {
+        for &dst_dt in &test_dtypes {
+            let op = CastOp { dtype: dst_dt };
+
+            let mut src_buf = TypedBuffer::zeros(&shape, src_dt);
+            for i in 0..num_elem {
+                src_buf.write_f32(i, raw_f32[i]);
+            }
+
+            let mut dst_buf = TypedBuffer::zeros(&shape, dst_dt);
+            cast(&op, &src_buf.as_view(), &mut dst_buf.as_view_mut()).unwrap();
+
+            let ref_input: Vec<f64> = (0..num_elem).map(|i| src_buf.read_f32(i) as f64).collect();
+            let ref_output = cast_f64_reference(&ref_input);
+
+            for i in 0..num_elem {
+                let actual = dst_buf.read_f32(i) as f64;
+                let expected = ref_output[i];
+                if dst_dt == DType::I8
+                    || dst_dt == DType::I32
+                    || dst_dt == DType::U32
+                    || dst_dt == DType::Bool
+                {
+                    let rounded_expected = if dst_dt == DType::Bool {
+                        if expected != 0.0 {
+                            1.0
+                        } else {
+                            0.0
+                        }
+                    } else if dst_dt == DType::I8 {
+                        expected.round_ties_even().clamp(-128.0, 127.0)
+                    } else if dst_dt == DType::U32 {
+                        expected.round_ties_even().max(0.0)
+                    } else {
+                        expected.round_ties_even()
+                    };
+                    assert_eq!(
+                        actual, rounded_expected,
+                        "integer cast {src_dt:?} -> {dst_dt:?} mismatch at {i}"
+                    );
+                } else {
+                    tol.assert_within(
+                        actual,
+                        expected,
+                        &format!("cast {src_dt:?} -> {dst_dt:?} at {i}"),
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn cast_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5051);
+    let n = 64;
+
+    let target_token = generate_f32_data(&mut rng, n, 5.0);
+    let op = CastOp { dtype: DType::F16 };
+
+    // 1. Alone (T = 1)
+    let x_alone = TypedBuffer::from_f32(&[1, n], &target_token);
+    let mut y_alone = TypedBuffer::zeros(&[1, n], DType::F16);
+    cast(&op, &x_alone.as_view(), &mut y_alone.as_view_mut()).unwrap();
+    let out_alone = y_alone.to_f32_vec();
+
+    // 2. Padded (T = 4)
+    let mut x_pad = target_token.clone();
+    x_pad.extend(vec![0.0f32; 3 * n]);
+    let x_pad_buf = TypedBuffer::from_f32(&[4, n], &x_pad);
+    let mut y_pad_buf = TypedBuffer::zeros(&[4, n], DType::F16);
+    cast(&op, &x_pad_buf.as_view(), &mut y_pad_buf.as_view_mut()).unwrap();
+    let out_pad = &y_pad_buf.to_f32_vec()[..n];
+
+    // 3. Embedded (T = 4, index 2)
+    let other_tokens = generate_f32_data(&mut rng, 3 * n, 5.0);
+    let mut x_emb = Vec::with_capacity(4 * n);
+    x_emb.extend_from_slice(&other_tokens[..2 * n]);
+    x_emb.extend_from_slice(&target_token);
+    x_emb.extend_from_slice(&other_tokens[2 * n..]);
+    let x_emb_buf = TypedBuffer::from_f32(&[4, n], &x_emb);
+    let mut y_emb_buf = TypedBuffer::zeros(&[4, n], DType::F16);
+    cast(&op, &x_emb_buf.as_view(), &mut y_emb_buf.as_view_mut()).unwrap();
+    let out_emb = &y_emb_buf.to_f32_vec()[2 * n..3 * n];
+
+    for i in 0..n {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_pad[i].to_bits(),
+            "alone vs padded at {i}"
+        );
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_emb[i].to_bits(),
+            "alone vs embedded at {i}"
+        );
+    }
+}
+
+#[test]
+fn cast_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5052);
+    let shape = [4, 64];
+    let num_elem = 256;
+
+    let op = CastOp { dtype: DType::Bf16 };
+    let x_data = generate_f32_data(&mut rng, num_elem, 8.0);
+    let x_buf = TypedBuffer::from_f32(&shape, &x_data);
+
+    let mut y1 = TypedBuffer::zeros(&shape, DType::Bf16);
+    let mut y2 = TypedBuffer::zeros(&shape, DType::Bf16);
+
+    cast(&op, &x_buf.as_view(), &mut y1.as_view_mut()).unwrap();
+    cast(&op, &x_buf.as_view(), &mut y2.as_view_mut()).unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+    for i in 0..num_elem {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "cast determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn cast_rejects_shape_and_dtype_mismatches() {
+    let op = CastOp { dtype: DType::F16 };
+    let x_buf = TypedBuffer::zeros(&[2, 64], DType::F32);
+    let mut y_buf = TypedBuffer::zeros(&[2, 32], DType::F32); // shape and dtype mismatch
+
+    let err = cast(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/copy_tests.rs
+++ b/crates/r9v-t0/tests/copy_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{CopyKind, CopyOp, DType};
-use r9v_t0::{copy, TypedBuffer};
+use r9v_t0::{copy, copy_f64_reference, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -132,4 +132,138 @@ fn copy_rejects_shape_and_dtype_mismatches() {
     let msg = err.to_string();
     assert!(msg.contains("validation error(s)"));
     assert!(msg.contains("does not match"));
+}
+
+#[test]
+fn copy_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5063);
+    let shape = [4, 64];
+    let num_elem = 256;
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    let data_f32 = generate_f32_data(&mut rng, num_elem, 25.0);
+    let data_f64: Vec<f64> = data_f32.iter().map(|&v| v as f64).collect();
+
+    let expected_f64 = copy_f64_reference(&op, &data_f64);
+
+    let src = TypedBuffer::from_f32(&shape, &data_f32);
+    let mut dst = TypedBuffer::zeros(&shape, DType::F32);
+    copy(&op, &src.as_view(), &mut dst.as_view_mut()).unwrap();
+
+    let out_f32 = dst.to_f32_vec();
+    for i in 0..num_elem {
+        assert_eq!(out_f32[i] as f64, expected_f64[i]);
+    }
+}
+
+#[test]
+fn copy_bit_exact_u32_and_i32() {
+    let shape = [4, 8];
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+
+    // Test U32 bit-exactness with numbers that cannot be represented accurately in f32
+    let u32_values: Vec<u32> = vec![
+        0xDEAD_BEEF,
+        0x8000_0001,
+        0xFFFF_FFFF,
+        0x1234_5678,
+        0x7FFF_FFFF,
+        0x0000_0000,
+        1,
+        42,
+        0xABCD_EF01,
+        0x1000_0001,
+        0x00FF_00FF,
+        0xFF00_FF00,
+        0x5555_5555,
+        0xAAAA_AAAA,
+        0x1234_4321,
+        0xFEDC_BA98,
+        0x0001_0000,
+        0x0000_0001,
+        0x8000_0000,
+        0x7FFF_0000,
+        0x0000_7FFF,
+        0xCAFE_BABE,
+        0x0102_0304,
+        0x0506_0708,
+        0x090A_0B0C,
+        0x0D0E_0F10,
+        0x1112_1314,
+        0x1516_1718,
+        0x191A_1B1C,
+        0x1D1E_1F20,
+        0x2122_2324,
+        0x2526_2728,
+    ];
+    let u32_src = TypedBuffer::from_u32(&shape, &u32_values);
+    let mut u32_dst = TypedBuffer::zeros(&shape, DType::U32);
+    copy(&op, &u32_src.as_view(), &mut u32_dst.as_view_mut()).unwrap();
+    assert_eq!(u32_dst.to_u32_vec(), u32_values);
+
+    // Test I32 bit-exactness
+    let i32_values: Vec<i32> = vec![
+        i32::MIN,
+        i32::MAX,
+        -1,
+        0,
+        1,
+        123456789,
+        -123456789,
+        0x7FFF_FF01,
+        -0x7FFF_FF01,
+        100,
+        -100,
+        2147483640,
+        -2147483640,
+        42,
+        -42,
+        1337,
+        -1337,
+        7777777,
+        -7777777,
+        1010101,
+        -1010101,
+        999999999,
+        -999999999,
+        2,
+        -2,
+        3,
+        -3,
+        4,
+        -4,
+        5,
+        -5,
+        6,
+    ];
+    let i32_src = TypedBuffer::from_i32(&shape, &i32_values);
+    let mut i32_dst = TypedBuffer::zeros(&shape, DType::I32);
+    copy(&op, &i32_src.as_view(), &mut i32_dst.as_view_mut()).unwrap();
+    assert_eq!(i32_dst.to_i32_vec(), i32_values);
+}
+
+#[test]
+fn copy_bit_exact_fp8_nans_and_packed_i4() {
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+
+    // FP8 E4M3 NaNs: 0x7F and 0xFF
+    let fp8_bytes = vec![0x7Fu8, 0xFF, 0x00, 0x80, 0x7E, 0xFE, 0x3C, 0xBC];
+    let shape = [2, 4];
+    let fp8_src = TypedBuffer::from_e4m3_bytes(&shape, &fp8_bytes);
+    let mut fp8_dst = TypedBuffer::zeros(&shape, DType::E4m3);
+    copy(&op, &fp8_src.as_view(), &mut fp8_dst.as_view_mut()).unwrap();
+    assert_eq!(fp8_dst.to_byte_vec(), fp8_bytes);
+
+    // Packed I4
+    let i4_shape = [2, 8]; // 16 elements = 8 bytes
+    let i4_bytes = vec![0xABu8, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89];
+    let i4_src = TypedBuffer::from_bytes(&i4_shape, DType::I4, &i4_bytes);
+    let mut i4_dst = TypedBuffer::zeros(&i4_shape, DType::I4);
+    copy(&op, &i4_src.as_view(), &mut i4_dst.as_view_mut()).unwrap();
+    assert_eq!(i4_dst.byte_data(), &i4_bytes[..]);
 }

--- a/crates/r9v-t0/tests/copy_tests.rs
+++ b/crates/r9v-t0/tests/copy_tests.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 copy (Spec 1 §4.A, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{CopyKind, CopyOp, DType};
+use r9v_t0::{copy, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn copy_preserves_elements_exactly() {
+    let mut rng = SeededRng::new(0xA1_5060);
+    let shape = [2, 4, 32];
+    let num_elem = 256;
+
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    let data = generate_f32_data(&mut rng, num_elem, 15.0);
+
+    let src_buf = TypedBuffer::from_f32(&shape, &data);
+    let mut dst_buf = TypedBuffer::zeros(&shape, DType::F32);
+
+    copy(&op, &src_buf.as_view(), &mut dst_buf.as_view_mut()).unwrap();
+
+    let out = dst_buf.to_f32_vec();
+    for i in 0..num_elem {
+        assert_eq!(
+            data[i].to_bits(),
+            out[i].to_bits(),
+            "copy mismatch at element {i}"
+        );
+    }
+}
+
+#[test]
+fn copy_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5061);
+    let n = 64;
+
+    let target_token = generate_f32_data(&mut rng, n, 4.0);
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+
+    // 1. Alone (T = 1)
+    let x_alone = TypedBuffer::from_f32(&[1, n], &target_token);
+    let mut y_alone = TypedBuffer::zeros(&[1, n], DType::F32);
+    copy(&op, &x_alone.as_view(), &mut y_alone.as_view_mut()).unwrap();
+    let out_alone = y_alone.to_f32_vec();
+
+    // 2. Padded (T = 4)
+    let mut x_pad = target_token.clone();
+    x_pad.extend(vec![0.0f32; 3 * n]);
+    let x_pad_buf = TypedBuffer::from_f32(&[4, n], &x_pad);
+    let mut y_pad_buf = TypedBuffer::zeros(&[4, n], DType::F32);
+    copy(&op, &x_pad_buf.as_view(), &mut y_pad_buf.as_view_mut()).unwrap();
+    let out_pad = &y_pad_buf.to_f32_vec()[..n];
+
+    // 3. Embedded (T = 4, index 2)
+    let other_tokens = generate_f32_data(&mut rng, 3 * n, 5.0);
+    let mut x_emb = Vec::with_capacity(4 * n);
+    x_emb.extend_from_slice(&other_tokens[..2 * n]);
+    x_emb.extend_from_slice(&target_token);
+    x_emb.extend_from_slice(&other_tokens[2 * n..]);
+    let x_emb_buf = TypedBuffer::from_f32(&[4, n], &x_emb);
+    let mut y_emb_buf = TypedBuffer::zeros(&[4, n], DType::F32);
+    copy(&op, &x_emb_buf.as_view(), &mut y_emb_buf.as_view_mut()).unwrap();
+    let out_emb = &y_emb_buf.to_f32_vec()[2 * n..3 * n];
+
+    for i in 0..n {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_pad[i].to_bits(),
+            "alone vs padded at {i}"
+        );
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_emb[i].to_bits(),
+            "alone vs embedded at {i}"
+        );
+    }
+}
+
+#[test]
+fn copy_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5062);
+    let shape = [2, 128];
+    let num_elem = 256;
+
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    let data = generate_f32_data(&mut rng, num_elem, 7.0);
+    let src_buf = TypedBuffer::from_f32(&shape, &data);
+
+    let mut y1 = TypedBuffer::zeros(&shape, DType::F32);
+    let mut y2 = TypedBuffer::zeros(&shape, DType::F32);
+
+    copy(&op, &src_buf.as_view(), &mut y1.as_view_mut()).unwrap();
+    copy(&op, &src_buf.as_view(), &mut y2.as_view_mut()).unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+    for i in 0..num_elem {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "copy determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn copy_rejects_shape_and_dtype_mismatches() {
+    let op = CopyOp {
+        kind: CopyKind::DeviceToDevice,
+    };
+    let src = TypedBuffer::zeros(&[2, 64], DType::F32);
+    let mut dst = TypedBuffer::zeros(&[2, 32], DType::F32); // shape mismatch
+
+    let err = copy(&op, &src.as_view(), &mut dst.as_view_mut()).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/norm_tests.rs
+++ b/crates/r9v-t0/tests/norm_tests.rs
@@ -429,3 +429,34 @@ fn norm_rejects_malformed_inputs_with_complete_error() {
     assert!(msg.contains("not divisible"));
     assert!(msg.contains("does not match"));
 }
+
+#[test]
+fn norm_rejects_invalid_attributes() {
+    let op = NormOp {
+        kind: NormKind::Rms,
+        eps: -1e-5,              // invalid eps <= 0
+        axis: NormAxis::Head(0), // invalid head dim 0
+        weight_offset: f32::NAN, // invalid weight_offset
+        out_dtype: DType::I8,    // invalid out_dtype
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 64], DType::F32);
+    let w_buf = TypedBuffer::zeros(&[64], DType::F32);
+    let mut y_buf = TypedBuffer::zeros(&[2, 64], DType::I8);
+
+    let err = norm(
+        &op,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("eps must be finite and > 0"));
+    assert!(msg.contains("out_dtype must be f16, bf16, or f32"));
+    assert!(msg.contains("weight_offset must be finite"));
+    assert!(msg.contains("NormAxis::Head(d): d must be > 0"));
+}

--- a/crates/r9v-t0/tests/norm_tests.rs
+++ b/crates/r9v-t0/tests/norm_tests.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 norm (Spec 1 §4.B, §6.1, §6.4, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{DType, NormAxis, NormKind, NormOp};
+use r9v_t0::{norm, norm_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn norm_rms_last_axis_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5001);
+    let tol = Tolerance::f32();
+
+    for &(t, n) in &[(1, 64), (2, 128), (4, 256), (3, 768)] {
+        let op = NormOp {
+            kind: NormKind::Rms,
+            eps: 1e-5,
+            axis: NormAxis::Last,
+            weight_offset: 0.0,
+            out_dtype: DType::F32,
+        };
+
+        let x_data = generate_f32_data(&mut rng, t * n, 5.0);
+        let w_data = generate_f32_data(&mut rng, n, 2.0);
+
+        let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+        let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+        let mut y_buf = TypedBuffer::zeros(&[t, n], DType::F32);
+
+        norm(
+            &op,
+            &x_buf.as_view(),
+            &w_buf.as_view(),
+            None,
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+        let w_f64: Vec<f64> = w_data.iter().map(|&v| v as f64).collect();
+        let ref_f64 = norm_f64_reference(&op, &x_f64, [t, n], &w_f64, None, 0.0, 1e-5);
+
+        for i in 0..(t * n) {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(
+                actual,
+                expected,
+                &format!("norm_rms_last_axis [t={t}, n={n}] at {i}"),
+            );
+        }
+    }
+}
+
+#[test]
+fn norm_rms_head_axis_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5002);
+    let tol = Tolerance::f32();
+
+    let d = 64;
+    for &(t, n) in &[(1, 128), (2, 256), (4, 512)] {
+        let op = NormOp {
+            kind: NormKind::Rms,
+            eps: 1e-6,
+            axis: NormAxis::Head(d as u32),
+            weight_offset: 0.0,
+            out_dtype: DType::F32,
+        };
+
+        let x_data = generate_f32_data(&mut rng, t * n, 4.0);
+        let w_data = generate_f32_data(&mut rng, n, 1.5);
+
+        let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+        let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+        let mut y_buf = TypedBuffer::zeros(&[t, n], DType::F32);
+
+        norm(
+            &op,
+            &x_buf.as_view(),
+            &w_buf.as_view(),
+            None,
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+        let w_f64: Vec<f64> = w_data.iter().map(|&v| v as f64).collect();
+        let ref_f64 = norm_f64_reference(&op, &x_f64, [t, n], &w_f64, None, 0.0, 1e-6);
+
+        for i in 0..(t * n) {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(
+                actual,
+                expected,
+                &format!("norm_rms_head_axis [t={t}, n={n}] at {i}"),
+            );
+        }
+    }
+}
+
+#[test]
+fn norm_rms_weight_offset_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5003);
+    let tol = Tolerance::f32();
+
+    let (t, n) = (2, 128);
+    let op = NormOp {
+        kind: NormKind::Rms,
+        eps: 1e-5,
+        axis: NormAxis::Last,
+        weight_offset: 1.0, // Gemma's (1 + w) parameterization
+        out_dtype: DType::F32,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 3.0);
+    let w_data = generate_f32_data(&mut rng, n, 0.5);
+
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+    let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+    let mut y_buf = TypedBuffer::zeros(&[t, n], DType::F32);
+
+    norm(
+        &op,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+    let w_f64: Vec<f64> = w_data.iter().map(|&v| v as f64).collect();
+    let ref_f64 = norm_f64_reference(&op, &x_f64, [t, n], &w_f64, None, 1.0, 1e-5);
+
+    for i in 0..(t * n) {
+        let actual = y_buf.read_f32(i) as f64;
+        let expected = ref_f64[i];
+        tol.assert_within(actual, expected, &format!("norm_rms_weight_offset at {i}"));
+    }
+}
+
+#[test]
+fn norm_layer_last_and_head_axis_with_bias_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5004);
+    let tol = Tolerance::f32();
+
+    // 1. Last axis with bias
+    let (t, n) = (2, 256);
+    let op_last = NormOp {
+        kind: NormKind::Layer,
+        eps: 1e-5,
+        axis: NormAxis::Last,
+        weight_offset: 0.0,
+        out_dtype: DType::F32,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 4.0);
+    let w_data = generate_f32_data(&mut rng, n, 1.0);
+    let b_data = generate_f32_data(&mut rng, n, 0.5);
+
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+    let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+    let b_buf = TypedBuffer::from_f32(&[n], &b_data);
+    let mut y_buf = TypedBuffer::zeros(&[t, n], DType::F32);
+
+    norm(
+        &op_last,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        Some(&b_buf.as_view()),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+    let w_f64: Vec<f64> = w_data.iter().map(|&v| v as f64).collect();
+    let b_f64: Vec<f64> = b_data.iter().map(|&v| v as f64).collect();
+    let ref_f64 = norm_f64_reference(&op_last, &x_f64, [t, n], &w_f64, Some(&b_f64), 0.0, 1e-5);
+
+    for i in 0..(t * n) {
+        let actual = y_buf.read_f32(i) as f64;
+        let expected = ref_f64[i];
+        tol.assert_within(actual, expected, &format!("norm_layer_last at {i}"));
+    }
+
+    // 2. Head axis with bias
+    let d = 64;
+    let op_head = NormOp {
+        kind: NormKind::Layer,
+        eps: 1e-5,
+        axis: NormAxis::Head(d),
+        weight_offset: 0.0,
+        out_dtype: DType::F32,
+    };
+
+    norm(
+        &op_head,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        Some(&b_buf.as_view()),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let ref_head_f64 =
+        norm_f64_reference(&op_head, &x_f64, [t, n], &w_f64, Some(&b_f64), 0.0, 1e-5);
+
+    for i in 0..(t * n) {
+        let actual = y_buf.read_f32(i) as f64;
+        let expected = ref_head_f64[i];
+        tol.assert_within(actual, expected, &format!("norm_layer_head at {i}"));
+    }
+}
+
+#[test]
+fn norm_f16_and_bf16_precision_paths() {
+    let mut rng = SeededRng::new(0xA1_5005);
+    let tol = Tolerance::f16_bf16();
+
+    let (t, n) = (2, 64);
+    let x_data = generate_f32_data(&mut rng, t * n, 2.0);
+    let w_data = generate_f32_data(&mut rng, n, 1.0);
+
+    for &dt in &[DType::F16, DType::Bf16] {
+        let op = NormOp {
+            kind: NormKind::Rms,
+            eps: 1e-4,
+            axis: NormAxis::Last,
+            weight_offset: 0.0,
+            out_dtype: dt,
+        };
+
+        let mut x_buf = TypedBuffer::zeros(&[t, n], dt);
+        for (i, &v) in x_data.iter().enumerate() {
+            x_buf.write_f32(i, v);
+        }
+        let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+        let mut y_buf = TypedBuffer::zeros(&[t, n], dt);
+
+        norm(
+            &op,
+            &x_buf.as_view(),
+            &w_buf.as_view(),
+            None,
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let x_f64: Vec<f64> = (0..(t * n)).map(|i| x_buf.read_f32(i) as f64).collect();
+        let w_f64: Vec<f64> = w_data.iter().map(|&v| v as f64).collect();
+        let ref_f64 = norm_f64_reference(&op, &x_f64, [t, n], &w_f64, None, 0.0, 1e-4);
+
+        for i in 0..(t * n) {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(actual, expected, &format!("norm_{dt} at {i}"));
+        }
+    }
+}
+
+#[test]
+fn norm_batch_invariance_rms_and_layer() {
+    let mut rng = SeededRng::new(0xA1_5006);
+    let n = 128;
+
+    // Single target token row
+    let target_row = generate_f32_data(&mut rng, n, 3.0);
+    let w_data = generate_f32_data(&mut rng, n, 1.2);
+    let b_data = generate_f32_data(&mut rng, n, 0.3);
+
+    for &kind in &[NormKind::Rms, NormKind::Layer] {
+        let op = NormOp {
+            kind,
+            eps: 1e-5,
+            axis: NormAxis::Last,
+            weight_offset: 0.5,
+            out_dtype: DType::F32,
+        };
+
+        // 1. Target token alone (T = 1)
+        let x_alone = TypedBuffer::from_f32(&[1, n], &target_row);
+        let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+        let b_buf = TypedBuffer::from_f32(&[n], &b_data);
+        let mut y_alone = TypedBuffer::zeros(&[1, n], DType::F32);
+        norm(
+            &op,
+            &x_alone.as_view(),
+            &w_buf.as_view(),
+            Some(&b_buf.as_view()),
+            &mut y_alone.as_view_mut(),
+        )
+        .unwrap();
+        let out_alone = y_alone.to_f32_vec();
+
+        // 2. Padded bucket (T = 4, target token at index 0, rest zeros)
+        let mut padded_data = target_row.clone();
+        padded_data.extend(vec![0.0f32; 3 * n]);
+        let x_padded = TypedBuffer::from_f32(&[4, n], &padded_data);
+        let mut y_padded = TypedBuffer::zeros(&[4, n], DType::F32);
+        norm(
+            &op,
+            &x_padded.as_view(),
+            &w_buf.as_view(),
+            Some(&b_buf.as_view()),
+            &mut y_padded.as_view_mut(),
+        )
+        .unwrap();
+        let out_padded = &y_padded.to_f32_vec()[..n];
+
+        // 3. Embedded among random tokens (T = 4, target token at index 2)
+        let other_tokens = generate_f32_data(&mut rng, 3 * n, 5.0);
+        let mut embedded_data = Vec::with_capacity(4 * n);
+        embedded_data.extend_from_slice(&other_tokens[..2 * n]);
+        embedded_data.extend_from_slice(&target_row); // token at index 2
+        embedded_data.extend_from_slice(&other_tokens[2 * n..]);
+        let x_embedded = TypedBuffer::from_f32(&[4, n], &embedded_data);
+        let mut y_embedded = TypedBuffer::zeros(&[4, n], DType::F32);
+        norm(
+            &op,
+            &x_embedded.as_view(),
+            &w_buf.as_view(),
+            Some(&b_buf.as_view()),
+            &mut y_embedded.as_view_mut(),
+        )
+        .unwrap();
+        let out_embedded = &y_embedded.to_f32_vec()[2 * n..3 * n];
+
+        // Spec 1 §6.1: batch invariance requires bit-identical L0 equality
+        for i in 0..n {
+            assert_eq!(
+                out_alone[i].to_bits(),
+                out_padded[i].to_bits(),
+                "batch invariance failed between alone and padded on {kind:?} at element {i}"
+            );
+            assert_eq!(
+                out_alone[i].to_bits(),
+                out_embedded[i].to_bits(),
+                "batch invariance failed between alone and embedded on {kind:?} at element {i}"
+            );
+        }
+    }
+}
+
+#[test]
+fn norm_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5007);
+    let (t, n) = (4, 128);
+
+    let op = NormOp {
+        kind: NormKind::Rms,
+        eps: 1e-5,
+        axis: NormAxis::Last,
+        weight_offset: 1.0,
+        out_dtype: DType::F32,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 4.0);
+    let w_data = generate_f32_data(&mut rng, n, 1.0);
+
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+    let w_buf = TypedBuffer::from_f32(&[n], &w_data);
+
+    let mut y1 = TypedBuffer::zeros(&[t, n], DType::F32);
+    let mut y2 = TypedBuffer::zeros(&[t, n], DType::F32);
+
+    norm(
+        &op,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        None,
+        &mut y1.as_view_mut(),
+    )
+    .unwrap();
+    norm(
+        &op,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        None,
+        &mut y2.as_view_mut(),
+    )
+    .unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+
+    for i in 0..(t * n) {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn norm_rejects_malformed_inputs_with_complete_error() {
+    let op = NormOp {
+        kind: NormKind::Rms,
+        eps: 1e-5,
+        axis: NormAxis::Head(50), // 128 not divisible by 50
+        weight_offset: 0.0,
+        out_dtype: DType::F32,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 128], DType::F32);
+    let w_buf = TypedBuffer::zeros(&[100], DType::F32); // 100 != 128
+    let mut y_buf = TypedBuffer::zeros(&[2, 64], DType::F32); // 64 != 128
+
+    let err = norm(
+        &op,
+        &x_buf.as_view(),
+        &w_buf.as_view(),
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("not divisible"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/quant_act_tests.rs
+++ b/crates/r9v-t0/tests/quant_act_tests.rs
@@ -4,7 +4,10 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{DType, QuantActOp, QuantScheme, Smoothing};
-use r9v_t0::{quant_act, quant_act_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{
+    fp8_e4m3_decode, fp8_e4m3_encode, fp8_e4m3_encode_f64_oracle, quant_act,
+    quant_act_f64_reference, Tolerance, TypedBuffer,
+};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -346,4 +349,192 @@ fn quant_act_rejects_invalid_per_token_target_without_panicking() {
     let msg = err.to_string();
     assert!(msg.contains("validation error(s)"));
     assert!(msg.contains("target must be i8 or e4m3") || msg.contains("only supports i8 or e4m3"));
+}
+
+/// Authoritative E4M3 golden vectors for the independent `f64` oracle (Spec 1 §2.1).
+///
+/// Hand-derived from the OCP FP8 E4M3 grid definition, not from the production encoder:
+/// a regression in either implementation breaks this test from opposite sides.
+#[test]
+fn e4m3_f64_oracle_golden_vectors() {
+    let cases: &[(f64, u8)] = &[
+        (0.0, 0x00),
+        (-0.0, 0x80),
+        (1.0, 0x38),
+        (-1.0, 0xB8),
+        (2.0, 0x40),
+        (0.5, 0x30),
+        (0.015625, 0x08),
+        (0.001953125, 0x01),
+        (0.013671875, 0x07),
+        (1.125, 0x39),
+        (0.1, 0x1D),
+        (1.0625, 0x38),  // exact tie between 1.0 and 1.125 rounds to even
+        (-1.0625, 0xB8), // exact tie between -1.0 and -1.125 rounds to even
+        (1.1875, 0x3A),  // exact tie between 1.125 and 1.25 rounds to even
+        (448.0, 0x7E),
+        (-448.0, 0xFE),
+        (500.0, 0x7E),  // saturates to +448
+        (-500.0, 0xFE), // saturates to -448
+        (f64::INFINITY, 0x7E),
+        (f64::NEG_INFINITY, 0xFE),
+        (f64::NAN, 0x7F),
+        (-f64::NAN, 0x7F),
+    ];
+    for &(input, expected) in cases {
+        assert_eq!(
+            fp8_e4m3_encode_f64_oracle(input),
+            expected,
+            "oracle golden mismatch for input {input}"
+        );
+    }
+}
+
+/// The same goldens through the production encoder (Spec 1 §2.1).
+///
+/// Uses only hard-coded expectations, never the oracle, so a production regression fails here
+/// even if the oracle were wrong.
+#[test]
+fn e4m3_production_encoder_golden_vectors() {
+    let cases: &[(f32, u8)] = &[
+        (0.0, 0x00),
+        (-0.0, 0x80),
+        (1.0, 0x38),
+        (-1.0, 0xB8),
+        (2.0, 0x40),
+        (0.5, 0x30),
+        (0.015625, 0x08),
+        (0.001953125, 0x01),
+        (0.013671875, 0x07),
+        (1.125, 0x39),
+        (0.1, 0x1D),
+        (1.0625, 0x38),
+        (-1.0625, 0xB8),
+        (1.1875, 0x3A),
+        (448.0, 0x7E),
+        (-448.0, 0xFE),
+        (500.0, 0x7E),
+        (-500.0, 0xFE),
+        (f32::INFINITY, 0x7E),
+        (f32::NEG_INFINITY, 0xFE),
+        (f32::NAN, 0x7F),
+    ];
+    for &(input, expected) in cases {
+        assert_eq!(
+            fp8_e4m3_encode(input),
+            expected,
+            "production golden mismatch for input {input}"
+        );
+    }
+}
+
+/// Every finite E4M3 code round-trips through the production encoder (Spec 1 §2.1).
+///
+/// Encodes each exactly-representable grid value and requires the original byte back;
+/// a production regression in saturation, NaN skipping, or nearest selection breaks this.
+#[test]
+fn e4m3_grid_values_roundtrip_through_production_encoder() {
+    for code in 0u16..256u16 {
+        let b = code as u8;
+        if b == 0x7F || b == 0xFF {
+            continue;
+        }
+        let grid = fp8_e4m3_decode(b);
+        assert_eq!(
+            fp8_e4m3_encode(grid),
+            b,
+            "roundtrip mismatch for code {b:#04X} (grid value {grid})"
+        );
+    }
+}
+
+/// Exact midpoints between adjacent grid codes round to even in both implementations (Spec 1 §2.1).
+///
+/// A flipped tie-break in the production encoder fails this while the oracle still passes.
+#[test]
+fn e4m3_midpoint_ties_round_to_even() {
+    for code in 0u16..255u16 {
+        let lo = code as u8;
+        let hi = (code + 1) as u8;
+        if lo == 0x7F || lo == 0xFF || hi == 0x7F || hi == 0xFF {
+            continue;
+        }
+        if lo == 0x80 {
+            // Midpoint between -0.0 and the first negative subnormal is a three-way
+            // tie with +0.0; pinned separately below.
+            continue;
+        }
+        let mid = (f64::from(fp8_e4m3_decode(lo)) + f64::from(fp8_e4m3_decode(hi))) / 2.0;
+        let expected = if lo & 1 == 0 { lo } else { hi };
+        assert_eq!(
+            fp8_e4m3_encode(mid as f32),
+            expected,
+            "production tie mismatch between {lo:#04X} and {hi:#04X}"
+        );
+        assert_eq!(
+            fp8_e4m3_encode_f64_oracle(mid),
+            expected,
+            "oracle tie mismatch between {lo:#04X} and {hi:#04X}"
+        );
+    }
+}
+
+/// The midpoint between -0.0 (`0x80`) and the first negative subnormal (`0x81`) ties
+/// three ways with +0.0 (`0x00`); both implementations keep the first even code (Spec 1 §2.1).
+#[test]
+fn e4m3_negative_zero_midpoint_three_way_tie() {
+    let mid = (f64::from(fp8_e4m3_decode(0x80)) + f64::from(fp8_e4m3_decode(0x81))) / 2.0;
+    assert_eq!(fp8_e4m3_encode(mid as f32), 0x00);
+    assert_eq!(fp8_e4m3_encode_f64_oracle(mid), 0x00);
+}
+
+/// Seeded sweep requiring exact production/oracle agreement across the full range (Spec 1 §2.1).
+///
+/// Covers subnormals, normals, ties, and the saturation zone with a fixed seed, so the test
+/// is deterministic; any production regression shows up as a mismatch against the oracle.
+#[test]
+fn e4m3_production_matches_independent_oracle_on_seeded_sweep() {
+    let mut rng = SeededRng::new(0xA1_5075);
+    for _ in 0..4096 {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let v = (f64::from(raw) / f64::from(u32::MAX)) * 1200.0 - 600.0;
+        let f = v as f32;
+        assert_eq!(
+            fp8_e4m3_encode(f),
+            fp8_e4m3_encode_f64_oracle(f64::from(f)),
+            "production/oracle mismatch at {f}"
+        );
+    }
+    for _ in 0..1024 {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let v = (f64::from(raw) / f64::from(u32::MAX)) * 0.03 - 0.015;
+        let f = v as f32;
+        assert_eq!(
+            fp8_e4m3_encode(f),
+            fp8_e4m3_encode_f64_oracle(f64::from(f)),
+            "production/oracle subnormal mismatch at {f}"
+        );
+    }
+}
+
+/// Pins the `quant_act_f64_reference` E4M3 path itself to golden bytes (Spec 1 §4.A).
+///
+/// With `absmax == 448.0` the scale is exactly 1.0, so each output byte is the oracle
+/// encoding of the input value; hard-coded expectations keep the reference honest
+/// without involving the production encoder at all.
+#[test]
+fn quant_act_f64_reference_e4m3_matches_golden_bytes() {
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::E4m3,
+        smoothing: Smoothing::None,
+    };
+    let x = vec![0.0, 1.0, -1.0, 448.0, -448.0, f64::NAN, 0.5, -0.0];
+    let (ref_xq, ref_scale) = quant_act_f64_reference(&op, &x, [1, 8]);
+    assert_eq!(ref_scale[0], 1.0);
+    let expected: Vec<f64> = vec![0x00, 0x38, 0xB8, 0x7E, 0xFE, 0x7F, 0x30, 0x80]
+        .into_iter()
+        .map(f64::from)
+        .collect();
+    assert_eq!(ref_xq, expected);
 }

--- a/crates/r9v-t0/tests/quant_act_tests.rs
+++ b/crates/r9v-t0/tests/quant_act_tests.rs
@@ -322,3 +322,28 @@ fn quant_act_rejects_non_divisible_block_size_and_mismatches() {
     assert!(msg.contains("validation error(s)"));
     assert!(msg.contains("divisible by 32"));
 }
+
+#[test]
+fn quant_act_rejects_invalid_per_token_target_without_panicking() {
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::F32, // Invalid target for quant_act (must be i8 or e4m3)
+        smoothing: Smoothing::None,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 32], DType::F32);
+    let mut xq_buf = TypedBuffer::zeros(&[2, 32], DType::F32);
+    let mut scale_buf = TypedBuffer::zeros(&[2], DType::F32);
+
+    let err = quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq_buf.as_view_mut(),
+        &mut scale_buf.as_view_mut(),
+    )
+    .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("target must be i8 or e4m3") || msg.contains("only supports i8 or e4m3"));
+}

--- a/crates/r9v-t0/tests/quant_act_tests.rs
+++ b/crates/r9v-t0/tests/quant_act_tests.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 quant_act (Spec 1 §4.A, Spec 2 §3.4, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{DType, QuantActOp, QuantScheme, Smoothing};
+use r9v_t0::{quant_act, quant_act_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn quant_act_per_token_i8_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5070);
+    let tol = Tolerance::f32();
+    let (t, n) = (3, 128);
+
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 50.0);
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+
+    let mut xq_buf = TypedBuffer::zeros(&[t, n], DType::I8);
+    let mut scale_buf = TypedBuffer::zeros(&[t], DType::F32);
+
+    quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq_buf.as_view_mut(),
+        &mut scale_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+    let (ref_xq, ref_scale) = quant_act_f64_reference(&op, &x_f64, [t, n]);
+
+    for row in 0..t {
+        let actual_scale = scale_buf.read_f32(row) as f64;
+        let expected_scale = ref_scale[row];
+        tol.assert_within(
+            actual_scale,
+            expected_scale,
+            &format!("quant_act scale at token {row}"),
+        );
+    }
+
+    let actual_xq = xq_buf.to_i8_vec();
+    for i in 0..(t * n) {
+        assert_eq!(
+            actual_xq[i] as f64, ref_xq[i],
+            "quant_act i8 quantized mismatch at {i}"
+        );
+        // Check symmetric bound [-127, 127] (i8 cannot be -128)
+        assert!(actual_xq[i] >= -127);
+    }
+}
+
+#[test]
+fn quant_act_per_token_e4m3_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5071);
+    let tol = Tolerance::f32();
+    let (t, n) = (3, 64);
+
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::E4m3,
+        smoothing: Smoothing::None,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 100.0);
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+
+    let mut xq_buf = TypedBuffer::zeros(&[t, n], DType::E4m3);
+    let mut scale_buf = TypedBuffer::zeros(&[t], DType::F32);
+
+    quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq_buf.as_view_mut(),
+        &mut scale_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+    let (ref_xq, ref_scale) = quant_act_f64_reference(&op, &x_f64, [t, n]);
+
+    for row in 0..t {
+        let actual_scale = scale_buf.read_f32(row) as f64;
+        let expected_scale = ref_scale[row];
+        tol.assert_within(
+            actual_scale,
+            expected_scale,
+            &format!("quant_act e4m3 scale at token {row}"),
+        );
+    }
+
+    let actual_bytes = xq_buf.to_byte_vec();
+    for i in 0..(t * n) {
+        assert_eq!(
+            actual_bytes[i] as f64, ref_xq[i],
+            "quant_act e4m3 byte mismatch at {i}"
+        );
+    }
+}
+
+#[test]
+fn quant_act_per_block32_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5072);
+    let tol = Tolerance::f32();
+    let (t, n) = (2, 128); // 4 blocks of 32 per row
+
+    let op = QuantActOp {
+        scheme: QuantScheme::PerBlock32,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 40.0);
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+
+    let num_blocks = n / 32;
+    let mut xq_buf = TypedBuffer::zeros(&[t, n], DType::I8);
+    let mut scale_buf = TypedBuffer::zeros(&[t, num_blocks], DType::F32);
+
+    quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq_buf.as_view_mut(),
+        &mut scale_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+    let (ref_xq, ref_scale) = quant_act_f64_reference(&op, &x_f64, [t, n]);
+
+    for b in 0..(t * num_blocks) {
+        let actual_scale = scale_buf.read_f32(b) as f64;
+        let expected_scale = ref_scale[b];
+        tol.assert_within(
+            actual_scale,
+            expected_scale,
+            &format!("quant_act perblock scale at block {b}"),
+        );
+    }
+
+    let actual_xq = xq_buf.to_i8_vec();
+    for i in 0..(t * n) {
+        assert_eq!(
+            actual_xq[i] as f64, ref_xq[i],
+            "quant_act perblock i8 quantized mismatch at {i}"
+        );
+    }
+}
+
+#[test]
+fn quant_act_zero_absmax_emits_zeros() {
+    let (t, n) = (2, 64);
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[t, n], DType::F32); // All zeros
+    let mut xq_buf = TypedBuffer::zeros(&[t, n], DType::I8);
+    let mut scale_buf = TypedBuffer::zeros(&[t], DType::F32);
+
+    quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq_buf.as_view_mut(),
+        &mut scale_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    for row in 0..t {
+        assert_eq!(scale_buf.read_f32(row), 0.0f32);
+    }
+    for val in xq_buf.to_i8_vec() {
+        assert_eq!(val, 0);
+    }
+}
+
+#[test]
+fn quant_act_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5073);
+    let n = 128;
+
+    let target_row = generate_f32_data(&mut rng, n, 20.0);
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+
+    // 1. Alone (T = 1)
+    let x_alone = TypedBuffer::from_f32(&[1, n], &target_row);
+    let mut xq_alone = TypedBuffer::zeros(&[1, n], DType::I8);
+    let mut scale_alone = TypedBuffer::zeros(&[1], DType::F32);
+    quant_act(
+        &op,
+        &x_alone.as_view(),
+        &mut xq_alone.as_view_mut(),
+        &mut scale_alone.as_view_mut(),
+    )
+    .unwrap();
+    let out_alone = xq_alone.to_i8_vec();
+    let scale_alone_val = scale_alone.read_f32(0);
+
+    // 2. Padded (T = 4)
+    let mut x_pad = target_row.clone();
+    x_pad.extend(vec![0.0f32; 3 * n]);
+    let x_pad_buf = TypedBuffer::from_f32(&[4, n], &x_pad);
+    let mut xq_pad = TypedBuffer::zeros(&[4, n], DType::I8);
+    let mut scale_pad = TypedBuffer::zeros(&[4], DType::F32);
+    quant_act(
+        &op,
+        &x_pad_buf.as_view(),
+        &mut xq_pad.as_view_mut(),
+        &mut scale_pad.as_view_mut(),
+    )
+    .unwrap();
+    let out_pad = &xq_pad.to_i8_vec()[..n];
+    let scale_pad_val = scale_pad.read_f32(0);
+
+    // 3. Embedded (T = 4, target at index 2)
+    let other_tokens = generate_f32_data(&mut rng, 3 * n, 50.0);
+    let mut x_emb = Vec::with_capacity(4 * n);
+    x_emb.extend_from_slice(&other_tokens[..2 * n]);
+    x_emb.extend_from_slice(&target_row);
+    x_emb.extend_from_slice(&other_tokens[2 * n..]);
+    let x_emb_buf = TypedBuffer::from_f32(&[4, n], &x_emb);
+    let mut xq_emb = TypedBuffer::zeros(&[4, n], DType::I8);
+    let mut scale_emb = TypedBuffer::zeros(&[4], DType::F32);
+    quant_act(
+        &op,
+        &x_emb_buf.as_view(),
+        &mut xq_emb.as_view_mut(),
+        &mut scale_emb.as_view_mut(),
+    )
+    .unwrap();
+    let out_emb = &xq_emb.to_i8_vec()[2 * n..3 * n];
+    let scale_emb_val = scale_emb.read_f32(2);
+
+    assert_eq!(scale_alone_val.to_bits(), scale_pad_val.to_bits());
+    assert_eq!(scale_alone_val.to_bits(), scale_emb_val.to_bits());
+    for i in 0..n {
+        assert_eq!(out_alone[i], out_pad[i]);
+        assert_eq!(out_alone[i], out_emb[i]);
+    }
+}
+
+#[test]
+fn quant_act_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5074);
+    let (t, n) = (3, 64);
+
+    let op = QuantActOp {
+        scheme: QuantScheme::PerToken,
+        target: DType::E4m3,
+        smoothing: Smoothing::None,
+    };
+
+    let x_data = generate_f32_data(&mut rng, t * n, 30.0);
+    let x_buf = TypedBuffer::from_f32(&[t, n], &x_data);
+
+    let mut xq1 = TypedBuffer::zeros(&[t, n], DType::E4m3);
+    let mut s1 = TypedBuffer::zeros(&[t], DType::F32);
+    let mut xq2 = TypedBuffer::zeros(&[t, n], DType::E4m3);
+    let mut s2 = TypedBuffer::zeros(&[t], DType::F32);
+
+    quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq1.as_view_mut(),
+        &mut s1.as_view_mut(),
+    )
+    .unwrap();
+    quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq2.as_view_mut(),
+        &mut s2.as_view_mut(),
+    )
+    .unwrap();
+
+    assert_eq!(xq1.to_byte_vec(), xq2.to_byte_vec());
+    assert_eq!(s1.to_f32_vec(), s2.to_f32_vec());
+}
+
+#[test]
+fn quant_act_rejects_non_divisible_block_size_and_mismatches() {
+    let op = QuantActOp {
+        scheme: QuantScheme::PerBlock32,
+        target: DType::I8,
+        smoothing: Smoothing::None,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 50], DType::F32); // 50 not divisible by 32
+    let mut xq_buf = TypedBuffer::zeros(&[2, 50], DType::I8);
+    let mut scale_buf = TypedBuffer::zeros(&[2, 2], DType::F32);
+
+    let err = quant_act(
+        &op,
+        &x_buf.as_view(),
+        &mut xq_buf.as_view_mut(),
+        &mut scale_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("divisible by 32"));
+}

--- a/crates/r9v-t0/tests/residual_add_tests.rs
+++ b/crates/r9v-t0/tests/residual_add_tests.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 residual_add (Spec 1 §4.B, §6.1, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{DType, ResidualAddOp};
+use r9v_t0::{residual_add, residual_add_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn residual_add_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5010);
+    let tol = Tolerance::f32();
+
+    for &shape in &[&[16][..], &[4, 32][..], &[2, 8, 64][..]] {
+        let num_elem: usize = shape.iter().product();
+        let op = ResidualAddOp {
+            out_dtype: DType::F32,
+        };
+
+        let a_data = generate_f32_data(&mut rng, num_elem, 10.0);
+        let b_data = generate_f32_data(&mut rng, num_elem, 10.0);
+
+        let a_buf = TypedBuffer::from_f32(shape, &a_data);
+        let b_buf = TypedBuffer::from_f32(shape, &b_data);
+        let mut y_buf = TypedBuffer::zeros(shape, DType::F32);
+
+        residual_add(
+            &op,
+            &a_buf.as_view(),
+            &b_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let a_f64: Vec<f64> = a_data.iter().map(|&v| v as f64).collect();
+        let b_f64: Vec<f64> = b_data.iter().map(|&v| v as f64).collect();
+        let ref_f64 = residual_add_f64_reference(&a_f64, &b_f64);
+
+        for i in 0..num_elem {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(
+                actual,
+                expected,
+                &format!("residual_add shape {shape:?} at {i}"),
+            );
+        }
+    }
+}
+
+#[test]
+fn residual_add_f16_and_bf16_precision_paths() {
+    let mut rng = SeededRng::new(0xA1_5011);
+    let tol = Tolerance::f16_bf16();
+    let shape = [2, 64];
+    let num_elem = 128;
+
+    let a_data = generate_f32_data(&mut rng, num_elem, 5.0);
+    let b_data = generate_f32_data(&mut rng, num_elem, 5.0);
+
+    for &dt in &[DType::F16, DType::Bf16] {
+        let op = ResidualAddOp { out_dtype: dt };
+
+        let mut a_buf = TypedBuffer::zeros(&shape, dt);
+        let mut b_buf = TypedBuffer::zeros(&shape, dt);
+        let mut y_buf = TypedBuffer::zeros(&shape, dt);
+
+        for i in 0..num_elem {
+            a_buf.write_f32(i, a_data[i]);
+            b_buf.write_f32(i, b_data[i]);
+        }
+
+        residual_add(
+            &op,
+            &a_buf.as_view(),
+            &b_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let a_f64: Vec<f64> = (0..num_elem).map(|i| a_buf.read_f32(i) as f64).collect();
+        let b_f64: Vec<f64> = (0..num_elem).map(|i| b_buf.read_f32(i) as f64).collect();
+        let ref_f64 = residual_add_f64_reference(&a_f64, &b_f64);
+
+        for i in 0..num_elem {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(actual, expected, &format!("residual_add_{dt} at {i}"));
+        }
+    }
+}
+
+#[test]
+fn residual_add_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5012);
+    let n = 64;
+
+    let target_a = generate_f32_data(&mut rng, n, 4.0);
+    let target_b = generate_f32_data(&mut rng, n, 4.0);
+
+    let op = ResidualAddOp {
+        out_dtype: DType::F32,
+    };
+
+    // 1. Alone (T = 1)
+    let a_alone = TypedBuffer::from_f32(&[1, n], &target_a);
+    let b_alone = TypedBuffer::from_f32(&[1, n], &target_b);
+    let mut y_alone = TypedBuffer::zeros(&[1, n], DType::F32);
+    residual_add(
+        &op,
+        &a_alone.as_view(),
+        &b_alone.as_view(),
+        &mut y_alone.as_view_mut(),
+    )
+    .unwrap();
+    let out_alone = y_alone.to_f32_vec();
+
+    // 2. Padded (T = 4)
+    let mut a_padded = target_a.clone();
+    a_padded.extend(vec![0.0f32; 3 * n]);
+    let mut b_padded = target_b.clone();
+    b_padded.extend(vec![0.0f32; 3 * n]);
+    let a_pad_buf = TypedBuffer::from_f32(&[4, n], &a_padded);
+    let b_pad_buf = TypedBuffer::from_f32(&[4, n], &b_padded);
+    let mut y_padded = TypedBuffer::zeros(&[4, n], DType::F32);
+    residual_add(
+        &op,
+        &a_pad_buf.as_view(),
+        &b_pad_buf.as_view(),
+        &mut y_padded.as_view_mut(),
+    )
+    .unwrap();
+    let out_padded = &y_padded.to_f32_vec()[..n];
+
+    // 3. Embedded (T = 4, index 2)
+    let other_a = generate_f32_data(&mut rng, 3 * n, 5.0);
+    let other_b = generate_f32_data(&mut rng, 3 * n, 5.0);
+    let mut a_emb = Vec::with_capacity(4 * n);
+    let mut b_emb = Vec::with_capacity(4 * n);
+    a_emb.extend_from_slice(&other_a[..2 * n]);
+    a_emb.extend_from_slice(&target_a);
+    a_emb.extend_from_slice(&other_a[2 * n..]);
+    b_emb.extend_from_slice(&other_b[..2 * n]);
+    b_emb.extend_from_slice(&target_b);
+    b_emb.extend_from_slice(&other_b[2 * n..]);
+
+    let a_emb_buf = TypedBuffer::from_f32(&[4, n], &a_emb);
+    let b_emb_buf = TypedBuffer::from_f32(&[4, n], &b_emb);
+    let mut y_emb = TypedBuffer::zeros(&[4, n], DType::F32);
+    residual_add(
+        &op,
+        &a_emb_buf.as_view(),
+        &b_emb_buf.as_view(),
+        &mut y_emb.as_view_mut(),
+    )
+    .unwrap();
+    let out_emb = &y_emb.to_f32_vec()[2 * n..3 * n];
+
+    for i in 0..n {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_padded[i].to_bits(),
+            "batch invariance alone vs padded at {i}"
+        );
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_emb[i].to_bits(),
+            "batch invariance alone vs embedded at {i}"
+        );
+    }
+}
+
+#[test]
+fn residual_add_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5013);
+    let shape = [2, 128];
+    let num_elem = 256;
+
+    let op = ResidualAddOp {
+        out_dtype: DType::F32,
+    };
+
+    let a_data = generate_f32_data(&mut rng, num_elem, 3.0);
+    let b_data = generate_f32_data(&mut rng, num_elem, 3.0);
+
+    let a_buf = TypedBuffer::from_f32(&shape, &a_data);
+    let b_buf = TypedBuffer::from_f32(&shape, &b_data);
+    let mut y1 = TypedBuffer::zeros(&shape, DType::F32);
+    let mut y2 = TypedBuffer::zeros(&shape, DType::F32);
+
+    residual_add(
+        &op,
+        &a_buf.as_view(),
+        &b_buf.as_view(),
+        &mut y1.as_view_mut(),
+    )
+    .unwrap();
+    residual_add(
+        &op,
+        &a_buf.as_view(),
+        &b_buf.as_view(),
+        &mut y2.as_view_mut(),
+    )
+    .unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+
+    for i in 0..num_elem {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn residual_add_rejects_shape_and_dtype_mismatches() {
+    let op = ResidualAddOp {
+        out_dtype: DType::F32,
+    };
+
+    let a_buf = TypedBuffer::zeros(&[2, 64], DType::F32);
+    let b_buf = TypedBuffer::zeros(&[2, 128], DType::F32); // Shape mismatch
+    let mut y_buf = TypedBuffer::zeros(&[2, 32], DType::F32); // Shape mismatch
+
+    let err = residual_add(
+        &op,
+        &a_buf.as_view(),
+        &b_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/rope_tests.rs
+++ b/crates/r9v-t0/tests/rope_tests.rs
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Deterministic property and batch-invariance tests for scalar T0 RoPE (Spec 1 §4.B, §6.1, §6.4, Spec 4 §2).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::{DType, RopeOp, RopeScaling, RopeStyle};
+use r9v_t0::{rope, rope_f64_reference, Tolerance, TypedBuffer};
+
+fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        let norm_val = (raw as f32 / u32::MAX as f32) * 2.0 - 1.0;
+        out.push(norm_val * scale);
+    }
+    out
+}
+
+#[test]
+fn rope_both_styles_and_partial_rotary_match_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5040);
+    let tol = Tolerance::f32();
+
+    let (t, h, d) = (3, 4, 64);
+    let num_elem = t * h * d;
+
+    let x_data = generate_f32_data(&mut rng, num_elem, 3.0);
+    let positions = vec![0u32, 17u32, 1024u32];
+
+    for &style in &[RopeStyle::Neox, RopeStyle::Interleaved] {
+        for &rot_dim in &[64u32, 32u32] {
+            let op = RopeOp {
+                rot_dim,
+                theta: 10000.0,
+                style,
+                scaling: RopeScaling::None,
+                mrope_sections: None,
+                out_dtype: DType::F32,
+            };
+
+            let x_buf = TypedBuffer::from_f32(&[t, h, d], &x_data);
+            let pos_buf = TypedBuffer::from_u32(&[t], &positions);
+            let mut y_buf = TypedBuffer::zeros(&[t, h, d], DType::F32);
+
+            rope(
+                &op,
+                &x_buf.as_view(),
+                &pos_buf.as_view(),
+                &mut y_buf.as_view_mut(),
+            )
+            .unwrap();
+
+            let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+            let ref_f64 = rope_f64_reference(&op, &x_f64, [t, h, d], &positions, false);
+
+            for i in 0..num_elem {
+                let actual = y_buf.read_f32(i) as f64;
+                let expected = ref_f64[i];
+                tol.assert_within(
+                    actual,
+                    expected,
+                    &format!("rope style={style:?} rot_dim={rot_dim} at {i}"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn rope_all_scalings_match_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5041);
+    let tol = Tolerance::f32();
+
+    let (t, h, d) = (2, 2, 64);
+    let num_elem = t * h * d;
+    let x_data = generate_f32_data(&mut rng, num_elem, 2.5);
+    let positions = vec![500u32, 3500u32];
+
+    let scalings = [
+        RopeScaling::None,
+        RopeScaling::Linear(2.5),
+        RopeScaling::Yarn {
+            factor: 4.0,
+            beta_fast: 32.0,
+            beta_slow: 1.0,
+            orig_ctx: 4096,
+            mscale: 1.1,
+        },
+        RopeScaling::Dynamic,
+    ];
+
+    for &scaling in &scalings {
+        let op = RopeOp {
+            rot_dim: 64,
+            theta: 10000.0,
+            style: RopeStyle::Neox,
+            scaling,
+            mrope_sections: None,
+            out_dtype: DType::F32,
+        };
+
+        let x_buf = TypedBuffer::from_f32(&[t, h, d], &x_data);
+        let pos_buf = TypedBuffer::from_u32(&[t], &positions);
+        let mut y_buf = TypedBuffer::zeros(&[t, h, d], DType::F32);
+
+        rope(
+            &op,
+            &x_buf.as_view(),
+            &pos_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+        let ref_f64 = rope_f64_reference(&op, &x_f64, [t, h, d], &positions, false);
+
+        for i in 0..num_elem {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(
+                actual,
+                expected,
+                &format!("rope scaling={scaling:?} at {i}"),
+            );
+        }
+    }
+}
+
+#[test]
+fn rope_mrope_matches_f64_reference() {
+    let mut rng = SeededRng::new(0xA1_5042);
+    let tol = Tolerance::f32();
+
+    let (t, h, d) = (2, 2, 64);
+    let num_elem = t * h * d;
+    let x_data = generate_f32_data(&mut rng, num_elem, 2.0);
+
+    // Positions [T, 3] for temporal, height, width
+    let positions_2d = vec![
+        10u32, 25u32, 30u32, // token 0
+        10u32, 26u32, 31u32, // token 1
+    ];
+
+    let op = RopeOp {
+        rot_dim: 64,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: Some([16, 24, 24]), // 16 + 24 + 24 = 64
+        out_dtype: DType::F32,
+    };
+
+    let x_buf = TypedBuffer::from_f32(&[t, h, d], &x_data);
+    let pos_buf = TypedBuffer::from_u32(&[t, 3], &positions_2d);
+    let mut y_buf = TypedBuffer::zeros(&[t, h, d], DType::F32);
+
+    rope(
+        &op,
+        &x_buf.as_view(),
+        &pos_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let x_f64: Vec<f64> = x_data.iter().map(|&v| v as f64).collect();
+    let ref_f64 = rope_f64_reference(&op, &x_f64, [t, h, d], &positions_2d, true);
+
+    for i in 0..num_elem {
+        let actual = y_buf.read_f32(i) as f64;
+        let expected = ref_f64[i];
+        tol.assert_within(actual, expected, &format!("mrope at {i}"));
+    }
+}
+
+#[test]
+fn rope_f16_and_bf16_precision_paths() {
+    let mut rng = SeededRng::new(0xA1_5043);
+    let tol = Tolerance::f16_bf16();
+    let (t, h, d) = (2, 2, 32);
+    let num_elem = t * h * d;
+
+    let x_data = generate_f32_data(&mut rng, num_elem, 2.0);
+    let positions = vec![5u32, 100u32];
+
+    for &dt in &[DType::F16, DType::Bf16] {
+        let op = RopeOp {
+            rot_dim: 32,
+            theta: 10000.0,
+            style: RopeStyle::Interleaved,
+            scaling: RopeScaling::Linear(2.0),
+            mrope_sections: None,
+            out_dtype: dt,
+        };
+
+        let mut x_buf = TypedBuffer::zeros(&[t, h, d], dt);
+        for i in 0..num_elem {
+            x_buf.write_f32(i, x_data[i]);
+        }
+        let pos_buf = TypedBuffer::from_u32(&[t], &positions);
+        let mut y_buf = TypedBuffer::zeros(&[t, h, d], dt);
+
+        rope(
+            &op,
+            &x_buf.as_view(),
+            &pos_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let x_f64: Vec<f64> = (0..num_elem).map(|i| x_buf.read_f32(i) as f64).collect();
+        let ref_f64 = rope_f64_reference(&op, &x_f64, [t, h, d], &positions, false);
+
+        for i in 0..num_elem {
+            let actual = y_buf.read_f32(i) as f64;
+            let expected = ref_f64[i];
+            tol.assert_within(actual, expected, &format!("rope_{dt} at {i}"));
+        }
+    }
+}
+
+#[test]
+fn rope_batch_invariance() {
+    let mut rng = SeededRng::new(0xA1_5044);
+    let (h, d) = (2, 64);
+    let token_elems = h * d;
+
+    let target_token_data = generate_f32_data(&mut rng, token_elems, 3.0);
+    let target_pos = 42u32;
+
+    let op = RopeOp {
+        rot_dim: 48,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::Yarn {
+            factor: 2.0,
+            beta_fast: 16.0,
+            beta_slow: 1.0,
+            orig_ctx: 2048,
+            mscale: 1.05,
+        },
+        mrope_sections: None,
+        out_dtype: DType::F32,
+    };
+
+    // 1. Alone (T = 1)
+    let x_alone = TypedBuffer::from_f32(&[1, h, d], &target_token_data);
+    let pos_alone = TypedBuffer::from_u32(&[1], &[target_pos]);
+    let mut y_alone = TypedBuffer::zeros(&[1, h, d], DType::F32);
+    rope(
+        &op,
+        &x_alone.as_view(),
+        &pos_alone.as_view(),
+        &mut y_alone.as_view_mut(),
+    )
+    .unwrap();
+    let out_alone = y_alone.to_f32_vec();
+
+    // 2. Padded (T = 4)
+    let mut x_pad = target_token_data.clone();
+    x_pad.extend(vec![0.0f32; 3 * token_elems]);
+    let x_pad_buf = TypedBuffer::from_f32(&[4, h, d], &x_pad);
+    let pos_pad_buf = TypedBuffer::from_u32(&[4], &[target_pos, 0, 0, 0]);
+    let mut y_padded = TypedBuffer::zeros(&[4, h, d], DType::F32);
+    rope(
+        &op,
+        &x_pad_buf.as_view(),
+        &pos_pad_buf.as_view(),
+        &mut y_padded.as_view_mut(),
+    )
+    .unwrap();
+    let out_padded = &y_padded.to_f32_vec()[..token_elems];
+
+    // 3. Embedded (T = 4, target token at index 2)
+    let other_tokens = generate_f32_data(&mut rng, 3 * token_elems, 4.0);
+    let mut x_emb = Vec::with_capacity(4 * token_elems);
+    x_emb.extend_from_slice(&other_tokens[..2 * token_elems]);
+    x_emb.extend_from_slice(&target_token_data);
+    x_emb.extend_from_slice(&other_tokens[2 * token_elems..]);
+    let x_emb_buf = TypedBuffer::from_f32(&[4, h, d], &x_emb);
+    let pos_emb_buf = TypedBuffer::from_u32(&[4], &[100, 200, target_pos, 400]);
+    let mut y_emb = TypedBuffer::zeros(&[4, h, d], DType::F32);
+    rope(
+        &op,
+        &x_emb_buf.as_view(),
+        &pos_emb_buf.as_view(),
+        &mut y_emb.as_view_mut(),
+    )
+    .unwrap();
+    let out_emb = &y_emb.to_f32_vec()[2 * token_elems..3 * token_elems];
+
+    for i in 0..token_elems {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_padded[i].to_bits(),
+            "batch invariance alone vs padded at {i}"
+        );
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_emb[i].to_bits(),
+            "batch invariance alone vs embedded at {i}"
+        );
+    }
+}
+
+#[test]
+fn rope_determinism_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xA1_5045);
+    let (t, h, d) = (3, 2, 64);
+    let num_elem = t * h * d;
+
+    let op = RopeOp {
+        rot_dim: 64,
+        theta: 10000.0,
+        style: RopeStyle::Interleaved,
+        scaling: RopeScaling::Dynamic,
+        mrope_sections: None,
+        out_dtype: DType::F32,
+    };
+
+    let x_data = generate_f32_data(&mut rng, num_elem, 3.0);
+    let positions = vec![10u32, 200u32, 3000u32];
+
+    let x_buf = TypedBuffer::from_f32(&[t, h, d], &x_data);
+    let pos_buf = TypedBuffer::from_u32(&[t], &positions);
+
+    let mut y1 = TypedBuffer::zeros(&[t, h, d], DType::F32);
+    let mut y2 = TypedBuffer::zeros(&[t, h, d], DType::F32);
+
+    rope(
+        &op,
+        &x_buf.as_view(),
+        &pos_buf.as_view(),
+        &mut y1.as_view_mut(),
+    )
+    .unwrap();
+    rope(
+        &op,
+        &x_buf.as_view(),
+        &pos_buf.as_view(),
+        &mut y2.as_view_mut(),
+    )
+    .unwrap();
+
+    let out1 = y1.to_f32_vec();
+    let out2 = y2.to_f32_vec();
+
+    for i in 0..num_elem {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "determinism failed at {i}"
+        );
+    }
+}
+
+#[test]
+fn rope_rejects_odd_rot_dim_and_dimension_mismatch() {
+    let op = RopeOp {
+        rot_dim: 33, // odd rot_dim invalid
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+        out_dtype: DType::F32,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 2, 32], DType::F32); // rot_dim 33 > head dim 32
+    let pos_buf = TypedBuffer::zeros(&[3], DType::U32); // T=3 != T=2
+    let mut y_buf = TypedBuffer::zeros(&[2, 2, 32], DType::F32);
+
+    let err = rope(
+        &op,
+        &x_buf.as_view(),
+        &pos_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("validation error(s)"));
+    assert!(msg.contains("rot_dim must be positive and even"));
+    assert!(msg.contains("exceeds head dimension"));
+    assert!(msg.contains("does not match"));
+}

--- a/crates/r9v-t0/tests/rope_tests.rs
+++ b/crates/r9v-t0/tests/rope_tests.rs
@@ -381,3 +381,68 @@ fn rope_rejects_odd_rot_dim_and_dimension_mismatch() {
     assert!(msg.contains("exceeds head dimension"));
     assert!(msg.contains("does not match"));
 }
+
+#[test]
+fn rope_rejects_rank_zero_positions_with_typed_error() {
+    let op = RopeOp {
+        rot_dim: 16,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+        out_dtype: DType::F32,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 2, 16], DType::F32);
+    let pos_buf = TypedBuffer::zeros(&[], DType::U32); // rank 0
+    let mut y_buf = TypedBuffer::zeros(&[2, 2, 16], DType::F32);
+
+    let err = rope(
+        &op,
+        &x_buf.as_view(),
+        &pos_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+
+    match err {
+        r9v_t0::T0Error::RankMismatch {
+            tensor,
+            expected,
+            got,
+            ..
+        } => {
+            assert_eq!(tensor, "positions");
+            assert_eq!(expected, 1);
+            assert_eq!(got, 0);
+        }
+        other => panic!("expected RankMismatch error, got {other:?}"),
+    }
+}
+
+#[test]
+fn rope_rejects_dynamic_scaling_rot_dim_2() {
+    let op = RopeOp {
+        rot_dim: 2,
+        theta: 10000.0,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::Dynamic,
+        mrope_sections: None,
+        out_dtype: DType::F32,
+    };
+
+    let x_buf = TypedBuffer::zeros(&[2, 2, 16], DType::F32);
+    let pos_buf = TypedBuffer::zeros(&[2], DType::U32);
+    let mut y_buf = TypedBuffer::zeros(&[2, 2, 16], DType::F32);
+
+    let err = rope(
+        &op,
+        &x_buf.as_view(),
+        &pos_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+
+    let msg = err.to_string();
+    assert!(msg.contains("rot_dim 2 is invalid for Dynamic RoPE"));
+}


### PR DESCRIPTION
## Card
A1.5 — t0 elementwise group   (kind: implementation; GPU: no; size: M)

## Spec sections implemented
- spec 1 §4.A: scalar copy, cast, and per-token/per-block activation quantization.
- spec 1 §4.B: scalar norm, residual add, gated and standalone activations, and RoPE including MRoPE.
- spec 1 §6.1, §6.4: deterministic f32 evaluation and batch invariance with independent f64 references.
- spec 4 §2: portable scalar T0 reference implementations.

## Deliverables
- [x] Scalar f32 RMS/Layer norm over Last/Head axes with weight offset and optional bias.
- [x] Residual add, act-mul, and standalone activation for every declared activation kind.
- [x] RoPE in NeoX and interleaved styles with every scaling mode, partial rotary, and MRoPE.
- [x] Cast and bit-exact copy across the declared dtypes.
- [x] PerToken i8/e4m3 and PerBlock32 i8 quant_act with f32 absmax and ties-to-even i8 rounding.
- [x] Typed validation and dispatch for all elementwise T0 operations.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| norm properties and batch invariance | crates/r9v-t0/tests/norm_tests.rs | cpu-only | green |
| activation/act-mul properties and batch invariance | crates/r9v-t0/tests/activation_tests.rs; crates/r9v-t0/tests/act_mul_tests.rs | cpu-only | green |
| RoPE styles/scalings/MRoPE properties and batch invariance | crates/r9v-t0/tests/rope_tests.rs | cpu-only | green |
| cast/copy properties, batch invariance, and bit preservation | crates/r9v-t0/tests/cast_tests.rs; crates/r9v-t0/tests/copy_tests.rs | cpu-only | green |
| quant_act modes, properties, and batch invariance | crates/r9v-t0/tests/quant_act_tests.rs | cpu-only | green |
| public dispatch, arity, and backing-storage safety | crates/r9v-t0/tests/api_shape.rs | cpu-only | green |

## Decisions
- crates/r9v-t0/src/act_mul.rs:91 — clamp applies to the activated gate before multiplication.
- crates/r9v-t0/src/quant_act.rs:137 — zero absmax emits zero scale and zero payload.
- crates/r9v-t0/src/quant_act.rs:143 — symmetric i8 uses ties-to-even and [-127, 127].
- crates/r9v-t0/src/rope.rs:20 — MRoPE sections allocate channel pairs across one monotonic frequency spectrum.
- crates/r9v-t0/src/rope.rs:87 — Dynamic RoPE uses a per-position 2048 reference context without batch-wide state.

## SPEC-ISSUES filed
- none

## New dependencies
- r9v-ir: existing workspace crate newly consumed for the typed Op IR contracts.
- thiserror: existing workspace dependency newly consumed for structured T0 errors.

## Hardware
Tests run here: hosted cpu-only plus existing stub-device workspace tests
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command `cargo test --workspace --all-targets`, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- Performance receipt: no; this is the scalar correctness tier and has no GPU performance gate.

## Size check
Diff size vs card size class: 6,678 changed lines vs M — larger than the estimate because the card spans nine typed kernels, dtype/buffer infrastructure, independent references, and exhaustive property/batch-invariance tests; scope remains exactly A1.5.
