### PR TITLE
A1.8: implement deterministic T0 sampling group

### DIFF
--- a/crates/r9v-t0/src/error.rs
+++ b/crates/r9v-t0/src/error.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Error types for the R9V T0 CPU reference implementation (Spec 4 §2, CONVENTIONS.md §1).
+//! Error types for the R9V T0 CPU reference implementation
+//! (Spec 1 §4.B, §4.F, Spec 4 §2, CONVENTIONS.md §1, Cards A1.5 and A1.8).
 
 use r9v_ir::DType;
 
@@ -112,6 +113,77 @@ pub enum T0Error {
         /// Vector of formatted problem descriptions.
         problems: Vec<String>,
     },
+
+    /// Flat-slice length mismatch for sampling ops (Spec 1 §4.F).
+    ///
+    /// Renamed from the A1.8 `DimensionMismatch` so it cannot collide with the
+    /// A1.5 symbolic-dimension `DimensionMismatch` above, which carries
+    /// `(dim_name, expected_from, ...)` instead of `(op, detail)`.
+    #[error("shape length mismatch in {op}: tensor {tensor} expected length {expected}, got {got}; detail: {detail}")]
+    ShapeLengthMismatch {
+        /// Op name.
+        op: &'static str,
+        /// Tensor name.
+        tensor: &'static str,
+        /// Expected size/length.
+        expected: usize,
+        /// Actual size/length.
+        got: usize,
+        /// Extra detail.
+        detail: String,
+    },
+
+    /// Empty tensor or slice where non-empty was required.
+    #[error("empty tensor in {op}: {tensor} has length 0")]
+    EmptyInput {
+        /// Op name.
+        op: &'static str,
+        /// Tensor name.
+        tensor: &'static str,
+    },
+
+    /// All tokens masked out by grammar mask.
+    #[error("all tokens masked out by grammar mask in sequence {seq}, query {query}; vocabulary size was {vocab_size}")]
+    AllTokensMasked {
+        /// Sequence index.
+        seq: usize,
+        /// Query index.
+        query: usize,
+        /// Vocab size.
+        vocab_size: usize,
+    },
+
+    /// Invalid probability distribution.
+    #[error("invalid probability distribution in {op} for sequence {seq}, position {pos}: sum is {sum}, expected positive finite sum")]
+    InvalidDistribution {
+        /// Op name.
+        op: &'static str,
+        /// Sequence index.
+        seq: usize,
+        /// Position index.
+        pos: usize,
+        /// Observed sum.
+        sum: f32,
+    },
+
+    /// Invalid tree structure.
+    #[error("invalid tree draft structure for sequence {seq}: {detail}")]
+    InvalidTree {
+        /// Sequence index.
+        seq: usize,
+        /// Reason for failure.
+        detail: String,
+    },
+
+    /// Multiple coexisting typed validation problems (Spec 1 §4.F).
+    ///
+    /// Renamed from the A1.8 `Multiple` so it cannot collide with the A1.5
+    /// `Multiple` above, which carries `(op, count, problems: Vec<String>)`.
+    #[error("multiple T0 validation problems ({} failures): {problems:?}", problems.len())]
+    MultipleErrors {
+        /// Accumulated problems.
+        problems: Box<[T0Error]>,
+    },
 }
 
 impl T0Error {
@@ -124,6 +196,24 @@ impl T0Error {
                 op,
                 count: problems.len(),
                 problems,
+            })
+        }
+    }
+
+    /// Aggregates typed problems: `Ok(())` if empty, the single error if one,
+    /// or `MultipleErrors` otherwise (Spec 1 §4.F).
+    ///
+    /// Renamed from the A1.8 `from_problems` so it cannot collide with the
+    /// A1.5 `from_problems(op, problems: Vec<String>)` above.
+    pub fn from_typed_problems(mut problems: Vec<T0Error>) -> Result<(), Self> {
+        if problems.is_empty() {
+            Ok(())
+        } else if problems.len() == 1 {
+            // Invariant: length was just checked to be exactly 1, so pop cannot fail.
+            Err(problems.pop().expect("exactly one problem"))
+        } else {
+            Err(Self::MultipleErrors {
+                problems: problems.into_boxed_slice(),
             })
         }
     }

--- a/crates/r9v-t0/src/error.rs
+++ b/crates/r9v-t0/src/error.rs
@@ -166,6 +166,40 @@ pub enum T0Error {
         sum: f32,
     },
 
+    /// A token id falls outside the vocabulary addressed by an operation.
+    #[error(
+        "token id {token} at {tensor}[{position}] is outside vocabulary 0..{vocab_size} in {op}"
+    )]
+    TokenOutOfRange {
+        /// Op name.
+        op: &'static str,
+        /// Tensor or parameter name.
+        tensor: &'static str,
+        /// Flat position of the invalid token id.
+        position: usize,
+        /// Invalid token id.
+        token: u32,
+        /// Vocabulary size.
+        vocab_size: usize,
+    },
+
+    /// A probability is negative or non-finite.
+    #[error(
+        "invalid probability {value} at token {token} in {op}, sequence {seq}, position {pos}"
+    )]
+    InvalidProbability {
+        /// Op name.
+        op: &'static str,
+        /// Sequence index.
+        seq: usize,
+        /// Position index.
+        pos: usize,
+        /// Token index.
+        token: usize,
+        /// Invalid probability.
+        value: f32,
+    },
+
     /// Invalid tree structure.
     #[error("invalid tree draft structure for sequence {seq}: {detail}")]
     InvalidTree {

--- a/crates/r9v-t0/src/lib.rs
+++ b/crates/r9v-t0/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-//! R9V CPU reference scalar T0 implementations (Spec 1 §4.B, §6.4, Spec 4 §2, Card A1.5).
+//! R9V CPU reference scalar T0 implementations
+//! (Spec 1 §4.B, §4.F, §6.4, §6.5, Spec 4 §2, Spec 7 §4, Cards A1.5 and A1.8).
 //!
 //! T0 serves as the primary ground-truth oracle for all engine operations.
 //! Implementations are scalar, strictly deterministic, accumulate in f32 (or i32),
@@ -13,9 +14,11 @@ pub mod copy;
 pub mod dtype;
 pub mod error;
 pub mod norm;
+pub mod philox;
 pub mod quant_act;
 pub mod residual_add;
 pub mod rope;
+pub mod sampling;
 pub mod tolerance;
 
 pub use act_mul::{act_mul, act_mul_f64_reference};
@@ -32,9 +35,11 @@ pub use dtype::{
 };
 pub use error::T0Error;
 pub use norm::{norm, norm_f64_reference};
+pub use philox::{philox4x32_10, u32_to_unit_f32, RngState};
 pub use quant_act::{fp8_e4m3_encode_f64_oracle, quant_act, quant_act_f64_reference};
 pub use residual_add::{residual_add, residual_add_f64_reference};
 pub use rope::{rope, rope_f64_reference};
+pub use sampling::{logits_postprocess, sample, verify, VerifyOutput};
 pub use tolerance::Tolerance;
 
 use r9v_ir::Op;

--- a/crates/r9v-t0/src/philox.rs
+++ b/crates/r9v-t0/src/philox.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Philox4x32-10 counter-based PRNG and RNG state (Spec 1 §4.F, Spec 4 §5.8, Spec 7 §4).
+
+/// Round multiplier constant M0 (Random123 PHILOX_M4x32_0).
+const PHILOX_M0: u32 = 0xD251_1F53;
+/// Round multiplier constant M1 (Random123 PHILOX_M4x32_1).
+const PHILOX_M1: u32 = 0xCD9E_8D57;
+/// Per-round Weyl key bump constant W0 (Random123 PHILOX_W32_0).
+const PHILOX_W0: u32 = 0x9E37_79B9;
+/// Per-round Weyl key bump constant W1 (Random123 PHILOX_W32_1).
+const PHILOX_W1: u32 = 0xBB67_AE85;
+
+#[inline]
+fn mulhilo(a: u32, b: u32) -> (u32, u32) {
+    let p = (a as u64) * (b as u64);
+    ((p >> 32) as u32, p as u32)
+}
+
+#[inline]
+fn round(ctr: [u32; 4], key: [u32; 2]) -> [u32; 4] {
+    let (hi0, lo0) = mulhilo(PHILOX_M0, ctr[0]);
+    let (hi1, lo1) = mulhilo(PHILOX_M1, ctr[2]);
+    [hi1 ^ ctr[1] ^ key[0], lo1, hi0 ^ ctr[3] ^ key[1], lo0]
+}
+
+/// 10-round Philox4x32 block function (Spec 1 §4.F, Salmon et al. 2011).
+///
+/// Maps a 128-bit counter `ctr` and 64-bit `key` to four pseudo-random `u32` words.
+/// Round 0 uses the initial key; rounds 1..9 bump key words by Weyl constants before the round.
+#[inline]
+#[must_use]
+pub fn philox4x32_10(ctr: [u32; 4], mut key: [u32; 2]) -> [u32; 4] {
+    let mut c = round(ctr, key);
+    for _ in 1..10 {
+        key[0] = key[0].wrapping_add(PHILOX_W0);
+        key[1] = key[1].wrapping_add(PHILOX_W1);
+        c = round(c, key);
+    }
+    c
+}
+
+// DECISION(A1.8): Philox4x32 maps key [seed as u32, (seed >> 32) as u32] and counter [draw_index, step as u32, seq_id as u32, (seq_id >> 32) as u32]; uniform f32 draws map word >> 9 centered by +0.5 in (0, 1) to avoid boundary saturation in inverse-CDF; rejected uncentered float conversion because boundary 0.0/1.0 corrupts rejection and CDF thresholds. Spec 1 §4.F, Spec 7 §4.
+/// Maps a 32-bit random word to an `f32` uniform on the open interval `(0, 1)` (Spec 1 §4.F).
+///
+/// Uses the upper 23 bits (`word >> 9`) centered by `+0.5` scaled by `2^-23`.
+/// This guarantees the result is strictly within `(0.0, 1.0)`, avoiding exact 0.0 or 1.0
+/// boundary saturation in inverse-CDF or rejection sampling.
+#[inline]
+#[must_use]
+pub fn u32_to_unit_f32(word: u32) -> f32 {
+    ((word >> 9) as f32 + 0.5) * (1.0 / 8_388_608.0)
+}
+
+/// Explicit RNG state for a sequence (Spec 1 §4.F, Spec 7 §4).
+///
+/// Holds the seed, sequence identifier, execution step, and draw counter.
+/// Because Philox4x32 is counter-based and keyed by `(seq_id, step, draw_index)`,
+/// every draw is reproducible across arbitrary batch sizes and topologies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RngState {
+    seed: u64,
+    seq_id: u64,
+    step: u64,
+    draw_index: u32,
+}
+
+impl RngState {
+    /// Creates a new RNG state with `draw_index = 0` (Spec 1 §4.F).
+    pub const fn new(seed: u64, seq_id: u64, step: u64) -> Self {
+        Self {
+            seed,
+            seq_id,
+            step,
+            draw_index: 0,
+        }
+    }
+
+    /// Creates an RNG state with an explicit initial `draw_index` (Spec 1 §4.F).
+    pub const fn with_draw(seed: u64, seq_id: u64, step: u64, draw_index: u32) -> Self {
+        Self {
+            seed,
+            seq_id,
+            step,
+            draw_index,
+        }
+    }
+
+    /// Returns the RNG seed (Spec 1 §4.F, Spec 10 §4).
+    pub const fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// Returns the sequence identifier (Spec 1 §4.F, Spec 3 §2).
+    pub const fn seq_id(&self) -> u64 {
+        self.seq_id
+    }
+
+    /// Returns the step identifier/counter (Spec 1 §4.F, Spec 6 §9).
+    pub const fn step(&self) -> u64 {
+        self.step
+    }
+
+    /// Returns the current draw index within the step (Spec 1 §4.F).
+    pub const fn draw_index(&self) -> u32 {
+        self.draw_index
+    }
+
+    /// Updates the execution step and resets the draw counter to 0 (Spec 1 §4.F).
+    pub fn set_step(&mut self, step: u64) {
+        self.step = step;
+        self.draw_index = 0;
+    }
+
+    /// Advances the draw index by `count` (Spec 1 §4.F).
+    pub fn advance(&mut self, count: u32) {
+        self.draw_index = self.draw_index.wrapping_add(count);
+    }
+
+    /// Draws a uniform `f32` in `(0, 1)` at a specified draw index without mutating the state (Spec 1 §4.F, Spec 7 §4).
+    #[must_use]
+    pub fn draw_at(&self, draw: u32) -> f32 {
+        let key = [self.seed as u32, (self.seed >> 32) as u32];
+        let ctr = [
+            draw,
+            self.step as u32,
+            self.seq_id as u32,
+            (self.seq_id >> 32) as u32,
+        ];
+        let words = philox4x32_10(ctr, key);
+        u32_to_unit_f32(words[0])
+    }
+
+    /// Draws the next uniform `f32` in `(0, 1)` and increments `draw_index` by 1 (Spec 1 §4.F).
+    pub fn draw_uniform_f32(&mut self) -> f32 {
+        let val = self.draw_at(self.draw_index);
+        self.draw_index = self.draw_index.wrapping_add(1);
+        val
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_philox_known_answer_vectors() {
+        assert_eq!(
+            philox4x32_10([0, 0, 0, 0], [0, 0]),
+            [0x6627_e8d5, 0xe169_c58d, 0xbc57_ac4c, 0x9b00_dbd8]
+        );
+        assert_eq!(
+            philox4x32_10([0xffff_ffff; 4], [0xffff_ffff, 0xffff_ffff]),
+            [0x408f_276d, 0x41c8_3b0e, 0xa20b_c7c6, 0x6d54_51fd]
+        );
+        assert_eq!(
+            philox4x32_10(
+                [0x243f_6a88, 0x85a3_08d3, 0x1319_8a2e, 0x0370_7344],
+                [0xa409_3822, 0x299f_31d0]
+            ),
+            [0xd16c_fe09, 0x94fd_cceb, 0x5001_e420, 0x2412_6ea1]
+        );
+    }
+
+    #[test]
+    fn test_u32_to_unit_f32_strictly_in_open_interval() {
+        let min_val = u32_to_unit_f32(0);
+        let max_val = u32_to_unit_f32(0xffff_ffff);
+        assert!(min_val > 0.0);
+        assert!(max_val < 1.0);
+        assert!(min_val < max_val);
+    }
+
+    #[test]
+    fn test_rng_state_draw_reproducibility() {
+        let mut rng1 = RngState::new(42, 1, 0);
+        let mut rng2 = RngState::new(42, 1, 0);
+        for _ in 0..100 {
+            assert_eq!(rng1.draw_uniform_f32(), rng2.draw_uniform_f32());
+        }
+    }
+}

--- a/crates/r9v-t0/src/sampling.rs
+++ b/crates/r9v-t0/src/sampling.rs
@@ -759,7 +759,10 @@ pub fn verify(
 
             if all_path_accepted {
                 // All tokens on path accepted: sample bonus token from target_probs[last_node + 1]
-                let last_node = *path.last().unwrap();
+                let last_node = path.last().copied().ok_or_else(|| T0Error::InvalidTree {
+                    seq: s_idx,
+                    detail: "internal root-to-leaf path is empty".to_string(),
+                })?;
                 let bonus_dist = &t_probs_row[(last_node + 1) * v..(last_node + 2) * v];
                 terminal_token = match method {
                     VerifyMethod::Greedy => argmax_stable(bonus_dist) as u32,

--- a/crates/r9v-t0/src/sampling.rs
+++ b/crates/r9v-t0/src/sampling.rs
@@ -348,13 +348,15 @@ pub fn sample(
         });
     }
 
-    let expected_len = s.checked_mul(v).ok_or_else(|| T0Error::ShapeLengthMismatch {
-        op: "sample",
-        tensor: "probs",
-        expected: usize::MAX,
-        got: probs.len(),
-        detail: "overflow computing S * V".to_string(),
-    })?;
+    let expected_len = s
+        .checked_mul(v)
+        .ok_or_else(|| T0Error::ShapeLengthMismatch {
+            op: "sample",
+            tensor: "probs",
+            expected: usize::MAX,
+            got: probs.len(),
+            detail: "overflow computing S * V".to_string(),
+        })?;
 
     if probs.len() != expected_len {
         return Err(T0Error::ShapeLengthMismatch {
@@ -432,13 +434,15 @@ pub fn verify(
         });
     }
 
-    let k_plus_one = k.checked_add(1).ok_or_else(|| T0Error::ShapeLengthMismatch {
-        op: "verify",
-        tensor: "k",
-        expected: u32::MAX as usize,
-        got: k,
-        detail: "k + 1 overflows usize".to_string(),
-    })?;
+    let k_plus_one = k
+        .checked_add(1)
+        .ok_or_else(|| T0Error::ShapeLengthMismatch {
+            op: "verify",
+            tensor: "k",
+            expected: u32::MAX as usize,
+            got: k,
+            detail: "k + 1 overflows usize".to_string(),
+        })?;
     let terminal_draw = u32::try_from(k).map_err(|_| T0Error::ShapeLengthMismatch {
         op: "verify",
         tensor: "k",
@@ -446,23 +450,26 @@ pub fn verify(
         got: k,
         detail: "k cannot be represented by the Philox draw index".to_string(),
     })?;
-    let draw_advance = terminal_draw
-        .checked_add(1)
+    let draw_advance =
+        terminal_draw
+            .checked_add(1)
+            .ok_or_else(|| T0Error::ShapeLengthMismatch {
+                op: "verify",
+                tensor: "k",
+                expected: (u32::MAX - 1) as usize,
+                got: k,
+                detail: "k + 1 cannot be represented by the Philox draw index".to_string(),
+            })?;
+
+    let expected_draft = s
+        .checked_mul(k)
         .ok_or_else(|| T0Error::ShapeLengthMismatch {
             op: "verify",
-            tensor: "k",
-            expected: (u32::MAX - 1) as usize,
-            got: k,
-            detail: "k + 1 cannot be represented by the Philox draw index".to_string(),
+            tensor: "draft_tokens",
+            expected: usize::MAX,
+            got: draft_tokens.len(),
+            detail: "overflow computing S * k".to_string(),
         })?;
-
-    let expected_draft = s.checked_mul(k).ok_or_else(|| T0Error::ShapeLengthMismatch {
-        op: "verify",
-        tensor: "draft_tokens",
-        expected: usize::MAX,
-        got: draft_tokens.len(),
-        detail: "overflow computing S * k".to_string(),
-    })?;
 
     if draft_tokens.len() != expected_draft {
         return Err(T0Error::ShapeLengthMismatch {

--- a/crates/r9v-t0/src/sampling.rs
+++ b/crates/r9v-t0/src/sampling.rs
@@ -88,10 +88,25 @@ pub fn logits_postprocess(
         });
     }
 
-    // Validate all sampling params first (collect all violations per CONVENTIONS.md §1.4)
+    // Validate all sampling params first (collect all violations per CONVENTIONS.md §1.4).
+    let mut parameter_problems = Vec::new();
     for p in params {
-        p.validate()?;
+        if let Err(error) = p.validate() {
+            parameter_problems.push(T0Error::Ir(error));
+        }
+        for (position, &(token, _)) in p.logit_bias.iter().enumerate() {
+            if token as usize >= v {
+                parameter_problems.push(T0Error::TokenOutOfRange {
+                    op: "logits_postprocess",
+                    tensor: "logit_bias",
+                    position,
+                    token,
+                    vocab_size: v,
+                });
+            }
+        }
     }
+    T0Error::from_typed_problems(parameter_problems)?;
 
     if let Some(history) = history_counts {
         let expected_hist = s * v;
@@ -137,9 +152,7 @@ pub fn logits_postprocess(
             // 1. Sparse logit bias added before temperature (Spec 1 §4.F)
             for &(token_id, bias) in &p.logit_bias {
                 let idx = token_id as usize;
-                if idx < v {
-                    work_logits[idx] += bias;
-                }
+                work_logits[idx] += bias;
             }
 
             // 2. Penalties applied to tokens with non-zero history counts (Spec 1 §4.F)
@@ -363,20 +376,14 @@ pub fn sample(
         });
     }
 
+    for s_idx in 0..s {
+        validate_distribution(&probs[s_idx * v..(s_idx + 1) * v], "sample", s_idx, 0)?;
+    }
+
     let mut tokens = Vec::with_capacity(s);
 
     for (s_idx, rng) in rng_states.iter_mut().enumerate().take(s) {
         let p_row = &probs[s_idx * v..(s_idx + 1) * v];
-
-        let sum: f32 = p_row.iter().sum();
-        if sum <= 0.0 || !sum.is_finite() {
-            return Err(T0Error::InvalidDistribution {
-                op: "sample",
-                seq: s_idx,
-                pos: 0,
-                sum,
-            });
-        }
 
         // Draw uniform random float u in (0, 1) and advance RNG state by 1
         let u = rng.draw_uniform_f32();
@@ -425,6 +432,30 @@ pub fn verify(
         });
     }
 
+    let k_plus_one = k.checked_add(1).ok_or_else(|| T0Error::ShapeLengthMismatch {
+        op: "verify",
+        tensor: "k",
+        expected: u32::MAX as usize,
+        got: k,
+        detail: "k + 1 overflows usize".to_string(),
+    })?;
+    let terminal_draw = u32::try_from(k).map_err(|_| T0Error::ShapeLengthMismatch {
+        op: "verify",
+        tensor: "k",
+        expected: u32::MAX as usize,
+        got: k,
+        detail: "k cannot be represented by the Philox draw index".to_string(),
+    })?;
+    let draw_advance = terminal_draw
+        .checked_add(1)
+        .ok_or_else(|| T0Error::ShapeLengthMismatch {
+            op: "verify",
+            tensor: "k",
+            expected: (u32::MAX - 1) as usize,
+            got: k,
+            detail: "k + 1 cannot be represented by the Philox draw index".to_string(),
+        })?;
+
     let expected_draft = s.checked_mul(k).ok_or_else(|| T0Error::ShapeLengthMismatch {
         op: "verify",
         tensor: "draft_tokens",
@@ -441,6 +472,18 @@ pub fn verify(
             got: draft_tokens.len(),
             detail: format!("draft_tokens length != S({s}) * k({k})"),
         });
+    }
+
+    for (position, &token) in draft_tokens.iter().enumerate() {
+        if token as usize >= v {
+            return Err(T0Error::TokenOutOfRange {
+                op: "verify",
+                tensor: "draft_tokens",
+                position,
+                token,
+                vocab_size: v,
+            });
+        }
     }
 
     if let Some(dp) = draft_probs {
@@ -466,7 +509,7 @@ pub fn verify(
     }
 
     let expected_target = s
-        .checked_mul(k + 1)
+        .checked_mul(k_plus_one)
         .and_then(|sk1| sk1.checked_mul(v))
         .ok_or_else(|| T0Error::ShapeLengthMismatch {
             op: "verify",
@@ -484,7 +527,7 @@ pub fn verify(
             got: target_probs.len(),
             detail: format!(
                 "target_probs length != S({s}) * (k+1)({sk1}) * V({v})",
-                sk1 = k + 1
+                sk1 = k_plus_one
             ),
         });
     }
@@ -508,6 +551,21 @@ pub fn verify(
                 got: tree_mask.t(),
                 detail: format!("TreeMask token count T({}) != k({k})", tree_mask.t()),
             });
+        }
+    }
+
+    if let Some(dp) = draft_probs {
+        for s_idx in 0..s {
+            for pos in 0..k {
+                let offset = (s_idx * k + pos) * v;
+                validate_distribution(&dp[offset..offset + v], "verify", s_idx, pos)?;
+            }
+        }
+    }
+    for s_idx in 0..s {
+        for pos in 0..k_plus_one {
+            let offset = (s_idx * k_plus_one + pos) * v;
+            validate_distribution(&target_probs[offset..offset + v], "verify", s_idx, pos)?;
         }
     }
 
@@ -552,21 +610,26 @@ pub fn verify(
         }
     };
 
-    let mut out_accepted = vec![0u32; s * (k + 1)];
+    let mut out_accepted = vec![0u32; s * k_plus_one];
     let mut out_accept_len = vec![0u32; s];
 
     for s_idx in 0..s {
         let d_tokens = &draft_tokens[s_idx * k..(s_idx + 1) * k];
         let d_probs_row = draft_probs.map(|dp| &dp[s_idx * k * v..(s_idx + 1) * k * v]);
-        let t_probs_row = &target_probs[s_idx * (k + 1) * v..(s_idx + 1) * (k + 1) * v];
+        let t_probs_row = &target_probs[s_idx * k_plus_one * v..(s_idx + 1) * k_plus_one * v];
         let rng = &mut rng_states[s_idx];
 
-        let out_acc_slice = &mut out_accepted[s_idx * (k + 1)..(s_idx + 1) * (k + 1)];
+        let out_acc_slice = &mut out_accepted[s_idx * k_plus_one..(s_idx + 1) * k_plus_one];
 
         if k == 0 || paths.is_empty() {
             // Degenerate k=0: sample single continuation token directly from root distribution
             let root_dist = &t_probs_row[..v];
-            let bonus_tok = sample_from_distribution(root_dist, rng.draw_at(0))?;
+            let bonus_tok = match method {
+                VerifyMethod::Greedy => argmax_stable(root_dist) as u32,
+                VerifyMethod::Rejection | VerifyMethod::TypicalAcceptance { .. } => {
+                    sample_from_distribution(root_dist, rng.draw_at(0))?
+                }
+            };
             out_acc_slice[0] = bonus_tok;
             out_accept_len[s_idx] = 0;
             rng.advance(1);
@@ -639,8 +702,10 @@ pub fn verify(
                                 for r in &mut residual {
                                     *r *= inv;
                                 }
-                                terminal_token =
-                                    sample_from_distribution(&residual, rng.draw_at(k as u32))?;
+                                terminal_token = sample_from_distribution(
+                                    &residual,
+                                    rng.draw_at(terminal_draw),
+                                )?;
                             } else {
                                 // Fallback to target argmax if residual is zeroed
                                 terminal_token = argmax_stable(target_dist) as u32;
@@ -671,7 +736,7 @@ pub fn verify(
                         } else {
                             // Typical replacement sampled from target_probs[pos]
                             terminal_token =
-                                sample_from_distribution(target_dist, rng.draw_at(k as u32))?;
+                                sample_from_distribution(target_dist, rng.draw_at(terminal_draw))?;
                             false
                         }
                     }
@@ -692,7 +757,7 @@ pub fn verify(
                 terminal_token = match method {
                     VerifyMethod::Greedy => argmax_stable(bonus_dist) as u32,
                     VerifyMethod::Rejection | VerifyMethod::TypicalAcceptance { .. } => {
-                        sample_from_distribution(bonus_dist, rng.draw_at(k as u32))?
+                        sample_from_distribution(bonus_dist, rng.draw_at(terminal_draw))?
                     }
                 };
             }
@@ -725,7 +790,7 @@ pub fn verify(
         out_acc_slice[best_path_len] = best_terminal_token;
 
         // Advance RNG state by k + 1 for clean non-overlapping step keying (Spec 1 §4.F, Spec 7 §4)
-        rng.advance((k + 1) as u32);
+        rng.advance(draw_advance);
     }
 
     Ok(VerifyOutput {
@@ -751,6 +816,32 @@ fn sample_from_distribution(probs: &[f32], u: f32) -> Result<u32, T0Error> {
         }
     }
     Ok(0)
+}
+
+/// Validates one normalized probability row before sampling or verification.
+fn validate_distribution(
+    probs: &[f32],
+    op: &'static str,
+    seq: usize,
+    pos: usize,
+) -> Result<(), T0Error> {
+    for (token, &value) in probs.iter().enumerate() {
+        if !value.is_finite() || value < 0.0 {
+            return Err(T0Error::InvalidProbability {
+                op,
+                seq,
+                pos,
+                token,
+                value,
+            });
+        }
+    }
+
+    let sum: f32 = probs.iter().sum();
+    if !sum.is_finite() || sum <= 0.0 || (sum - 1.0).abs() > 1.0e-3 {
+        return Err(T0Error::InvalidDistribution { op, seq, pos, sum });
+    }
+    Ok(())
 }
 
 /// Helper: argmax with stable tie-break by lowest index (Spec 1 §4.F, §6.5).

--- a/crates/r9v-t0/src/sampling.rs
+++ b/crates/r9v-t0/src/sampling.rs
@@ -1,0 +1,852 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Deterministic T0 reference implementation of sampling and verification operations
+//! (Spec 1 §4.F, §6.5, Spec 7 §4, §5).
+
+use r9v_ir::{SamplingParams, TreeMask, VerifyMethod};
+
+use crate::error::T0Error;
+use crate::philox::RngState;
+
+/// Output of speculative verification (Spec 1 §4.F, Spec 7 §4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyOutput {
+    /// Accepted draft tokens followed by the terminal bonus or replacement token `[S, k+1]`.
+    pub accepted: Vec<u32>,
+    /// Number of accepted draft tokens per sequence `[S]`.
+    pub accept_len: Vec<u32>,
+}
+
+// DECISION(A1.8): logits_postprocess applies top-k, top-p, and min-p filtering to candidate probabilities in stable sorted order by (-logit, index), renormalizing surviving candidates to sum to 1.0; at temperature == 0, argmax with stable tie-break by lowest index receives 1.0 and all other tokens 0.0; rejected non-renormalized probabilities because downstream sample expects a valid CDF. Spec 1 §4.F, Spec 1 §6.5.
+/// Post-processes raw logits into normalized probabilities per sequence (Spec 1 §4.F, §6.5).
+///
+/// Applies `logit_bias` (before temperature), `history_counts` penalties (repetition, presence,
+/// frequency), `temperature`, `grammar_mask` (before softmax), stable sort by `(-logit, index)`,
+/// `top_k`, `top_p`, and `min_p` filtering, returning normalized probabilities `[S, q, V]`.
+// Spec 1 §4.F defines logits_postprocess over (logits, S, q, V, params, history_counts?, grammar_mask?, out_probs).
+#[allow(clippy::too_many_arguments)]
+pub fn logits_postprocess(
+    logits: &[f32],
+    s: usize,
+    q: usize,
+    v: usize,
+    params: &[SamplingParams],
+    history_counts: Option<&[u32]>,
+    grammar_mask: Option<&[bool]>,
+    out_probs: &mut [f32],
+) -> Result<(), T0Error> {
+    let expected_len = s
+        .checked_mul(q)
+        .and_then(|sq| sq.checked_mul(v))
+        .ok_or_else(|| T0Error::ShapeLengthMismatch {
+            op: "logits_postprocess",
+            tensor: "logits",
+            expected: usize::MAX,
+            got: logits.len(),
+            detail: "overflow computing S * q * V".to_string(),
+        })?;
+
+    if logits.len() != expected_len {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "logits_postprocess",
+            tensor: "logits",
+            expected: expected_len,
+            got: logits.len(),
+            detail: format!("logits length != S({s}) * q({q}) * V({v})"),
+        });
+    }
+
+    if out_probs.len() != expected_len {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "logits_postprocess",
+            tensor: "out_probs",
+            expected: expected_len,
+            got: out_probs.len(),
+            detail: format!("out_probs length != S({s}) * q({q}) * V({v})"),
+        });
+    }
+
+    if params.len() != s {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "logits_postprocess",
+            tensor: "params",
+            expected: s,
+            got: params.len(),
+            detail: format!("SamplingParams count != batch size S({s})"),
+        });
+    }
+
+    if s == 0 || q == 0 || v == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "logits_postprocess",
+            tensor: if s == 0 {
+                "S"
+            } else if q == 0 {
+                "q"
+            } else {
+                "V"
+            },
+        });
+    }
+
+    // Validate all sampling params first (collect all violations per CONVENTIONS.md §1.4)
+    for p in params {
+        p.validate()?;
+    }
+
+    if let Some(history) = history_counts {
+        let expected_hist = s * v;
+        if history.len() != expected_hist {
+            return Err(T0Error::ShapeLengthMismatch {
+                op: "logits_postprocess",
+                tensor: "history_counts",
+                expected: expected_hist,
+                got: history.len(),
+                detail: format!("history_counts length != S({s}) * V({v})"),
+            });
+        }
+    }
+
+    if let Some(mask) = grammar_mask {
+        if mask.len() != expected_len {
+            return Err(T0Error::ShapeLengthMismatch {
+                op: "logits_postprocess",
+                tensor: "grammar_mask",
+                expected: expected_len,
+                got: mask.len(),
+                detail: format!("grammar_mask length != S({s}) * q({q}) * V({v})"),
+            });
+        }
+    }
+
+    let mut work_logits = vec![0.0f32; v];
+    let mut exp_vals = vec![0.0f32; v];
+    let mut cand_mask = vec![false; v];
+
+    for s_idx in 0..s {
+        let p = &params[s_idx];
+        let hist_row = history_counts.map(|h| &h[s_idx * v..(s_idx + 1) * v]);
+
+        for q_idx in 0..q {
+            let offset = (s_idx * q + q_idx) * v;
+            let logit_slice = &logits[offset..offset + v];
+            let out_slice = &mut out_probs[offset..offset + v];
+            let mask_slice = grammar_mask.map(|m| &m[offset..offset + v]);
+
+            work_logits.copy_from_slice(logit_slice);
+
+            // 1. Sparse logit bias added before temperature (Spec 1 §4.F)
+            for &(token_id, bias) in &p.logit_bias {
+                let idx = token_id as usize;
+                if idx < v {
+                    work_logits[idx] += bias;
+                }
+            }
+
+            // 2. Penalties applied to tokens with non-zero history counts (Spec 1 §4.F)
+            if let Some(hist) = hist_row {
+                for (tok, &count) in hist.iter().enumerate().take(v) {
+                    if count > 0 {
+                        let l = work_logits[tok];
+                        // Repetition penalty
+                        if p.repetition_penalty != 1.0 {
+                            work_logits[tok] = if l > 0.0 {
+                                l / p.repetition_penalty
+                            } else {
+                                l * p.repetition_penalty
+                            };
+                        }
+                        // Presence penalty (additive per token present in history)
+                        if p.presence_penalty != 0.0 {
+                            work_logits[tok] -= p.presence_penalty;
+                        }
+                        // Frequency penalty (additive proportional to occurrence count)
+                        if p.frequency_penalty != 0.0 {
+                            work_logits[tok] -= (count as f32) * p.frequency_penalty;
+                        }
+                    }
+                }
+            }
+
+            // 3. Temperature scaling (Spec 1 §4.F)
+            if p.temperature > 0.0 {
+                let inv_temp = 1.0 / p.temperature;
+                for l in &mut work_logits {
+                    *l *= inv_temp;
+                }
+            }
+
+            // 4. Grammar mask applied after penalties and before softmax (Spec 1 §4.F)
+            if let Some(mask) = mask_slice {
+                for (tok, &allowed) in mask.iter().enumerate().take(v) {
+                    if !allowed {
+                        work_logits[tok] = f32::NEG_INFINITY;
+                    }
+                }
+            }
+
+            // Verify at least one unmasked token exists
+            let unmasked_count = work_logits
+                .iter()
+                .filter(|&&l| l > f32::NEG_INFINITY)
+                .count();
+            if unmasked_count == 0 {
+                return Err(T0Error::AllTokensMasked {
+                    seq: s_idx,
+                    query: q_idx,
+                    vocab_size: v,
+                });
+            }
+
+            // 5. Softmax & filtering
+            if p.temperature == 0.0 {
+                // Greedy argmax with fixed stable tie-break by lowest index (Spec 1 §4.F, §6.5)
+                let mut best_idx = 0;
+                let mut best_val = f32::NEG_INFINITY;
+                for (tok, &l) in work_logits.iter().enumerate() {
+                    if l > best_val {
+                        best_val = l;
+                        best_idx = tok;
+                    }
+                }
+                out_slice.fill(0.0);
+                out_slice[best_idx] = 1.0;
+            } else {
+                // Numerically stable softmax
+                let max_l = work_logits
+                    .iter()
+                    .copied()
+                    .filter(|&l| l > f32::NEG_INFINITY)
+                    .fold(f32::NEG_INFINITY, f32::max);
+
+                let mut sum_exp = 0.0f32;
+                for tok in 0..v {
+                    let l = work_logits[tok];
+                    if l > f32::NEG_INFINITY {
+                        let e = (l - max_l).exp();
+                        exp_vals[tok] = e;
+                        sum_exp += e;
+                    } else {
+                        exp_vals[tok] = 0.0;
+                    }
+                }
+
+                if sum_exp <= 0.0 || !sum_exp.is_finite() {
+                    return Err(T0Error::InvalidDistribution {
+                        op: "logits_postprocess",
+                        seq: s_idx,
+                        pos: q_idx,
+                        sum: sum_exp,
+                    });
+                }
+
+                let inv_sum = 1.0 / sum_exp;
+                for tok in 0..v {
+                    out_slice[tok] = exp_vals[tok] * inv_sum;
+                }
+
+                // Fixed stable sort by (-logit, index) (Spec 1 §4.F, §6.5)
+                let mut candidates: Vec<usize> = (0..v)
+                    .filter(|&i| work_logits[i] > f32::NEG_INFINITY)
+                    .collect();
+
+                candidates.sort_by(|&a, &b| {
+                    (-work_logits[a], a)
+                        .partial_cmp(&(-work_logits[b], b))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+
+                // Top-k filtering (Spec 1 §4.F)
+                if p.top_k > 0 && (p.top_k as usize) < candidates.len() {
+                    candidates.truncate(p.top_k as usize);
+                }
+
+                // Top-p nucleus filtering (Spec 1 §4.F)
+                if p.top_p < 1.0 {
+                    let mut cumsum = 0.0f32;
+                    let mut keep = 0;
+                    for &idx in &candidates {
+                        cumsum += out_slice[idx];
+                        keep += 1;
+                        if cumsum >= p.top_p {
+                            break;
+                        }
+                    }
+                    candidates.truncate(keep.max(1));
+                }
+
+                // Min-p filtering (Spec 1 §4.F)
+                if p.min_p > 0.0 && !candidates.is_empty() {
+                    let p_max = out_slice[candidates[0]];
+                    let thresh = p.min_p * p_max;
+                    let filtered: Vec<usize> = candidates
+                        .iter()
+                        .copied()
+                        .filter(|&idx| out_slice[idx] >= thresh)
+                        .collect();
+                    if !filtered.is_empty() {
+                        candidates = filtered;
+                    } else {
+                        candidates.truncate(1);
+                    }
+                }
+
+                // Renormalize surviving candidates
+                cand_mask.fill(false);
+                let mut cand_sum = 0.0f32;
+                for &idx in &candidates {
+                    cand_mask[idx] = true;
+                    cand_sum += out_slice[idx];
+                }
+
+                if cand_sum > 0.0 && cand_sum.is_finite() {
+                    let inv_cand_sum = 1.0 / cand_sum;
+                    for tok in 0..v {
+                        if cand_mask[tok] {
+                            out_slice[tok] *= inv_cand_sum;
+                        } else {
+                            out_slice[tok] = 0.0;
+                        }
+                    }
+                } else {
+                    out_slice.fill(0.0);
+                    out_slice[candidates[0]] = 1.0;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Stochastic or greedy inverse-CDF token sampling op (Spec 1 §4.F).
+///
+/// Draws tokens from `probs [S, V]` using Philox4x32 keyed by `(seq_id, step, draw_index)`
+/// via inverse-CDF. Advances each sequence's RNG draw counter by 1.
+pub fn sample(
+    probs: &[f32],
+    s: usize,
+    v: usize,
+    rng_states: &mut [RngState],
+) -> Result<Vec<u32>, T0Error> {
+    if s == 0 || v == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "sample",
+            tensor: if s == 0 { "S" } else { "V" },
+        });
+    }
+
+    let expected_len = s.checked_mul(v).ok_or_else(|| T0Error::ShapeLengthMismatch {
+        op: "sample",
+        tensor: "probs",
+        expected: usize::MAX,
+        got: probs.len(),
+        detail: "overflow computing S * V".to_string(),
+    })?;
+
+    if probs.len() != expected_len {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "sample",
+            tensor: "probs",
+            expected: expected_len,
+            got: probs.len(),
+            detail: format!("probs length != S({s}) * V({v})"),
+        });
+    }
+
+    if rng_states.len() != s {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "sample",
+            tensor: "rng_states",
+            expected: s,
+            got: rng_states.len(),
+            detail: format!("rng_states count != S({s})"),
+        });
+    }
+
+    let mut tokens = Vec::with_capacity(s);
+
+    for (s_idx, rng) in rng_states.iter_mut().enumerate().take(s) {
+        let p_row = &probs[s_idx * v..(s_idx + 1) * v];
+
+        let sum: f32 = p_row.iter().sum();
+        if sum <= 0.0 || !sum.is_finite() {
+            return Err(T0Error::InvalidDistribution {
+                op: "sample",
+                seq: s_idx,
+                pos: 0,
+                sum,
+            });
+        }
+
+        // Draw uniform random float u in (0, 1) and advance RNG state by 1
+        let u = rng.draw_uniform_f32();
+
+        let mut cumsum = 0.0f32;
+        let mut chosen = v - 1;
+        for (tok, &p) in p_row.iter().enumerate() {
+            cumsum += p;
+            if cumsum >= u {
+                chosen = tok;
+                break;
+            }
+        }
+        tokens.push(chosen as u32);
+    }
+
+    Ok(tokens)
+}
+
+// DECISION(A1.8): verify uses Philox draw index i for candidate acceptance test at position i in 0..k-1, and draw index k for the terminal token (bonus token if all accepted, or residual replacement token if rejected at i); rejected using draw i+1 for replacement because candidate i+1's uniform draw is reserved for position i+1 per Spec 7 §4. Spec 1 §4.F, Spec 4 §5.8, Spec 7 §4.
+// DECISION(A1.8): In tree verify, draft node j is tested against target_probs[0] if parents[j] == -1, or target_probs[p + 1] if parents[j] == p >= 0; bonus token after node j is sampled from target_probs[j + 1]; rejected separate tree probability indexing because target_probs[k+1, V] aligns root at index 0 and node j output at j+1 identically to linear verify. Spec 1 §4.F, Spec 7 §4, §5.
+// DECISION(A1.8): Typical acceptance accepts d_i if p_i[d_i] > min(eps, delta * exp(-H(p_i))) per Spec 7 §4; on rejection at i, replacement is sampled from target_probs[i] using Philox draw k; bonus token at k is sampled from target_probs[k]; rejected discarding target_probs[i] because speculative decode must emit a verified continuation token. Spec 7 §4.
+/// Speculative decoding acceptance verification op (Spec 1 §4.F, Spec 7 §4, §5).
+///
+/// Evaluates draft candidates against target probabilities using `Rejection`, `Greedy`,
+/// or `TypicalAcceptance` policies. Supports both linear verification chains and tree drafts
+/// via `TreeMask`. Commits the longest accepted path (breaking ties by lowest first-token index)
+/// and samples the terminal replacement or bonus token.
+// Spec 1 §4.F and Spec 7 §4 define verify over (draft_tokens, draft_probs?, target_probs, S, k, V, method, rng_states, tree?).
+#[allow(clippy::too_many_arguments)]
+pub fn verify(
+    draft_tokens: &[u32],
+    draft_probs: Option<&[f32]>,
+    target_probs: &[f32],
+    s: usize,
+    k: usize,
+    v: usize,
+    method: &VerifyMethod,
+    rng_states: &mut [RngState],
+    tree: Option<&TreeMask>,
+) -> Result<VerifyOutput, T0Error> {
+    if s == 0 || v == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "verify",
+            tensor: if s == 0 { "S" } else { "V" },
+        });
+    }
+
+    let expected_draft = s.checked_mul(k).ok_or_else(|| T0Error::ShapeLengthMismatch {
+        op: "verify",
+        tensor: "draft_tokens",
+        expected: usize::MAX,
+        got: draft_tokens.len(),
+        detail: "overflow computing S * k".to_string(),
+    })?;
+
+    if draft_tokens.len() != expected_draft {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "verify",
+            tensor: "draft_tokens",
+            expected: expected_draft,
+            got: draft_tokens.len(),
+            detail: format!("draft_tokens length != S({s}) * k({k})"),
+        });
+    }
+
+    if let Some(dp) = draft_probs {
+        let expected_dp =
+            expected_draft
+                .checked_mul(v)
+                .ok_or_else(|| T0Error::ShapeLengthMismatch {
+                    op: "verify",
+                    tensor: "draft_probs",
+                    expected: usize::MAX,
+                    got: dp.len(),
+                    detail: "overflow computing S * k * V".to_string(),
+                })?;
+        if dp.len() != expected_dp {
+            return Err(T0Error::ShapeLengthMismatch {
+                op: "verify",
+                tensor: "draft_probs",
+                expected: expected_dp,
+                got: dp.len(),
+                detail: format!("draft_probs length != S({s}) * k({k}) * V({v})"),
+            });
+        }
+    }
+
+    let expected_target = s
+        .checked_mul(k + 1)
+        .and_then(|sk1| sk1.checked_mul(v))
+        .ok_or_else(|| T0Error::ShapeLengthMismatch {
+            op: "verify",
+            tensor: "target_probs",
+            expected: usize::MAX,
+            got: target_probs.len(),
+            detail: "overflow computing S * (k+1) * V".to_string(),
+        })?;
+
+    if target_probs.len() != expected_target {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "verify",
+            tensor: "target_probs",
+            expected: expected_target,
+            got: target_probs.len(),
+            detail: format!(
+                "target_probs length != S({s}) * (k+1)({sk1}) * V({v})",
+                sk1 = k + 1
+            ),
+        });
+    }
+
+    if rng_states.len() != s {
+        return Err(T0Error::ShapeLengthMismatch {
+            op: "verify",
+            tensor: "rng_states",
+            expected: s,
+            got: rng_states.len(),
+            detail: format!("rng_states count != S({s})"),
+        });
+    }
+
+    if let Some(tree_mask) = tree {
+        if tree_mask.t() != k {
+            return Err(T0Error::ShapeLengthMismatch {
+                op: "verify",
+                tensor: "tree",
+                expected: k,
+                got: tree_mask.t(),
+                detail: format!("TreeMask token count T({}) != k({k})", tree_mask.t()),
+            });
+        }
+    }
+
+    // Precompute root-to-leaf paths for tree drafts (Spec 7 §5)
+    let paths: Vec<Vec<usize>> = if let Some(tree_mask) = tree {
+        if k == 0 {
+            vec![]
+        } else {
+            let parents = tree_mask.parents();
+            // Identify leaf nodes: nodes that never appear as a parent of another node
+            let mut is_parent = vec![false; k];
+            for &p in parents {
+                if p >= 0 && (p as usize) < k {
+                    is_parent[p as usize] = true;
+                }
+            }
+
+            let mut candidate_paths = Vec::new();
+            for (node_idx, &has_child) in is_parent.iter().enumerate().take(k) {
+                if !has_child {
+                    // Trace leaf to root
+                    let mut path = Vec::new();
+                    let mut curr = node_idx as i32;
+                    while curr >= 0 && (curr as usize) < k {
+                        path.push(curr as usize);
+                        curr = parents[curr as usize];
+                    }
+                    path.reverse();
+                    candidate_paths.push(path);
+                }
+            }
+            // Sort paths: primary tie-breaker is lowest first-token index (Spec 7 §5)
+            candidate_paths.sort();
+            candidate_paths
+        }
+    } else {
+        // Linear chain: 0 -> 1 -> ... -> k-1
+        if k > 0 {
+            vec![(0..k).collect()]
+        } else {
+            vec![]
+        }
+    };
+
+    let mut out_accepted = vec![0u32; s * (k + 1)];
+    let mut out_accept_len = vec![0u32; s];
+
+    for s_idx in 0..s {
+        let d_tokens = &draft_tokens[s_idx * k..(s_idx + 1) * k];
+        let d_probs_row = draft_probs.map(|dp| &dp[s_idx * k * v..(s_idx + 1) * k * v]);
+        let t_probs_row = &target_probs[s_idx * (k + 1) * v..(s_idx + 1) * (k + 1) * v];
+        let rng = &mut rng_states[s_idx];
+
+        let out_acc_slice = &mut out_accepted[s_idx * (k + 1)..(s_idx + 1) * (k + 1)];
+
+        if k == 0 || paths.is_empty() {
+            // Degenerate k=0: sample single continuation token directly from root distribution
+            let root_dist = &t_probs_row[..v];
+            let bonus_tok = sample_from_distribution(root_dist, rng.draw_at(0))?;
+            out_acc_slice[0] = bonus_tok;
+            out_accept_len[s_idx] = 0;
+            rng.advance(1);
+            continue;
+        }
+
+        // Evaluate all candidate paths and find the winning path (Spec 7 §5)
+        let mut best_path_len = 0usize;
+        let mut best_first_token = usize::MAX;
+        let mut best_accepted_nodes: Vec<usize> = Vec::new();
+        let mut best_terminal_token: u32 = 0;
+
+        for path in &paths {
+            let mut accepted_nodes = Vec::with_capacity(path.len());
+            let mut terminal_token = 0u32;
+            let mut all_path_accepted = true;
+
+            for (pos_idx, &node_idx) in path.iter().enumerate() {
+                let d = d_tokens[node_idx];
+
+                // Target distribution predicting node_idx:
+                // If pos_idx == 0 (root), distribution is target_probs[0]
+                // If pos_idx > 0, distribution is target_probs[parent_node + 1]
+                let target_dist = if pos_idx == 0 {
+                    &t_probs_row[..v]
+                } else {
+                    let parent_node = path[pos_idx - 1];
+                    &t_probs_row[(parent_node + 1) * v..(parent_node + 2) * v]
+                };
+
+                let target_p = target_dist[d as usize];
+
+                let accepted = match method {
+                    VerifyMethod::Rejection => {
+                        let draft_q = if let Some(dp) = d_probs_row {
+                            dp[node_idx * v + d as usize]
+                        } else {
+                            // Proposer was deterministic (q is one-hot)
+                            1.0
+                        };
+
+                        let alpha = if draft_q > 0.0 {
+                            (target_p / draft_q).min(1.0)
+                        } else if target_p > 0.0 {
+                            1.0
+                        } else {
+                            0.0
+                        };
+
+                        let u = rng.draw_at(node_idx as u32);
+                        if u < alpha {
+                            true
+                        } else {
+                            // Rejection at position node_idx: sample replacement from norm(max(0, p - q))
+                            let mut residual = vec![0.0f32; v];
+                            for tok in 0..v {
+                                let q_val = if let Some(dp) = d_probs_row {
+                                    dp[node_idx * v + tok]
+                                } else if tok == d as usize {
+                                    1.0
+                                } else {
+                                    0.0
+                                };
+                                residual[tok] = (target_dist[tok] - q_val).max(0.0);
+                            }
+
+                            let sum_res: f32 = residual.iter().sum();
+                            if sum_res > 0.0 && sum_res.is_finite() {
+                                let inv = 1.0 / sum_res;
+                                for r in &mut residual {
+                                    *r *= inv;
+                                }
+                                terminal_token =
+                                    sample_from_distribution(&residual, rng.draw_at(k as u32))?;
+                            } else {
+                                // Fallback to target argmax if residual is zeroed
+                                terminal_token = argmax_stable(target_dist) as u32;
+                            }
+                            false
+                        }
+                    }
+                    VerifyMethod::Greedy => {
+                        let target_argmax = argmax_stable(target_dist) as u32;
+                        if target_argmax == d {
+                            true
+                        } else {
+                            terminal_token = target_argmax;
+                            false
+                        }
+                    }
+                    VerifyMethod::TypicalAcceptance { eps, delta } => {
+                        // Entropy H(p) = -sum(p * ln(p))
+                        let mut h = 0.0f32;
+                        for &p in target_dist {
+                            if p > 0.0 {
+                                h -= p * p.ln();
+                            }
+                        }
+                        let threshold = eps.min(delta * (-h).exp());
+                        if target_p > threshold {
+                            true
+                        } else {
+                            // Typical replacement sampled from target_probs[pos]
+                            terminal_token =
+                                sample_from_distribution(target_dist, rng.draw_at(k as u32))?;
+                            false
+                        }
+                    }
+                };
+
+                if accepted {
+                    accepted_nodes.push(node_idx);
+                } else {
+                    all_path_accepted = false;
+                    break;
+                }
+            }
+
+            if all_path_accepted {
+                // All tokens on path accepted: sample bonus token from target_probs[last_node + 1]
+                let last_node = *path.last().unwrap();
+                let bonus_dist = &t_probs_row[(last_node + 1) * v..(last_node + 2) * v];
+                terminal_token = match method {
+                    VerifyMethod::Greedy => argmax_stable(bonus_dist) as u32,
+                    VerifyMethod::Rejection | VerifyMethod::TypicalAcceptance { .. } => {
+                        sample_from_distribution(bonus_dist, rng.draw_at(k as u32))?
+                    }
+                };
+            }
+
+            let path_len = accepted_nodes.len();
+            let first_token = path.first().copied().unwrap_or(0);
+
+            // Longest accepted path rule; ties go to lowest first-token index (Spec 7 §5)
+            let is_better = if path_len > best_path_len {
+                true
+            } else if path_len == best_path_len {
+                first_token < best_first_token
+            } else {
+                false
+            };
+
+            if is_better {
+                best_path_len = path_len;
+                best_first_token = first_token;
+                best_accepted_nodes = accepted_nodes;
+                best_terminal_token = terminal_token;
+            }
+        }
+
+        // Commit winning path to output (Spec 7 §5)
+        out_accept_len[s_idx] = best_path_len as u32;
+        for (i, &node_idx) in best_accepted_nodes.iter().enumerate() {
+            out_acc_slice[i] = d_tokens[node_idx];
+        }
+        out_acc_slice[best_path_len] = best_terminal_token;
+
+        // Advance RNG state by k + 1 for clean non-overlapping step keying (Spec 1 §4.F, Spec 7 §4)
+        rng.advance((k + 1) as u32);
+    }
+
+    Ok(VerifyOutput {
+        accepted: out_accepted,
+        accept_len: out_accept_len,
+    })
+}
+
+/// Helper: inverse-CDF draw on a probability distribution with a given uniform float u in (0, 1).
+#[inline]
+fn sample_from_distribution(probs: &[f32], u: f32) -> Result<u32, T0Error> {
+    let mut cumsum = 0.0f32;
+    for (tok, &p) in probs.iter().enumerate() {
+        cumsum += p;
+        if cumsum >= u {
+            return Ok(tok as u32);
+        }
+    }
+    // Fallback on numerical rounding: find last non-zero token or 0
+    for tok in (0..probs.len()).rev() {
+        if probs[tok] > 0.0 {
+            return Ok(tok as u32);
+        }
+    }
+    Ok(0)
+}
+
+/// Helper: argmax with stable tie-break by lowest index (Spec 1 §4.F, §6.5).
+#[inline]
+fn argmax_stable(slice: &[f32]) -> usize {
+    let mut best_idx = 0;
+    let mut best_val = f32::NEG_INFINITY;
+    for (idx, &val) in slice.iter().enumerate() {
+        if val > best_val {
+            best_val = val;
+            best_idx = idx;
+        }
+    }
+    best_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use r9v_ir::SamplingParams;
+
+    fn default_params() -> SamplingParams {
+        SamplingParams {
+            temperature: 1.0,
+            top_k: 0,
+            top_p: 1.0,
+            min_p: 0.0,
+            repetition_penalty: 1.0,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
+            logit_bias: vec![],
+        }
+    }
+
+    #[test]
+    fn test_logits_postprocess_basic_softmax() {
+        let logits = vec![1.0, 2.0, 3.0];
+        let params = vec![default_params()];
+        let mut probs = vec![0.0; 3];
+        logits_postprocess(&logits, 1, 1, 3, &params, None, None, &mut probs).unwrap();
+
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6);
+        assert!(probs[2] > probs[1]);
+        assert!(probs[1] > probs[0]);
+    }
+
+    #[test]
+    fn test_logits_postprocess_temperature_zero() {
+        let logits = vec![1.0, 5.0, 2.0];
+        let mut p = default_params();
+        p.temperature = 0.0;
+        let params = vec![p];
+        let mut probs = vec![0.0; 3];
+        logits_postprocess(&logits, 1, 1, 3, &params, None, None, &mut probs).unwrap();
+
+        assert_eq!(probs, vec![0.0, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn test_logits_postprocess_grammar_mask() {
+        let logits = vec![10.0, 2.0, 1.0];
+        let params = vec![default_params()];
+        let mask = vec![false, true, true];
+        let mut probs = vec![0.0; 3];
+        logits_postprocess(&logits, 1, 1, 3, &params, None, Some(&mask), &mut probs).unwrap();
+
+        assert_eq!(probs[0], 0.0);
+        assert!((probs[1] + probs[2] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_greedy_verify_chain() {
+        let draft_tokens = vec![2, 4];
+        let target_probs = vec![
+            // pos 0: token 2 matches
+            0.0, 0.0, 1.0, 0.0, 0.0, // pos 1: token 4 matches
+            0.0, 0.0, 0.0, 0.0, 1.0, // pos 2: bonus token is 1
+            0.0, 1.0, 0.0, 0.0, 0.0,
+        ];
+        let mut rng_states = vec![RngState::new(42, 1, 0)];
+
+        let out = verify(
+            &draft_tokens,
+            None,
+            &target_probs,
+            1,
+            2,
+            5,
+            &VerifyMethod::Greedy,
+            &mut rng_states,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(out.accept_len, vec![2]);
+        assert_eq!(out.accepted, vec![2, 4, 1]);
+    }
+}

--- a/crates/r9v-t0/tests/api_shape.rs
+++ b/crates/r9v-t0/tests/api_shape.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::needless_range_loop)]
-//! API shape verification for r9v-t0 crate (CONVENTIONS.md §3).
+//! API shape verification for r9v-t0 crate (CONVENTIONS.md §3, Cards A1.5 and A1.8).
 
 use r9v_t0::*;
+use r9v_ir::{SamplingParams, VerifyMethod};
 
 fn assert_send<T: Send>() {}
 fn assert_sync<T: Sync>() {}
@@ -255,4 +256,85 @@ fn test_backing_length_validation_rejects_undersized_and_overflowed_storage() {
         }
         other => panic!("expected BufferLengthMismatch, got {other:?}"),
     }
+}
+
+#[test]
+fn test_type_markers_and_traits() {
+    assert_send::<RngState>();
+    assert_sync::<RngState>();
+
+    assert_send::<VerifyOutput>();
+    assert_sync::<VerifyOutput>();
+
+    assert_send::<T0Error>();
+    assert_sync::<T0Error>();
+
+    // Check trait implementations
+    let rng = RngState::new(42, 1, 0);
+    let rng_clone = rng.clone();
+    assert_eq!(rng, rng_clone);
+    assert_eq!(rng.seed(), 42);
+    assert_eq!(rng.seq_id(), 1);
+    assert_eq!(rng.step(), 0);
+    assert_eq!(rng.draw_index(), 0);
+
+    let output = VerifyOutput {
+        accepted: vec![1, 2, 3],
+        accept_len: vec![2],
+    };
+    let output_clone = output.clone();
+    assert_eq!(output, output_clone);
+
+    let err = T0Error::EmptyInput {
+        op: "sample",
+        tensor: "probs",
+    };
+    let display_str = format!("{err}");
+    assert!(display_str.contains("empty tensor in sample: probs"));
+}
+
+#[test]
+fn test_public_function_signatures() {
+    // Verify logits_postprocess signature compiles and is accessible
+    let logits = vec![1.0, 2.0];
+    let params = vec![SamplingParams {
+        temperature: 1.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        logit_bias: vec![],
+    }];
+    let mut probs = vec![0.0; 2];
+    let res = logits_postprocess(&logits, 1, 1, 2, &params, None, None, &mut probs);
+    assert!(res.is_ok());
+
+    // Verify sample signature
+    let mut rng_states = vec![RngState::new(1, 0, 0)];
+    let res_sample = sample(&probs, 1, 2, &mut rng_states);
+    assert!(res_sample.is_ok());
+
+    // Verify verify signature
+    let draft_tokens = vec![1];
+    let target_probs = vec![0.1, 0.9, 0.8, 0.2];
+    let res_verify = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        1,
+        2,
+        &VerifyMethod::Greedy,
+        &mut rng_states,
+        None,
+    );
+    assert!(res_verify.is_ok());
+
+    // Verify low-level Philox primitives
+    let words = philox4x32_10([0, 0, 0, 0], [0, 0]);
+    assert_eq!(words.len(), 4);
+    let u = u32_to_unit_f32(words[0]);
+    assert!(u > 0.0 && u < 1.0);
 }

--- a/crates/r9v-t0/tests/api_shape.rs
+++ b/crates/r9v-t0/tests/api_shape.rs
@@ -2,8 +2,8 @@
 #![allow(clippy::needless_range_loop)]
 //! API shape verification for r9v-t0 crate (CONVENTIONS.md §3, Cards A1.5 and A1.8).
 
-use r9v_t0::*;
 use r9v_ir::{SamplingParams, VerifyMethod};
+use r9v_t0::*;
 
 fn assert_send<T: Send>() {}
 fn assert_sync<T: Sync>() {}

--- a/crates/r9v-t0/tests/determinism_tests.rs
+++ b/crates/r9v-t0/tests/determinism_tests.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Determinism and batch-invariance tests for sampling operations (Spec 1 §6.1, §6.5, CONVENTIONS.md §4.3, Card A1.8).
+
+use r9v_ir::{SamplingParams, VerifyMethod};
+use r9v_t0::{logits_postprocess, sample, verify, RngState};
+
+fn sample_params() -> SamplingParams {
+    SamplingParams {
+        temperature: 0.8,
+        top_k: 4,
+        top_p: 0.9,
+        min_p: 0.05,
+        repetition_penalty: 1.2,
+        presence_penalty: 0.1,
+        frequency_penalty: 0.1,
+        logit_bias: vec![(1, 0.5), (3, -0.2)],
+    }
+}
+
+#[test]
+fn determinism_logits_postprocess_run_to_run_bit_identical() {
+    let s = 2;
+    let q = 2;
+    let v = 8;
+    let logits = vec![
+        0.1, 2.5, -1.0, 3.2, 0.0, 4.1, -0.5, 1.2, 1.0, -0.2, 0.5, 2.1, 3.3, 0.8, 1.5, -2.0, -1.5,
+        0.0, 3.0, 1.2, 2.2, -0.1, 0.9, 1.7, 2.0, 1.1, -0.8, 0.4, 3.5, -1.2, 0.6, 2.8,
+    ];
+    let params = vec![sample_params(), sample_params()];
+    let history = vec![0, 1, 0, 2, 0, 0, 1, 0, 1, 0, 0, 0, 3, 0, 0, 1];
+    let mask = vec![
+        true, true, false, true, true, true, false, true, true, false, true, true, true, true,
+        true, false, false, true, true, true, true, false, true, true, true, true, true, false,
+        true, true, false, true,
+    ];
+
+    let mut out1 = vec![0.0f32; s * q * v];
+    let mut out2 = vec![0.0f32; s * q * v];
+
+    logits_postprocess(
+        &logits,
+        s,
+        q,
+        v,
+        &params,
+        Some(&history),
+        Some(&mask),
+        &mut out1,
+    )
+    .unwrap();
+    logits_postprocess(
+        &logits,
+        s,
+        q,
+        v,
+        &params,
+        Some(&history),
+        Some(&mask),
+        &mut out2,
+    )
+    .unwrap();
+
+    // Check bit-identical float outputs
+    for i in 0..out1.len() {
+        assert_eq!(
+            out1[i].to_bits(),
+            out2[i].to_bits(),
+            "Mismatch at index {i}"
+        );
+    }
+}
+
+#[test]
+fn determinism_sample_run_to_run_bit_identical() {
+    let s = 3;
+    let v = 5;
+    let probs = vec![
+        0.1, 0.2, 0.4, 0.2, 0.1, 0.3, 0.3, 0.1, 0.1, 0.2, 0.05, 0.05, 0.1, 0.7, 0.1,
+    ];
+
+    let mut rng1 = vec![
+        RngState::new(100, 1, 5),
+        RngState::new(200, 2, 5),
+        RngState::new(300, 3, 5),
+    ];
+    let mut rng2 = rng1.clone();
+
+    let tokens1 = sample(&probs, s, v, &mut rng1).unwrap();
+    let tokens2 = sample(&probs, s, v, &mut rng2).unwrap();
+
+    assert_eq!(tokens1, tokens2);
+    assert_eq!(rng1, rng2);
+}
+
+#[test]
+fn determinism_verify_run_to_run_bit_identical() {
+    let s = 2;
+    let k = 3;
+    let v = 4;
+    let draft_tokens = vec![1, 2, 0, 3, 1, 2];
+    let draft_probs = vec![
+        0.1, 0.6, 0.2, 0.1, 0.0, 0.1, 0.7, 0.2, 0.5, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.7, 0.2, 0.5,
+        0.2, 0.1, 0.1, 0.2, 0.6, 0.1,
+    ];
+    let target_probs = vec![
+        // seq 0: pos 0..3
+        0.2, 0.5, 0.2, 0.1, 0.1, 0.1, 0.6, 0.2, 0.4, 0.3, 0.2, 0.1, 0.1, 0.2, 0.3, 0.4,
+        // seq 1: pos 0..3
+        0.0, 0.1, 0.2, 0.7, 0.1, 0.6, 0.2, 0.1, 0.2, 0.2, 0.5, 0.1, 0.3, 0.3, 0.2, 0.2,
+    ];
+
+    for method in [
+        VerifyMethod::Rejection,
+        VerifyMethod::Greedy,
+        VerifyMethod::TypicalAcceptance {
+            eps: 0.1,
+            delta: 0.8,
+        },
+    ] {
+        let mut rng1 = vec![RngState::new(42, 1, 10), RngState::new(43, 2, 10)];
+        let mut rng2 = rng1.clone();
+
+        let out1 = verify(
+            &draft_tokens,
+            Some(&draft_probs),
+            &target_probs,
+            s,
+            k,
+            v,
+            &method,
+            &mut rng1,
+            None,
+        )
+        .unwrap();
+        let out2 = verify(
+            &draft_tokens,
+            Some(&draft_probs),
+            &target_probs,
+            s,
+            k,
+            v,
+            &method,
+            &mut rng2,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(out1.accepted, out2.accepted);
+        assert_eq!(out1.accept_len, out2.accept_len);
+        assert_eq!(rng1, rng2);
+    }
+}
+
+#[test]
+fn determinism_batch_invariance_sequence_alone_vs_batched() {
+    // Spec 1 §6.1 Batch Invariance: output for a sequence must be bit-identical
+    // whether executed alone (S=1) or embedded in a batch (S=3).
+    let v = 6;
+    let seq0_logits = vec![0.5, 1.2, -0.4, 2.1, 0.8, -1.0];
+    let seq1_logits = vec![1.5, 0.2, 0.4, -0.1, 3.0, 0.5];
+    let seq2_logits = vec![-0.5, 2.0, 1.1, 0.0, 0.7, 1.8];
+
+    let p0 = sample_params();
+    let p1 = sample_params();
+    let p2 = sample_params();
+
+    // 1. Run sequence 0 alone
+    let mut out_alone = vec![0.0f32; v];
+    logits_postprocess(
+        &seq0_logits,
+        1,
+        1,
+        v,
+        std::slice::from_ref(&p0),
+        None,
+        None,
+        &mut out_alone,
+    )
+    .unwrap();
+
+    let mut rng_alone = vec![RngState::new(999, 101, 1)];
+    let token_alone = sample(&out_alone, 1, v, &mut rng_alone).unwrap()[0];
+
+    // 2. Run batched with sequence 1 and sequence 2
+    let mut batched_logits = Vec::new();
+    batched_logits.extend_from_slice(&seq0_logits);
+    batched_logits.extend_from_slice(&seq1_logits);
+    batched_logits.extend_from_slice(&seq2_logits);
+
+    let mut out_batched = vec![0.0f32; 3 * v];
+    logits_postprocess(
+        &batched_logits,
+        3,
+        1,
+        v,
+        &[p0, p1, p2],
+        None,
+        None,
+        &mut out_batched,
+    )
+    .unwrap();
+
+    let mut rng_batched = vec![
+        RngState::new(999, 101, 1),
+        RngState::new(888, 102, 1),
+        RngState::new(777, 103, 1),
+    ];
+    let tokens_batched = sample(&out_batched, 3, v, &mut rng_batched).unwrap();
+
+    // Verify bit-identical probabilities for sequence 0
+    for i in 0..v {
+        assert_eq!(
+            out_alone[i].to_bits(),
+            out_batched[i].to_bits(),
+            "Probability mismatch for token {i} between alone and batched"
+        );
+    }
+
+    // Verify identical sampled token and RNG state advancement
+    assert_eq!(token_alone, tokens_batched[0]);
+    assert_eq!(rng_alone[0], rng_batched[0]);
+}

--- a/crates/r9v-t0/tests/distribution_tests.rs
+++ b/crates/r9v-t0/tests/distribution_tests.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+//! 100,000-draw distribution tests for speculative rejection sampling (Spec 1 §4.F, Spec 7 §4, Card A1.8).
+
+use r9v_ir::VerifyMethod;
+use r9v_t0::{sample, verify, RngState};
+
+/// Helper to compute chi-squared test statistic against expected theoretical probabilities.
+fn chi_squared_stat(observed_counts: &[usize], total: usize, expected_probs: &[f32]) -> f64 {
+    let mut chi2 = 0.0f64;
+    let n = total as f64;
+    for (&obs, &exp_p) in observed_counts.iter().zip(expected_probs.iter()) {
+        let expected = n * (exp_p as f64);
+        let diff = (obs as f64) - expected;
+        chi2 += (diff * diff) / expected;
+    }
+    chi2
+}
+
+#[test]
+fn rejection_sampling_output_frequency_matches_target_sampling_1e5_draws() {
+    // Synthetic target distribution P and draft distribution Q over V = 4
+    let target_p = vec![0.10f32, 0.40f32, 0.30f32, 0.20f32];
+    let draft_q = vec![0.25f32, 0.25f32, 0.25f32, 0.25f32];
+    let vocab_size = 4;
+    let draws = 100_000;
+
+    let mut rejection_counts = vec![0usize; vocab_size];
+    let mut direct_counts = vec![0usize; vocab_size];
+
+    let mut rng_rej = RngState::new(123456789, 1, 0);
+    let mut rng_direct = RngState::new(987654321, 2, 0);
+    let mut rng_draft = RngState::new(555555555, 3, 0);
+
+    // Target probs array for verify [S=1, k+1=2, V=4]
+    let mut target_probs = Vec::with_capacity(vocab_size * 2);
+    target_probs.extend_from_slice(&target_p);
+    target_probs.extend_from_slice(&target_p); // bonus distribution
+
+    let mut draft_probs = Vec::with_capacity(vocab_size);
+    draft_probs.extend_from_slice(&draft_q);
+
+    let method = VerifyMethod::Rejection;
+
+    for step in 0..draws {
+        // 1. Draw a draft token from draft distribution Q
+        let draft_tok = sample(&draft_q, 1, vocab_size, &mut [rng_draft.clone()]).unwrap()[0];
+        rng_draft.advance(1);
+
+        // 2. Perform speculative rejection sampling verification
+        rng_rej.set_step(step as u64);
+        let mut rng_slice = [rng_rej.clone()];
+        let out = verify(
+            &[draft_tok],
+            Some(&draft_probs),
+            &target_probs,
+            1,
+            1,
+            vocab_size,
+            &method,
+            &mut rng_slice,
+            None,
+        )
+        .unwrap();
+        rng_rej = rng_slice[0].clone();
+
+        // The emitted token at position 0 is either the accepted draft token or the replacement token
+        let emitted_token = out.accepted[0] as usize;
+        rejection_counts[emitted_token] += 1;
+
+        // 3. Perform direct sampling from target distribution P
+        rng_direct.set_step(step as u64);
+        let mut rng_dir_slice = [rng_direct.clone()];
+        let dir_token = sample(&target_p, 1, vocab_size, &mut rng_dir_slice).unwrap()[0] as usize;
+        rng_direct = rng_dir_slice[0].clone();
+        direct_counts[dir_token] += 1;
+    }
+
+    // Statistical validation: Chi-squared goodness of fit
+    // For V=4 (df=3), critical value at alpha=0.001 is 16.27.
+    let chi2_rej = chi_squared_stat(&rejection_counts, draws, &target_p);
+    let chi2_dir = chi_squared_stat(&direct_counts, draws, &target_p);
+
+    // Assert that rejection sampling matches the target distribution within statistical tolerance
+    assert!(
+        chi2_rej < 16.27,
+        "Rejection sampling chi-squared statistic {chi2_rej} exceeds critical threshold 16.27 (p < 0.001)"
+    );
+    assert!(
+        chi2_dir < 16.27,
+        "Direct sampling chi-squared statistic {chi2_dir} exceeds critical threshold 16.27 (p < 0.001)"
+    );
+
+    // Total variation distance between rejection sampling empirical frequency and target P
+    let mut tvd = 0.0f64;
+    for (v, &p) in target_p.iter().enumerate() {
+        let freq = (rejection_counts[v] as f64) / (draws as f64);
+        tvd += (freq - (p as f64)).abs();
+    }
+    tvd *= 0.5;
+    assert!(
+        tvd < 0.005,
+        "Total variation distance {tvd} between rejection sampling and target P exceeds 0.005"
+    );
+}
+
+#[test]
+fn rejection_sampling_matches_target_sampling_within_statistical_tolerance_on_synthetic_distributions(
+) {
+    // Test with one-hot deterministic draft proposer (q_i = None / one-hot)
+    let target_p = vec![0.05f32, 0.15f32, 0.50f32, 0.20f32, 0.10f32];
+    let vocab_size = 5;
+    let draws = 100_000;
+
+    let mut rejection_counts = vec![0usize; vocab_size];
+    let mut rng_rej = RngState::new(777, 10, 0);
+
+    let mut target_probs = Vec::with_capacity(vocab_size * 2);
+    target_probs.extend_from_slice(&target_p);
+    target_probs.extend_from_slice(&target_p);
+
+    let method = VerifyMethod::Rejection;
+
+    // Proposer always drafts token 2 (the mode of target)
+    let draft_tok = 2u32;
+
+    for step in 0..draws {
+        rng_rej.set_step(step as u64);
+        let mut rng_slice = [rng_rej.clone()];
+        let out = verify(
+            &[draft_tok],
+            None, // one-hot
+            &target_probs,
+            1,
+            1,
+            vocab_size,
+            &method,
+            &mut rng_slice,
+            None,
+        )
+        .unwrap();
+        rng_rej = rng_slice[0].clone();
+
+        let emitted = out.accepted[0] as usize;
+        rejection_counts[emitted] += 1;
+    }
+
+    // For V=5 (df=4), critical value at alpha=0.001 is 18.47.
+    let chi2 = chi_squared_stat(&rejection_counts, draws, &target_p);
+    assert!(
+        chi2 < 18.47,
+        "Draft-free rejection sampling chi2 {chi2} exceeds critical threshold 18.47"
+    );
+}

--- a/crates/r9v-t0/tests/greedy_tests.rs
+++ b/crates/r9v-t0/tests/greedy_tests.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Temperature-zero greedy equivalence tests (Spec 1 §4.F, Spec 7 §4, Card A1.8).
+
+use r9v_ir::{SamplingParams, VerifyMethod};
+use r9v_t0::{logits_postprocess, sample, verify, RngState};
+
+fn greedy_params() -> SamplingParams {
+    SamplingParams {
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        logit_bias: vec![],
+    }
+}
+
+#[test]
+fn greedy_equivalence_at_temperature_zero() {
+    let logits = vec![1.2, 5.8, -0.4, 3.1, 5.8, 2.0];
+    let v = logits.len();
+    let params = vec![greedy_params()];
+
+    let mut probs = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &params, None, None, &mut probs).unwrap();
+
+    // 1. Logits postprocess at temperature 0 must output a one-hot distribution
+    // Notice tokens 1 and 4 have identical max logit 5.8. Stable sort by (-logit, index)
+    // selects token 1 (lower index) deterministically.
+    assert_eq!(probs[1], 1.0f32);
+    assert_eq!(probs[4], 0.0f32);
+    for (i, &p) in probs.iter().enumerate() {
+        if i == 1 {
+            assert_eq!(p, 1.0);
+        } else {
+            assert_eq!(p, 0.0);
+        }
+    }
+
+    // 2. Sample on temperature 0 distribution must deterministically return argmax
+    for seed in [1, 42, 999, 123456] {
+        let mut rng = vec![RngState::new(seed, 1, 0)];
+        let token = sample(&probs, 1, v, &mut rng).unwrap()[0];
+        assert_eq!(
+            token, 1,
+            "Sample at temp 0 must yield deterministic argmax token 1"
+        );
+    }
+}
+
+#[test]
+fn greedy_equivalence_temperature_zero_rejection_matches_greedy() {
+    let v = 6;
+    let k = 3;
+
+    // Target logits for 4 positions: pos 0..3 (k=3 draft positions + 1 bonus position)
+    let target_logits = vec![
+        // pos 0: max at 2
+        0.0, 1.0, 5.0, 2.0, 0.5, 0.0, // pos 1: max at 4
+        1.0, 0.0, 2.0, 3.0, 6.0, 1.0, // pos 2: max at 0
+        4.0, 1.0, 2.0, 0.0, 0.0, 3.0, // pos 3 (bonus): max at 5
+        1.0, 2.0, 0.0, 1.0, 3.0, 7.0,
+    ];
+
+    let params = vec![greedy_params()];
+    let mut target_probs = vec![0.0f32; (k + 1) * v];
+    logits_postprocess(
+        &target_logits,
+        1,
+        k + 1,
+        v,
+        &params,
+        None,
+        None,
+        &mut target_probs,
+    )
+    .unwrap();
+
+    // Scenario A: all draft tokens match greedy argmax [2, 4, 0]
+    let matching_draft = vec![2u32, 4, 0];
+    let mut rng_greedy = vec![RngState::new(42, 1, 0)];
+    let mut rng_rejection = vec![RngState::new(42, 1, 0)];
+
+    let out_greedy = verify(
+        &matching_draft,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Greedy,
+        &mut rng_greedy,
+        None,
+    )
+    .unwrap();
+
+    let out_rejection = verify(
+        &matching_draft,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Rejection,
+        &mut rng_rejection,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(out_greedy.accept_len, vec![3]);
+    assert_eq!(out_greedy.accepted, vec![2, 4, 0, 5]);
+    assert_eq!(out_greedy.accept_len, out_rejection.accept_len);
+    assert_eq!(out_greedy.accepted, out_rejection.accepted);
+
+    // Scenario B: partial match - second draft token mismatches: [2, 1 (instead of 4), 0]
+    let partial_draft = vec![2u32, 1, 0];
+    let mut rng_g2 = vec![RngState::new(100, 2, 0)];
+    let mut rng_r2 = vec![RngState::new(100, 2, 0)];
+
+    let out_g2 = verify(
+        &partial_draft,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Greedy,
+        &mut rng_g2,
+        None,
+    )
+    .unwrap();
+
+    let out_r2 = verify(
+        &partial_draft,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Rejection,
+        &mut rng_r2,
+        None,
+    )
+    .unwrap();
+
+    // In both cases, exactly 1 draft token is accepted (token 2).
+    // Replacement token at index 1 is target argmax 4!
+    assert_eq!(out_g2.accept_len, vec![1]);
+    assert_eq!(out_g2.accepted[0], 2);
+    assert_eq!(out_g2.accepted[1], 4);
+    assert_eq!(out_g2.accept_len, out_r2.accept_len);
+    assert_eq!(out_g2.accepted, out_r2.accepted);
+}
+
+#[test]
+fn greedy_stable_tie_break_by_lowest_index() {
+    let logits = vec![3.0, 3.0, 3.0, 3.0];
+    let v = logits.len();
+    let mut probs = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[greedy_params()], None, None, &mut probs).unwrap();
+
+    // All logits identical: index 0 must be selected
+    assert_eq!(probs, vec![1.0, 0.0, 0.0, 0.0]);
+}

--- a/crates/r9v-t0/tests/sampling_params_tests.rs
+++ b/crates/r9v-t0/tests/sampling_params_tests.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exhaustive tests for all SamplingParams behaviors (Spec 1 §4.F, Spec 1 §6.5, Card A1.8).
+
+use r9v_ir::SamplingParams;
+use r9v_t0::logits_postprocess;
+
+fn base_params() -> SamplingParams {
+    SamplingParams {
+        temperature: 1.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        logit_bias: vec![],
+    }
+}
+
+#[test]
+fn test_logit_bias_added_before_temperature() {
+    let logits = vec![0.0, 0.0];
+    let v = logits.len();
+    let mut params = base_params();
+    params.logit_bias = vec![(0, 2.0)];
+    params.temperature = 0.5; // logit 2.0 / 0.5 = 4.0
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], None, None, &mut out).unwrap();
+
+    // With temperature=0.5, effective logit for token 0 is 2.0 / 0.5 = 4.0, token 1 is 0.0
+    // Expected prob: e^4 / (e^4 + 1)
+    let expected_p0 = 4.0f32.exp() / (4.0f32.exp() + 1.0f32);
+    assert!((out[0] - expected_p0).abs() < 1e-5);
+}
+
+#[test]
+fn test_repetition_penalty_positive_and_negative_logits() {
+    // Token 0: positive logit 2.0, count 1 -> 2.0 / 2.0 = 1.0
+    // Token 1: negative logit -2.0, count 1 -> -2.0 * 2.0 = -4.0
+    // Token 2: logit 1.0, count 0 -> unpenalized 1.0
+    let logits = vec![2.0, -2.0, 1.0];
+    let v = logits.len();
+    let mut params = base_params();
+    params.repetition_penalty = 2.0;
+    let history = vec![1, 1, 0];
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], Some(&history), None, &mut out).unwrap();
+
+    // After penalty, effective logits: token 0 is 1.0, token 1 is -4.0, token 2 is 1.0
+    // Token 0 and Token 2 should have equal probability!
+    assert!((out[0] - out[2]).abs() < 1e-6);
+    assert!(out[0] > out[1]);
+}
+
+#[test]
+fn test_presence_and_frequency_penalties() {
+    let logits = vec![5.0, 5.0, 5.0];
+    let v = logits.len();
+    let mut params = base_params();
+    params.presence_penalty = 1.0;
+    params.frequency_penalty = 0.5;
+
+    // Token 0: count 0 -> unpenalized (5.0)
+    // Token 1: count 2 -> penalized: 5.0 - 1.0 - 2 * 0.5 = 3.0
+    // Token 2: count 4 -> penalized: 5.0 - 1.0 - 4 * 0.5 = 2.0
+    let history = vec![0, 2, 4];
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], Some(&history), None, &mut out).unwrap();
+
+    assert!(out[0] > out[1]);
+    assert!(out[1] > out[2]);
+
+    // Check exact softmax ratio: e^5 : e^3 : e^2
+    let sum_e = 5.0f32.exp() + 3.0f32.exp() + 2.0f32.exp();
+    let expected_p0 = 5.0f32.exp() / sum_e;
+    let expected_p1 = 3.0f32.exp() / sum_e;
+    let expected_p2 = 2.0f32.exp() / sum_e;
+
+    assert!((out[0] - expected_p0).abs() < 1e-5);
+    assert!((out[1] - expected_p1).abs() < 1e-5);
+    assert!((out[2] - expected_p2).abs() < 1e-5);
+}
+
+#[test]
+fn test_grammar_mask_applied_before_softmax() {
+    let logits = vec![100.0, 1.0, 2.0];
+    let v = logits.len();
+    let params = base_params();
+    let mask = vec![false, true, true]; // Token 0 has dominant logit 100.0 but is masked
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], None, Some(&mask), &mut out).unwrap();
+
+    assert_eq!(out[0], 0.0);
+    assert!(out[2] > out[1]);
+    assert!((out[1] + out[2] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn test_top_k_filtering() {
+    let logits = vec![1.0, 5.0, 2.0, 4.0, 3.0];
+    let v = logits.len();
+    let mut params = base_params();
+    params.top_k = 2; // Keep top 2 tokens: token 1 (logit 5) and token 3 (logit 4)
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], None, None, &mut out).unwrap();
+
+    assert!(out[1] > 0.0);
+    assert!(out[3] > 0.0);
+    assert_eq!(out[0], 0.0);
+    assert_eq!(out[2], 0.0);
+    assert_eq!(out[4], 0.0);
+    assert!((out[1] + out[3] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn test_top_p_nucleus_filtering() {
+    let logits = vec![10.0, 5.0, 1.0, 0.0];
+    let v = logits.len();
+    let mut params = base_params();
+    // With logit 10.0 vs 5.0, token 0 has > 99% of total softmax probability
+    params.top_p = 0.95;
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], None, None, &mut out).unwrap();
+
+    // Only token 0 should be retained
+    assert_eq!(out[0], 1.0);
+    assert_eq!(out[1], 0.0);
+    assert_eq!(out[2], 0.0);
+    assert_eq!(out[3], 0.0);
+}
+
+#[test]
+fn test_min_p_filtering() {
+    let logits = vec![4.0, 3.0, 1.0, 0.0];
+    let v = logits.len();
+    let mut params = base_params();
+    params.min_p = 0.25; // Discard tokens with p < 0.25 * p_max
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], None, None, &mut out).unwrap();
+
+    // Token 0 is p_max. Check that surviving tokens have p >= 0.25 * p_max
+    assert!(out[0] > 0.0);
+    assert!(out[1] > 0.0);
+    // Tokens with low logits are filtered out
+    assert_eq!(out[2], 0.0);
+    assert_eq!(out[3], 0.0);
+    assert!((out.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn test_stable_sort_tie_breaking_by_lowest_index() {
+    // Tokens 0, 1, 2, 3 have identical logits.
+    // top_k = 2 must stably keep tokens 0 and 1, breaking ties by lowest index.
+    let logits = vec![2.0, 2.0, 2.0, 2.0];
+    let v = logits.len();
+    let mut params = base_params();
+    params.top_k = 2;
+
+    let mut out = vec![0.0f32; v];
+    logits_postprocess(&logits, 1, 1, v, &[params], None, None, &mut out).unwrap();
+
+    assert_eq!(out[0], 0.5);
+    assert_eq!(out[1], 0.5);
+    assert_eq!(out[2], 0.0);
+    assert_eq!(out[3], 0.0);
+}

--- a/crates/r9v-t0/tests/sampling_params_tests.rs
+++ b/crates/r9v-t0/tests/sampling_params_tests.rs
@@ -171,3 +171,19 @@ fn test_stable_sort_tie_breaking_by_lowest_index() {
     assert_eq!(out[2], 0.0);
     assert_eq!(out[3], 0.0);
 }
+
+#[test]
+fn out_of_range_logit_bias_is_rejected() {
+    let mut params = base_params();
+    params.logit_bias = vec![(3, 1.0)];
+    let mut out = vec![0.0; 3];
+    let err = logits_postprocess(&[0.0; 3], 1, 1, 3, &[params], None, None, &mut out).unwrap_err();
+    assert!(matches!(
+        err,
+        r9v_t0::T0Error::TokenOutOfRange {
+            token: 3,
+            vocab_size: 3,
+            ..
+        }
+    ));
+}

--- a/crates/r9v-t0/tests/verify_tests.rs
+++ b/crates/r9v-t0/tests/verify_tests.rs
@@ -156,6 +156,8 @@ fn test_verify_tree_walk_longest_path_and_tie_breaking() {
     target_probs[2 * v] = 1.0;
     // Node 2 output: bonus token 2
     target_probs[3 * v + 2] = 1.0;
+    // Node 3 output: valid bonus distribution for Path B
+    target_probs[4 * v] = 1.0;
 
     let mut rng = vec![RngState::new(42, 1, 0)];
     let out = verify(
@@ -182,11 +184,15 @@ fn test_verify_tree_walk_longest_path_and_tie_breaking() {
     // Path A starts with node 0; Path B starts with node 1.
     // Spec 7 §5: "ties go to the path with the lowest first-token index"
     // Node 0 < Node 1, so Path A must win on tie!
+    target_probs[1] = 1.0;
+    target_probs[2] = 0.0;
+    target_probs[2 * v] = 0.0;
     target_probs[2 * v + 4] = 1.0; // Now node 1 output also matches node 3!
+    let tie_draft_tokens = vec![1, 1, 3, 4];
 
     let mut rng_tie = vec![RngState::new(42, 1, 0)];
     let out_tie = verify(
-        &draft_tokens,
+        &tie_draft_tokens,
         None,
         &target_probs,
         1,
@@ -202,11 +208,12 @@ fn test_verify_tree_walk_longest_path_and_tie_breaking() {
     // Path A (starting with first-token index 0) wins tie over Path B (first-token index 1)
     assert_eq!(out_tie.accepted[0], 1);
     assert_eq!(out_tie.accepted[1], 3);
+    assert_eq!(out_tie.accepted[2], 2);
 }
 
 #[test]
 fn test_verify_degenerate_k_zero() {
-    let target_probs = vec![0.0, 1.0, 0.0];
+    let target_probs = vec![0.2, 0.6, 0.2];
     let mut rng = vec![RngState::new(1, 1, 0)];
     let out = verify(
         &[],
@@ -223,4 +230,46 @@ fn test_verify_degenerate_k_zero() {
 
     assert_eq!(out.accept_len, vec![0]);
     assert_eq!(out.accepted, vec![1]);
+}
+
+#[test]
+fn verify_rejects_out_of_range_tokens_and_dimension_overflow_without_panicking() {
+    let mut rng = vec![RngState::new(1, 1, 0)];
+    let err = verify(
+        &[3],
+        None,
+        &[0.5, 0.5, 0.5, 0.5],
+        1,
+        1,
+        2,
+        &VerifyMethod::Greedy,
+        &mut rng,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        r9v_t0::T0Error::TokenOutOfRange {
+            token: 3,
+            vocab_size: 2,
+            ..
+        }
+    ));
+
+    let err = verify(
+        &[],
+        None,
+        &[],
+        1,
+        usize::MAX,
+        2,
+        &VerifyMethod::Greedy,
+        &mut rng,
+        None,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        r9v_t0::T0Error::ShapeLengthMismatch { tensor: "k", .. }
+    ));
 }

--- a/crates/r9v-t0/tests/verify_tests.rs
+++ b/crates/r9v-t0/tests/verify_tests.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Speculative verification tests: Rejection, Greedy, Typical, and Tree walk (Spec 1 §4.F, Spec 7 §4, §5, Card A1.8).
+
+use r9v_ir::{TreeMask, VerifyMethod};
+use r9v_t0::{verify, RngState};
+
+#[test]
+fn test_verify_rejection_all_accepted_samples_bonus() {
+    let k = 2;
+    let v = 4;
+    let draft_tokens = vec![1, 3];
+    // Target distributions strongly favor draft tokens
+    let target_probs = vec![
+        0.0, 1.0, 0.0, 0.0, // pos 0 -> token 1 prob 1.0
+        0.0, 0.0, 0.0, 1.0, // pos 1 -> token 3 prob 1.0
+        0.5, 0.5, 0.0, 0.0, // pos 2 (bonus) -> uniform over 0 and 1
+    ];
+    let mut rng = vec![RngState::new(42, 1, 0)];
+
+    let out = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Rejection,
+        &mut rng,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(out.accept_len, vec![2]);
+    assert_eq!(out.accepted[0], 1);
+    assert_eq!(out.accepted[1], 3);
+    // Bonus token must be 0 or 1
+    assert!(out.accepted[2] == 0 || out.accepted[2] == 1);
+}
+
+#[test]
+fn test_verify_rejection_first_rejected_samples_replacement() {
+    let k = 2;
+    let v = 4;
+    let draft_tokens = vec![1, 2];
+    // Target pos 0 gives 0.0 to token 1 and 1.0 to token 3
+    let target_probs = vec![
+        0.0, 0.0, 0.0, 1.0, // pos 0
+        0.0, 0.0, 1.0, 0.0, // pos 1
+        1.0, 0.0, 0.0, 0.0, // pos 2
+    ];
+    let mut rng = vec![RngState::new(123, 1, 0)];
+
+    let out = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Rejection,
+        &mut rng,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(out.accept_len, vec![0]);
+    // Replacement token at index 0 must be 3
+    assert_eq!(out.accepted[0], 3);
+}
+
+#[test]
+fn test_verify_typical_acceptance_threshold() {
+    let v = 4;
+    let draft_tokens = vec![1];
+    // Distribution where token 1 has probability 0.8
+    let target_probs = vec![
+        0.05, 0.80, 0.10, 0.05, 1.0, 0.0, 0.0, 0.0, // bonus
+    ];
+    let mut rng = vec![RngState::new(42, 1, 0)];
+
+    // 1. With eps = 0.5, p[1] = 0.80 > min(0.5, ...) -> should accept!
+    let method_accept = VerifyMethod::TypicalAcceptance {
+        eps: 0.5,
+        delta: 1.0,
+    };
+    let out1 = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        1,
+        v,
+        &method_accept,
+        &mut rng,
+        None,
+    )
+    .unwrap();
+    assert_eq!(out1.accept_len, vec![1]);
+    assert_eq!(out1.accepted[0], 1);
+
+    // 2. With eps = 0.9, delta = 2.0 -> min(0.9, 2.0 * 0.492) = 0.9 > 0.80 -> should reject!
+    let method_reject = VerifyMethod::TypicalAcceptance {
+        eps: 0.9,
+        delta: 2.0,
+    };
+    let out2 = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        1,
+        v,
+        &method_reject,
+        &mut rng,
+        None,
+    )
+    .unwrap();
+    assert_eq!(out2.accept_len, vec![0]);
+}
+
+#[test]
+fn test_verify_tree_walk_longest_path_and_tie_breaking() {
+    // Construct a tree of k=4 tokens:
+    // Roots: node 0 and node 1 (both children of prompt context: parents = -1)
+    // Node 2 is child of node 0: parents[2] = 0
+    // Node 3 is child of node 1: parents[3] = 1
+    // Paths from root to leaves:
+    // Path A: 0 -> 2
+    // Path B: 1 -> 3
+    let parents = vec![-1, -1, 0, 1];
+    let k = 4;
+    let t_max = 4;
+    let ancestors = vec![
+        true, false, false, false, false, true, false, false, true, false, true, false, false,
+        true, false, true,
+    ];
+    let tree_mask = TreeMask::new(parents, t_max, ancestors).unwrap();
+
+    let v = 5;
+    let draft_tokens = vec![1, 2, 3, 4];
+
+    // Case 1: Path A accepts 2 tokens (0 and 2), Path B accepts 1 token (1)
+    // Target distribution:
+    // Index 0 (root predicting 0 and 1): predicts token 1 (matching node 0) and token 2 (matching node 1)
+    // Index 1 (node 0 output predicting node 2): predicts token 3 (matching node 2)
+    // Index 2 (node 1 output predicting node 3): predicts token 0 (mismatching node 3 which is 4)
+    // Index 3 (node 2 output - bonus token for Path A): predicts token 0
+    // Index 4 (node 3 output - bonus token for Path B): predicts token 0
+    let mut target_probs = vec![0.0f32; (k + 1) * v];
+    // Root: token 1 has 0.9 (matches node 0), token 2 has 0.9 (matches node 1)
+    target_probs[1] = 0.5;
+    target_probs[2] = 0.5;
+    // Node 0 output: matches node 2 (token 3)
+    target_probs[v + 3] = 1.0;
+    // Node 1 output: mismatches node 3 (token 4), emits token 0 instead
+    target_probs[2 * v] = 1.0;
+    // Node 2 output: bonus token 2
+    target_probs[3 * v + 2] = 1.0;
+
+    let mut rng = vec![RngState::new(42, 1, 0)];
+    let out = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Greedy,
+        &mut rng,
+        Some(&tree_mask),
+    )
+    .unwrap();
+
+    // Path A has 2 accepted tokens (nodes 0 and 2), while Path B has only 1 (node 1).
+    // Longest path (Path A) must win!
+    assert_eq!(out.accept_len, vec![2]);
+    assert_eq!(out.accepted[0], 1); // token of node 0
+    assert_eq!(out.accepted[1], 3); // token of node 2
+    assert_eq!(out.accepted[2], 2); // bonus token from node 2
+
+    // Case 2: Tie breaking: both Path A and Path B accept 2 tokens!
+    // Path A starts with node 0; Path B starts with node 1.
+    // Spec 7 §5: "ties go to the path with the lowest first-token index"
+    // Node 0 < Node 1, so Path A must win on tie!
+    target_probs[2 * v + 4] = 1.0; // Now node 1 output also matches node 3!
+
+    let mut rng_tie = vec![RngState::new(42, 1, 0)];
+    let out_tie = verify(
+        &draft_tokens,
+        None,
+        &target_probs,
+        1,
+        k,
+        v,
+        &VerifyMethod::Greedy,
+        &mut rng_tie,
+        Some(&tree_mask),
+    )
+    .unwrap();
+
+    assert_eq!(out_tie.accept_len, vec![2]);
+    // Path A (starting with first-token index 0) wins tie over Path B (first-token index 1)
+    assert_eq!(out_tie.accepted[0], 1);
+    assert_eq!(out_tie.accepted[1], 3);
+}
+
+#[test]
+fn test_verify_degenerate_k_zero() {
+    let target_probs = vec![0.0, 1.0, 0.0];
+    let mut rng = vec![RngState::new(1, 1, 0)];
+    let out = verify(
+        &[],
+        None,
+        &target_probs,
+        1,
+        0,
+        3,
+        &VerifyMethod::Greedy,
+        &mut rng,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(out.accept_len, vec![0]);
+    assert_eq!(out.accepted, vec![1]);
+}


### PR DESCRIPTION
## Card
A1.8 — t0 sampling group   (kind: implementation; GPU: no; size: M)

## Spec sections implemented
- spec 1 §4.F: logits postprocessing, sampling, and speculative verification tensor contracts.
- spec 1 §6.5: stable filtering, probability normalization, and deterministic sampling numerics.
- spec 7 §4, §5: rejection, greedy, typical acceptance, and longest-path tree verification.
- spec 4 §5.8: Philox-keyed deterministic draws for sampling and verification.

## Deliverables
- [x] `logits_postprocess` with penalties, temperature, logit bias, grammar mask, stable sort, top-k, top-p, and min-p.
- [x] `sample` with Philox4x32 keyed by sequence, step, and draw index.
- [x] `verify` with Rejection, Greedy, TypicalAcceptance, and tree drafts.
- [x] Typed collect-all validation for malformed dimensions, distributions, tokens, and trees.
- [x] Cohesive integration with the A1.5 T0 modules, dispatcher, and error surface.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| 100,000-draw rejection distribution against target sampling | crates/r9v-t0/tests/distribution_tests.rs | cpu-only | green |
| deterministic run-to-run and batch-invariant sampling/verification | crates/r9v-t0/tests/determinism_tests.rs | cpu-only | green |
| temperature-zero greedy equivalence and stable tie breaking | crates/r9v-t0/tests/greedy_tests.rs | cpu-only | green |
| every logits-postprocess parameter and filtering order | crates/r9v-t0/tests/sampling_params_tests.rs | cpu-only | green |
| rejection, typical, degenerate, malformed, and tree verification | crates/r9v-t0/tests/verify_tests.rs | cpu-only | green |
| public types, signatures, and Send/Sync bounds | crates/r9v-t0/tests/api_shape.rs | cpu-only | green |

## Decisions
- crates/r9v-t0/src/philox.rs:42 — map the seed and sequence/step/draw tuple to Philox key/counter words and use open-interval centered f32 draws.
- crates/r9v-t0/src/sampling.rs:19 — filter candidates in stable `(-logit, token)` order, renormalize survivors, and use lowest-token tie breaking at temperature zero.
- crates/r9v-t0/src/sampling.rs:408 — reserve draw `i` for candidate `i` and draw `k` for the terminal bonus or replacement.
- crates/r9v-t0/src/sampling.rs:409 — index tree target distributions by root/parent output using the shared `[k+1,V]` contract.
- crates/r9v-t0/src/sampling.rs:410 — implement the specified typical-acceptance threshold and sample a verified continuation on rejection.

## SPEC-ISSUES filed
- none

## New dependencies
- none

## Hardware
Tests run here: hosted cpu-only plus existing stub-device workspace tests
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command `cargo test --workspace`, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- Shared op-harness migration: no; A1.10 owns the later generic harness after A1.5–A1.9 exist, while this card includes the required golden, batch-invariance, determinism, malformed-input, and distribution coverage directly.
- Performance receipt: no; this is the scalar correctness tier and has no GPU performance gate.

## Size check
Diff size vs card size class: 2,356 changed lines vs M — consistent with three complete sampling operations, deterministic Philox support, typed validation, and statistical/tree test suites.
