### PR TITLE
A1.3: implement model graph builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,8 @@ name = "r9v-models"
 version = "0.1.0"
 dependencies = [
  "r9v-common",
+ "r9v-ir",
+ "thiserror",
 ]
 
 [[package]]

--- a/SPEC-ISSUES.md
+++ b/SPEC-ISSUES.md
@@ -101,3 +101,9 @@ What: Spec 2 §2.3 requires the `L1S` index region to store 2 bits per kept elem
 Why it blocks or misleads: The two rules imply different index-region lengths, tensor offsets, checksums, and whole-model size estimates. A 16×16 compressed-K value tile contains 256 kept values, so §2.3 requires 64 index bytes; the §8 shorthand would permit only 32 bytes and cannot encode a 2-bit position for every kept value.
 Option taken: Followed the byte-defining rule in §2.3: 256 kept values × 2 bits = 64 index bytes per compressed-K `L1` tile. Size accounting must therefore use `dense_bpw × 0.5 + 1.0 bpw indices` until the specification resolves the contradiction.
 Proposed resolution: Change the §8 shorthand to `×0.5 + 1.0 bpw indices`, or explicitly redefine the §2.3 index encoding to a 2-bit-per-four-dense-values scheme and provide its legal pattern table and SWMMAC operand mapping.
+
+## SI-16 — A1.3 — spec 8 §3
+What: Spec 8 §3 defines `NgramSpec { orders, heads, table_sizes, hash, combine, inject_at: layer }` with no row dimension, while Spec 1 §4.A `ngram_gather` requires `Dn` (`gather_staging [T, Np, Dn]` → `x [T, Np·Dn]`) to shape the device table and the projection.
+Why it blocks or misleads: Without `Dn` in the model definition, the builder cannot declare the `[TotalEntries, Dn]` table shape or the `heads·Dn`/`Dn` projection width from the spec; any value it picks (including the previously hardcoded 32) is unverifiable and silently fixes a model property the checkpoint family should own.
+Option taken: Added an explicit `dim: u32` (Dn) to `NgramSpec`, validated nonzero and bounded, with `orders.len` and `table_sizes.len` each required to equal `heads`; see DECISION(A1.3) at the struct.
+Proposed resolution: Add `dim: u32` (Dn) to the Spec 8 §3 `NgramSpec` surface and state that `orders.len == table_sizes.len == heads`.

--- a/crates/r9v-models/Cargo.toml
+++ b/crates/r9v-models/Cargo.toml
@@ -9,3 +9,5 @@ description = "R9V model architecture builder and model families (Spec 8, Spec 1
 
 [dependencies]
 r9v-common = { path = "../r9v-common" }
+r9v-ir = { path = "../r9v-ir" }
+thiserror = "2.0"

--- a/crates/r9v-models/src/builder.rs
+++ b/crates/r9v-models/src/builder.rs
@@ -1,0 +1,1336 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Sealed model graph builder and model graph representation (Spec 8 §2, §5, §7; card A1.3).
+//!
+//! A model definition consumes [`GraphBuilder`] to declare weights, state allocations,
+//! tensor transformations, fusions, and exports. Sealing the builder guarantees that
+//! architecture definitions remain pure functions without side-effects or device access.
+
+use std::collections::BTreeMap;
+
+use r9v_ir::graph::{
+    EdgeId, ExternalInputKind, ExternalOutputKind, Graph as IrGraph, PlanId, StepGraphKey,
+};
+use r9v_ir::op::{
+    ActMulOp, ActivationKind, ActivationOp, AttentionMask, AttentionOp, CausalConv1dOp,
+    ConvActivation, EmbedGatherOp, Epilogue, HashId, LinearAttnKind, LinearAttnScanOp, MatmulOp,
+    MlaAttentionSpec, MlaLatent, MoeFfnOp, MoeGroup, MoeRouteOp, MoeScoring, NgramCombine,
+    NgramGatherOp, NgramSource, NormAxis, NormOp, Op, ResidualAddOp, RopeOp, StateWriteKvOp,
+};
+use r9v_ir::state::StateHandle;
+use r9v_ir::tensor::{Class, Dim, ShapeSymbol, ShardLayout, Tensor};
+use r9v_ir::version::IrVersion;
+use r9v_ir::{DType, LayoutId, QuantScheme};
+
+use crate::error::ModelsError;
+use crate::spec::{CacheDtype, NormSpec, PositionEncoding, RopeSpec, StateSpec};
+use crate::summary::{ExpertSummary, LayerSummary, MixerKind, ModelSummary, SchemeKey};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker trait sealing the [`GraphBuilder`] interface (Spec 8 §2; card A1.3).
+// DECISION(A1.3): GraphBuilder is sealed using a private Sealed trait so external crates cannot implement it directly, preserving pure graph construction; rejected making GraphBuilder an open trait or unsealed struct. Spec 8 §1, §2.
+pub trait SealedGraphBuilder: sealed::Sealed {}
+
+/// Semantic role of a bound weight tensor (Spec 8 §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WeightRole {
+    /// General matrix multiplication weight.
+    Matmul,
+    /// Token embedding lookup table.
+    Embed,
+    /// Language model output head projection.
+    LmHead,
+    /// Speculative decoding n-gram hash table.
+    NgramTable,
+    /// 1D vector parameter (e.g. normalization weight/bias).
+    Vector,
+}
+
+/// Class of quantization schemes a weight binding can consume (Spec 8 §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SchemeClass {
+    /// Matrix multiplication weights: accepts any Spec 2 scheme or unquantized.
+    Matmul,
+    /// Normalization or bias vectors: must be f32 unquantized.
+    Vector,
+    /// Embedding lookup table weights.
+    Embed,
+    /// Speculative n-gram table weights.
+    NgramTable,
+}
+
+/// Fusion declaration over named weights (Spec 8 §2, §5).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FusionDecl {
+    /// QKV projection fusion (Spec 8 §5: `Qkv { q, k, v }`).
+    Qkv {
+        /// Q weight name.
+        q: String,
+        /// K weight name.
+        k: String,
+        /// V weight name.
+        v: String,
+    },
+    /// FFN Gate/Up projection fusion (Spec 8 §5: `GateUp { gate, up }`).
+    GateUp {
+        /// Gate weight name.
+        gate: String,
+        /// Up weight name.
+        up: String,
+    },
+}
+
+/// Tied embedding declaration (Spec 8 §2, §5).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TiedDecl {
+    /// Source embedding weight name (e.g. `"token_embd.weight"`).
+    pub embed_name: String,
+    /// Destination output projection weight name (e.g. `"output.weight"`).
+    pub head_name: String,
+}
+
+/// Record of a weight bound in a model definition (Spec 8 §2, §5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundWeight {
+    /// Tensor name following llama.cpp GGUF convention.
+    pub name: String,
+    /// Semantic role.
+    pub role: WeightRole,
+    /// Expected logical shape.
+    pub shape: Vec<Dim>,
+    /// Expected scheme classification.
+    pub expected_scheme_class: SchemeClass,
+    /// Bound tensor descriptor.
+    pub tensor: Tensor,
+}
+
+/// Factory entry point for creating a [`GraphBuilder`] (Spec 8 §2).
+pub struct Graph;
+
+impl Graph {
+    /// Creates a new [`GraphBuilder`] pinned to an IR version and model identifier (Spec 8 §2).
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(ir_version: IrVersion, model_id: impl Into<String>) -> GraphBuilder {
+        GraphBuilder::new(ir_version, model_id)
+    }
+}
+
+/// Sealed graph builder for model definitions (Spec 8 §2; card A1.3).
+#[derive(Debug)]
+pub struct GraphBuilder {
+    _sealed: (),
+    ir_version: IrVersion,
+    model_id: String,
+    graph: IrGraph,
+    bound_weights: Vec<BoundWeight>,
+    fusion_decls: Vec<FusionDecl>,
+    tied_decls: Vec<TiedDecl>,
+    state_specs: Vec<(u32, StateSpec, StateHandle)>,
+    exports: Vec<(String, Tensor)>,
+    subgraphs: BTreeMap<String, ModelGraph>,
+    edge_map: Vec<(Tensor, EdgeId)>,
+    tokens_tensor: Option<Tensor>,
+}
+
+impl sealed::Sealed for GraphBuilder {}
+impl SealedGraphBuilder for GraphBuilder {}
+
+/// Reads dimension `index` of `tensor`, returning a typed error instead of
+/// panicking on a short shape (Spec 8 §2, §6).
+pub(crate) fn shape_dim(
+    tensor: &Tensor,
+    index: usize,
+    context: &'static str,
+) -> Result<Dim, ModelsError> {
+    tensor.shape().get(index).copied().ok_or_else(|| {
+        let rank = tensor.rank();
+        ModelsError::ShapeAccess {
+            context: context.to_string(),
+            reason: format!("rank {rank} has no dimension {index}"),
+        }
+    })
+}
+
+/// Extracts the single output tensor of an op emission helper (Spec 8 §2).
+pub(crate) fn single_output(
+    outputs: Vec<Tensor>,
+    context: &'static str,
+) -> Result<Tensor, ModelsError> {
+    outputs
+        .into_iter()
+        .next()
+        .ok_or_else(|| ModelsError::ShapeAccess {
+            context: context.to_string(),
+            reason: "op emission produced no output tensor".to_string(),
+        })
+}
+
+/// Checked `a * b` over untrusted dimensions; reports both operands (Spec 8 §6).
+pub(crate) fn checked_mul(a: u32, b: u32, context: &'static str) -> Result<u32, ModelsError> {
+    a.checked_mul(b)
+        .ok_or_else(|| ModelsError::ArithmeticOverflow {
+            context: context.to_string(),
+            operation: format!("{a} * {b}"),
+        })
+}
+
+/// Checked `a + b` over untrusted dimensions; reports both operands (Spec 8 §6).
+pub(crate) fn checked_add(a: u32, b: u32, context: &'static str) -> Result<u32, ModelsError> {
+    a.checked_add(b)
+        .ok_or_else(|| ModelsError::ArithmeticOverflow {
+            context: context.to_string(),
+            operation: format!("{a} + {b}"),
+        })
+}
+
+/// Checked `usize -> u32` narrowing for ordinals derived from `Vec` positions
+/// (Spec 8 §6).
+pub(crate) fn checked_u32(value: usize, context: &'static str) -> Result<u32, ModelsError> {
+    u32::try_from(value).map_err(|_| ModelsError::ArithmeticOverflow {
+        context: context.to_string(),
+        operation: format!("usize {value} exceeds u32 range"),
+    })
+}
+
+/// Checked `a * b` over byte-accounting totals; reports both operands
+/// (Spec 8 §7).
+pub(crate) fn checked_mul_u64(a: u64, b: u64, context: &'static str) -> Result<u64, ModelsError> {
+    a.checked_mul(b)
+        .ok_or_else(|| ModelsError::ArithmeticOverflow {
+            context: context.to_string(),
+            operation: format!("{a} * {b}"),
+        })
+}
+
+/// Checked `a + b` over byte-accounting totals; reports both operands
+/// (Spec 8 §7).
+pub(crate) fn checked_add_u64(a: u64, b: u64, context: &'static str) -> Result<u64, ModelsError> {
+    a.checked_add(b)
+        .ok_or_else(|| ModelsError::ArithmeticOverflow {
+            context: context.to_string(),
+            operation: format!("{a} + {b}"),
+        })
+}
+
+impl GraphBuilder {
+    /// Creates a new sealed graph builder (Spec 8 §2).
+    pub fn new(ir_version: IrVersion, model_id: impl Into<String>) -> Self {
+        let key = StepGraphKey::new(PlanId::new(0), 0, 1, 1, 0, 0)
+            .expect("canonical decode bucket key (S=1, T_dec=1, T_pre=0) must be valid");
+        let mut graph = IrGraph::new(key);
+        // Pre-register global structured metadata inputs required by IR validation (SI-12).
+        let _ = graph.add_batch_meta_input();
+        let _ = graph.add_sampling_params_input();
+        let _ = graph.add_rng_state_input();
+        let _ = graph.add_updated_rng_state_output();
+
+        Self {
+            _sealed: (),
+            ir_version,
+            model_id: model_id.into(),
+            graph,
+            bound_weights: Vec::new(),
+            fusion_decls: Vec::new(),
+            tied_decls: Vec::new(),
+            state_specs: Vec::new(),
+            exports: Vec::new(),
+            subgraphs: BTreeMap::new(),
+            edge_map: Vec::new(),
+            tokens_tensor: None,
+        }
+    }
+
+    /// Pinned IR version.
+    pub fn ir_version(&self) -> IrVersion {
+        self.ir_version
+    }
+
+    /// Model identifier.
+    pub fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn record_edge(&mut self, tensor: Tensor, edge_id: EdgeId) {
+        self.edge_map.push((tensor, edge_id));
+    }
+
+    /// Resolves the most recent edge ID for a given tensor.
+    pub fn resolve_edge(&self, tensor: &Tensor) -> Result<EdgeId, ModelsError> {
+        for (t, edge_id) in self.edge_map.iter().rev() {
+            if t == tensor {
+                return Ok(*edge_id);
+            }
+        }
+        Err(ModelsError::InvalidModelSpec {
+            reason: format!("tensor not registered in builder DAG: {tensor:?}"),
+        })
+    }
+
+    /// Registers the external token IDs input `[T] u32` (Spec 8 §2; Spec 1 §3.2).
+    pub fn input_tokens(&mut self) -> Result<Tensor, ModelsError> {
+        if let Some(existing) = &self.tokens_tensor {
+            return Ok(existing.clone());
+        }
+
+        let shape = vec![Dim::Symbolic(ShapeSymbol::T)];
+        let tensor = Tensor::new(
+            shape,
+            DType::U32,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let edge_id = self
+            .graph
+            .add_external_input(ExternalInputKind::TokenIds, tensor.clone())?;
+        self.record_edge(tensor.clone(), edge_id);
+        self.tokens_tensor = Some(tensor.clone());
+        Ok(tensor)
+    }
+
+    /// Registers the multimodal embedding override tensors `[T, Dm] act`, `[T] bool mask` (Spec 8 §2).
+    pub fn input_embed_override(&mut self, dm: u32) -> Result<(Tensor, Tensor), ModelsError> {
+        let embed_tensor = Tensor::new(
+            vec![Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(dm)],
+            DType::F16,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let edge_embed = self
+            .graph
+            .add_external_input(ExternalInputKind::EmbedOverride, embed_tensor.clone())?;
+        self.record_edge(embed_tensor.clone(), edge_embed);
+
+        let mask_tensor = Tensor::new(
+            vec![Dim::Symbolic(ShapeSymbol::T)],
+            DType::Bool,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let edge_mask = self
+            .graph
+            .add_external_input(ExternalInputKind::EmbedMask, mask_tensor.clone())?;
+        self.record_edge(mask_tensor.clone(), edge_mask);
+
+        Ok((embed_tensor, mask_tensor))
+    }
+
+    /// Returns the sequence positions tensor based on position encoding kind (Spec 8 §2).
+    pub fn positions(&mut self, kind: PositionEncoding) -> Result<Tensor, ModelsError> {
+        let tokens = self.input_tokens()?;
+        match kind {
+            PositionEncoding::Scalar => Ok(tokens),
+            PositionEncoding::MRope(_) => {
+                let mrope_tensor = Tensor::new(
+                    vec![Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(3)],
+                    DType::U32,
+                    QuantScheme::None,
+                    LayoutId::CONTIGUOUS,
+                    r9v_ir::Placement::Device { rank: 0 },
+                    ShardLayout::Replicated,
+                    Class::Activation,
+                )?;
+                let tokens_edge = self.resolve_edge(&tokens)?;
+                self.record_edge(mrope_tensor.clone(), tokens_edge);
+                Ok(mrope_tensor)
+            }
+        }
+    }
+
+    /// Binds a GGUF weight tensor by name, role, expected shape and scheme class (Spec 8 §2, §5).
+    pub fn weight(
+        &mut self,
+        name: impl Into<String>,
+        role: WeightRole,
+        shape: &[Dim],
+        expected: SchemeClass,
+    ) -> Result<Tensor, ModelsError> {
+        let name = name.into();
+        let dtype = match (role, expected) {
+            (WeightRole::Vector, _) | (_, SchemeClass::Vector) => DType::F32,
+            _ => DType::F16,
+        };
+        let class = if name.ends_with(".bias") {
+            Class::Param
+        } else {
+            Class::Weight
+        };
+        let tensor = Tensor::new(
+            shape.to_vec(),
+            dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            class,
+        )?;
+
+        let edge_id = self.graph.add_tensor(tensor.clone())?;
+        self.record_edge(tensor.clone(), edge_id);
+
+        self.bound_weights.push(BoundWeight {
+            name,
+            role,
+            shape: shape.to_vec(),
+            expected_scheme_class: expected,
+            tensor: tensor.clone(),
+        });
+
+        Ok(tensor)
+    }
+
+    /// Declares per-layer state specification and returns its opaque handle (Spec 8 §2; Spec 3 §2).
+    pub fn state(&mut self, layer: u32, spec: StateSpec) -> Result<StateHandle, ModelsError> {
+        let handle = StateHandle::new(layer, spec.kind());
+        self.state_specs.push((layer, spec, handle));
+        Ok(handle)
+    }
+
+    /// Lowers an Op IR node into the step graph DAG (Spec 8 §2).
+    pub fn op(
+        &mut self,
+        op: Op,
+        inputs: &[Tensor],
+        outputs: &[Tensor],
+    ) -> Result<Vec<Tensor>, ModelsError> {
+        let mut input_edges = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            input_edges.push(self.resolve_edge(input)?);
+        }
+
+        let node_id = self.graph.add_op(op, &input_edges, outputs)?;
+        // The node id was just returned by `add_op`, so a missing entry names
+        // an internal graph invariant violation rather than untrusted input.
+        let node_outputs = self
+            .graph
+            .nodes()
+            .get(node_id.0)
+            .ok_or_else(|| ModelsError::ShapeAccess {
+                context: "graph.add_op".to_string(),
+                reason: format!("node {} missing after successful add_op", node_id.0),
+            })?
+            .outputs
+            .clone();
+
+        let mut result_tensors = Vec::with_capacity(outputs.len());
+        for (i, &edge_id) in node_outputs.iter().enumerate() {
+            let out_tensor = outputs
+                .get(i)
+                .ok_or_else(|| ModelsError::ShapeAccess {
+                    context: "graph.add_op".to_string(),
+                    reason: format!(
+                        "node {} reports {} outputs but only {} were declared",
+                        node_id.0,
+                        node_outputs.len(),
+                        outputs.len()
+                    ),
+                })?
+                .clone();
+            self.record_edge(out_tensor.clone(), edge_id);
+            result_tensors.push(out_tensor);
+        }
+
+        Ok(result_tensors)
+    }
+
+    /// Exports a tensor as a named graph output (Spec 8 §2).
+    pub fn export(&mut self, name: impl Into<String>, tensor: Tensor) -> Result<(), ModelsError> {
+        let name = name.into();
+        let edge_id = self.resolve_edge(&tensor)?;
+
+        if name == "logits" {
+            let _ = self
+                .graph
+                .add_external_output(ExternalOutputKind::Logits, edge_id);
+        } else if name == "hidden" {
+            let _ = self
+                .graph
+                .add_external_output(ExternalOutputKind::Hidden, edge_id);
+        }
+
+        self.exports.push((name, tensor));
+        Ok(())
+    }
+
+    /// Declares an interleave fusion over named weights (Spec 8 §2, §5).
+    pub fn declare_fusion(&mut self, fusion: FusionDecl) -> Result<(), ModelsError> {
+        self.fusion_decls.push(fusion);
+        Ok(())
+    }
+
+    /// Declares tied embeddings between token embedding and output head (Spec 8 §2, §5).
+    pub fn declare_tied(
+        &mut self,
+        embed_name: impl Into<String>,
+        head_name: impl Into<String>,
+    ) -> Result<(), ModelsError> {
+        self.tied_decls.push(TiedDecl {
+            embed_name: embed_name.into(),
+            head_name: head_name.into(),
+        });
+        Ok(())
+    }
+
+    /// Spawns a child builder for a named subgraph (Spec 8 §2; e.g. MTP head, eagle head).
+    pub fn subgraph(&mut self, name: &str) -> Result<GraphBuilder, ModelsError> {
+        let sub_id = format!("{}.{}", self.model_id, name);
+        Ok(GraphBuilder::new(self.ir_version, sub_id))
+    }
+
+    /// Adds a finished subgraph to this builder (Spec 8 §2, §5).
+    pub fn add_subgraph(
+        &mut self,
+        name: impl Into<String>,
+        sub: ModelGraph,
+    ) -> Result<(), ModelsError> {
+        let name = name.into();
+        if self.subgraphs.contains_key(&name) {
+            return Err(ModelsError::SubgraphError {
+                name: name.clone(),
+                reason: format!("subgraph '{name}' already registered"),
+            });
+        }
+        self.subgraphs.insert(name, sub);
+        Ok(())
+    }
+
+    /// Reshapes a tensor edge in the graph DAG to a new shape (Spec 1 §2.3).
+    pub fn op_reshape(
+        &mut self,
+        tensor: Tensor,
+        new_shape: Vec<Dim>,
+    ) -> Result<Tensor, ModelsError> {
+        let edge = self.resolve_edge(&tensor)?;
+        let new_edge_id = self.graph.reshape_edge(edge, new_shape)?;
+        let new_tensor = self
+            .graph
+            .edges()
+            .get(new_edge_id.0)
+            .ok_or_else(|| ModelsError::ShapeAccess {
+                context: "graph.reshape_edge".to_string(),
+                reason: format!("edge {} missing after successful reshape", new_edge_id.0),
+            })?
+            .tensor
+            .clone();
+        self.record_edge(new_tensor.clone(), new_edge_id);
+        Ok(new_tensor)
+    }
+
+    /// Finalizes graph construction and returns the completed [`ModelGraph`] (Spec 8 §2).
+    pub fn finish(self) -> Result<ModelGraph, ModelsError> {
+        let mut graph = self.graph;
+        let _ = graph.materialize_copies()?;
+        graph.validate()?;
+
+        Ok(ModelGraph {
+            ir_version: self.ir_version,
+            model_id: self.model_id,
+            graph,
+            bound_weights: self.bound_weights,
+            fusion_decls: self.fusion_decls,
+            tied_decls: self.tied_decls,
+            state_specs: self.state_specs,
+            exports: self.exports,
+            subgraphs: self.subgraphs,
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Typed op emission helpers
+    // -------------------------------------------------------------------------
+
+    /// Emits a normalization op (`NormOp`).
+    pub fn op_norm(
+        &mut self,
+        x: Tensor,
+        weight: Tensor,
+        norm_spec: NormSpec,
+        axis: NormAxis,
+        out_dtype: DType,
+    ) -> Result<Tensor, ModelsError> {
+        let shape = x.shape().to_vec();
+        let out_tensor = Tensor::new(
+            shape,
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::Norm(NormOp {
+            kind: norm_spec.kind,
+            eps: norm_spec.eps,
+            axis,
+            weight_offset: norm_spec.weight_offset,
+            out_dtype,
+        });
+        let res = self.op(op, &[x, weight], &[out_tensor])?;
+        single_output(res, "op_norm")
+    }
+
+    /// Emits a general matrix multiplication (`MatmulOp`).
+    pub fn op_matmul(
+        &mut self,
+        x: Tensor,
+        w: Tensor,
+        out_dtype: DType,
+    ) -> Result<Tensor, ModelsError> {
+        let m = shape_dim(&x, 0, "op_matmul x")?;
+        let n = shape_dim(&w, 0, "op_matmul w")?;
+        let out_tensor = Tensor::new(
+            vec![m, n],
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::Matmul(MatmulOp {
+            out_dtype,
+            epilogue: Epilogue::None,
+            transpose_w: false,
+        });
+        let res = self.op(op, &[x, w], &[out_tensor])?;
+        single_output(res, "op_matmul")
+    }
+
+    /// Emits a matrix multiplication with bias epilogue (`MatmulOp`).
+    pub fn op_matmul_bias(
+        &mut self,
+        x: Tensor,
+        w: Tensor,
+        bias: Tensor,
+        out_dtype: DType,
+    ) -> Result<Tensor, ModelsError> {
+        let m = shape_dim(&x, 0, "op_matmul_bias x")?;
+        let n = shape_dim(&w, 0, "op_matmul_bias w")?;
+        let out_tensor = Tensor::new(
+            vec![m, n],
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::Matmul(MatmulOp {
+            out_dtype,
+            epilogue: Epilogue::Bias,
+            transpose_w: false,
+        });
+        let res = self.op(op, &[x, w, bias], &[out_tensor])?;
+        single_output(res, "op_matmul_bias")
+    }
+
+    /// Emits an elementwise gated activation product (`ActMulOp`).
+    pub fn op_act_mul(
+        &mut self,
+        gate: Tensor,
+        up: Tensor,
+        act: ActivationKind,
+    ) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            gate.shape().to_vec(),
+            gate.dtype(),
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::ActMul(ActMulOp { act, clamp: None });
+        let res = self.op(op, &[gate, up], &[out_tensor])?;
+        single_output(res, "op_act_mul")
+    }
+
+    /// Emits an activation function pass (`ActivationOp`).
+    pub fn op_activation(&mut self, x: Tensor, act: ActivationKind) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            x.shape().to_vec(),
+            x.dtype(),
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::Activation(ActivationOp { act, clamp: None });
+        let res = self.op(op, &[x], &[out_tensor])?;
+        single_output(res, "op_activation")
+    }
+
+    /// Emits a residual addition (`ResidualAddOp`).
+    pub fn op_residual_add(
+        &mut self,
+        a: Tensor,
+        b: Tensor,
+        out_dtype: DType,
+    ) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            a.shape().to_vec(),
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::ResidualAdd(ResidualAddOp { out_dtype });
+        let res = self.op(op, &[a, b], &[out_tensor])?;
+        single_output(res, "op_residual_add")
+    }
+
+    /// Emits a Rotary Position Embedding op (`RopeOp`).
+    pub fn op_rope(
+        &mut self,
+        x: Tensor,
+        pos: Tensor,
+        rope: &RopeSpec,
+    ) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            x.shape().to_vec(),
+            x.dtype(),
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::Rope(RopeOp {
+            rot_dim: rope.rot_dim,
+            theta: rope.theta,
+            style: rope.style,
+            scaling: rope.scaling,
+            mrope_sections: rope.mrope_sections,
+            out_dtype: x.dtype(),
+        });
+        let res = self.op(op, &[x, pos], &[out_tensor])?;
+        single_output(res, "op_rope")
+    }
+
+    /// Emits a KV cache state write op (`StateWriteKvOp`).
+    pub fn op_state_write_kv(
+        &mut self,
+        k: Tensor,
+        v: Tensor,
+        handle: StateHandle,
+        cache: CacheDtype,
+        latent: Option<MlaLatent>,
+    ) -> Result<(), ModelsError> {
+        let cache_dtype = match cache {
+            CacheDtype::E4m3 => DType::E4m3,
+            CacheDtype::I8 => DType::I8,
+            CacheDtype::F16 => DType::F16,
+        };
+        let op = Op::StateWriteKv(StateWriteKvOp {
+            cache_dtype,
+            scale_granularity: r9v_ir::op::CacheScaleGranularity::PerTokenHead,
+            latent,
+            handle,
+        });
+        self.op(op, &[k, v], &[])?;
+        Ok(())
+    }
+
+    /// Emits a multi-head attention op (`AttentionOp`).
+    ///
+    /// A plain attention output repeats the query shape `[T, H, D]`; an MLA
+    /// output is `[T, H, v_dim]` (Spec 1 §4.D), where `v_dim` may differ from
+    /// `qk_nope_dim + qk_rope_dim`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn op_attention(
+        &mut self,
+        q: Tensor,
+        handle: StateHandle,
+        softmax_scale: f32,
+        mask: AttentionMask,
+        sinks: u32,
+        logit_softcap: Option<f32>,
+        mla: Option<MlaAttentionSpec>,
+        out_dtype: DType,
+    ) -> Result<Tensor, ModelsError> {
+        let out_shape = match &mla {
+            Some(spec) => vec![
+                shape_dim(&q, 0, "op_attention q")?,
+                shape_dim(&q, 1, "op_attention q")?,
+                Dim::Concrete(spec.v_dim),
+            ],
+            None => q.shape().to_vec(),
+        };
+        let out_tensor = Tensor::new(
+            out_shape,
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::Attention(AttentionOp {
+            softmax_scale,
+            mask,
+            sinks,
+            logit_softcap,
+            mla,
+            out_dtype,
+            handle,
+        });
+        let res = self.op(op, &[q], &[out_tensor])?;
+        single_output(res, "op_attention")
+    }
+
+    /// Emits an MoE gating / router op (`MoeRouteOp`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn op_moe_route(
+        &mut self,
+        logits: Tensor,
+        bias: Option<Tensor>,
+        top_k: u32,
+        scoring: MoeScoring,
+        renormalize: bool,
+        group: Option<MoeGroup>,
+        scale: f32,
+    ) -> Result<(Tensor, Tensor), ModelsError> {
+        let t = shape_dim(&logits, 0, "op_moe_route logits")?;
+        let weights_tensor = Tensor::new(
+            vec![t, Dim::Concrete(top_k)],
+            DType::F32,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let indices_tensor = Tensor::new(
+            vec![t, Dim::Concrete(top_k)],
+            DType::U32,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::MoeRoute(MoeRouteOp {
+            top_k,
+            scoring,
+            renormalize,
+            group,
+            scale,
+        });
+
+        let mut inputs = vec![logits];
+        if let Some(b) = bias {
+            inputs.push(b);
+        }
+        let res = self.op(op, &inputs, &[indices_tensor, weights_tensor])?;
+        let indices = res
+            .first()
+            .ok_or_else(|| ModelsError::ShapeAccess {
+                context: "op_moe_route".to_string(),
+                reason: "moe_route produced no expert_ids tensor".to_string(),
+            })?
+            .clone();
+        let weights = res
+            .get(1)
+            .ok_or_else(|| ModelsError::ShapeAccess {
+                context: "op_moe_route".to_string(),
+                reason: "moe_route produced no weights tensor".to_string(),
+            })?
+            .clone();
+        Ok((indices, weights))
+    }
+
+    /// Emits an MoE expert execution op (`MoeFfnOp`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn op_moe_ffn(
+        &mut self,
+        x: Tensor,
+        expert_ids: Tensor,
+        weights: Tensor,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+        act: ActivationKind,
+        out_dtype: DType,
+        shared_experts: u32,
+    ) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            x.shape().to_vec(),
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::MoeFfn(MoeFfnOp {
+            act,
+            out_dtype,
+            shared_experts,
+        });
+        let res = self.op(
+            op,
+            &[x, expert_ids, weights, w_gate_up, w_down],
+            &[out_tensor],
+        )?;
+        single_output(res, "op_moe_ffn")
+    }
+
+    /// Emits a causal 1D convolution op (`CausalConv1dOp`).
+    pub fn op_causal_conv1d(
+        &mut self,
+        x: Tensor,
+        w: Tensor,
+        bias: Option<Tensor>,
+        kernel: u32,
+        act: ConvActivation,
+        handle: StateHandle,
+    ) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            x.shape().to_vec(),
+            x.dtype(),
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::CausalConv1d(CausalConv1dOp {
+            kernel,
+            act,
+            handle,
+        });
+        let mut inputs = vec![x, w];
+        if let Some(b) = bias {
+            inputs.push(b);
+        }
+        let res = self.op(op, &inputs, &[out_tensor])?;
+        single_output(res, "op_causal_conv1d")
+    }
+
+    /// Emits a linear attention / SSM recurrence scan op (`LinearAttnScanOp`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn op_linear_attn_scan(
+        &mut self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        alpha: Tensor,
+        beta: Tensor,
+        kind: LinearAttnKind,
+        chunk: u32,
+        out_dtype: DType,
+        handle: StateHandle,
+    ) -> Result<Tensor, ModelsError> {
+        let out_tensor = Tensor::new(
+            v.shape().to_vec(),
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::LinearAttnScan(LinearAttnScanOp {
+            kind,
+            chunk,
+            out_dtype,
+            handle,
+        });
+        let res = self.op(op, &[q, k, v, alpha, beta], &[out_tensor])?;
+        single_output(res, "op_linear_attn_scan")
+    }
+
+    /// Emits an n-gram speculative feature gather op (`NgramGatherOp`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn op_ngram_gather(
+        &mut self,
+        source: NgramSource,
+        inputs: &[Tensor],
+        orders: &[u32],
+        heads: u32,
+        hash: HashId,
+        table_sizes: &[u32],
+        combine: NgramCombine,
+        out_dim: u32,
+        out_dtype: DType,
+    ) -> Result<Tensor, ModelsError> {
+        let first = inputs.first().ok_or_else(|| ModelsError::ShapeAccess {
+            context: "op_ngram_gather".to_string(),
+            reason: "ngram_gather requires at least one input tensor".to_string(),
+        })?;
+        let t = shape_dim(first, 0, "op_ngram_gather inputs")?;
+        let out_tensor = Tensor::new(
+            vec![t, Dim::Concrete(out_dim)],
+            out_dtype,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::NgramGather(NgramGatherOp {
+            source,
+            orders: orders.to_vec().into_boxed_slice(),
+            heads,
+            hash,
+            table_sizes: table_sizes.to_vec().into_boxed_slice(),
+            combine,
+            out_dtype,
+        });
+        let res = self.op(op, inputs, &[out_tensor])?;
+        single_output(res, "op_ngram_gather")
+    }
+
+    /// Emits a token embedding lookup op (`EmbedGatherOp`).
+    pub fn op_embed_gather(
+        &mut self,
+        tokens: Tensor,
+        embed: Tensor,
+        scale: f32,
+    ) -> Result<Tensor, ModelsError> {
+        let t = shape_dim(&tokens, 0, "op_embed_gather tokens")?;
+        let dm = shape_dim(&embed, 1, "op_embed_gather embed")?;
+        let out_tensor = Tensor::new(
+            vec![t, dm],
+            DType::F16,
+            QuantScheme::None,
+            LayoutId::CONTIGUOUS,
+            r9v_ir::Placement::Device { rank: 0 },
+            ShardLayout::Replicated,
+            Class::Activation,
+        )?;
+        let op = Op::EmbedGather(EmbedGatherOp {
+            scale,
+            out_dtype: DType::F16,
+        });
+        let res = self.op(op, &[tokens, embed], &[out_tensor])?;
+        single_output(res, "op_embed_gather")
+    }
+}
+
+/// Representation of a built model graph DAG and structural declarations (Spec 8 §2).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelGraph {
+    ir_version: IrVersion,
+    model_id: String,
+    graph: IrGraph,
+    bound_weights: Vec<BoundWeight>,
+    fusion_decls: Vec<FusionDecl>,
+    tied_decls: Vec<TiedDecl>,
+    state_specs: Vec<(u32, StateSpec, StateHandle)>,
+    exports: Vec<(String, Tensor)>,
+    subgraphs: BTreeMap<String, ModelGraph>,
+}
+
+impl ModelGraph {
+    /// Pinned IR version.
+    pub fn ir_version(&self) -> IrVersion {
+        self.ir_version
+    }
+
+    /// Model identifier.
+    pub fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    /// Reference to the underlying captured step graph DAG.
+    pub fn graph(&self) -> &IrGraph {
+        &self.graph
+    }
+
+    /// Slices of all bound weight declarations.
+    pub fn bound_weights(&self) -> &[BoundWeight] {
+        &self.bound_weights
+    }
+
+    /// Slices of all weight fusion declarations.
+    pub fn fusion_decls(&self) -> &[FusionDecl] {
+        &self.fusion_decls
+    }
+
+    /// Slices of all tied embedding declarations.
+    pub fn tied_decls(&self) -> &[TiedDecl] {
+        &self.tied_decls
+    }
+
+    /// Slices of all state specifications and handles.
+    pub fn state_specs(&self) -> &[(u32, StateSpec, StateHandle)] {
+        &self.state_specs
+    }
+
+    /// Slices of all exported graph output tensors.
+    pub fn exports(&self) -> &[(String, Tensor)] {
+        &self.exports
+    }
+
+    /// Registered nested subgraphs (e.g. MTP head, eagle head).
+    pub fn subgraphs(&self) -> &BTreeMap<String, ModelGraph> {
+        &self.subgraphs
+    }
+
+    /// Computes the comprehensive [`ModelSummary`] for partitioner planning (Spec 8 §7; Spec 5 §5.1).
+    ///
+    /// Checked: every byte total uses checked `u64` arithmetic and reports
+    /// [`ModelsError::ArithmeticOverflow`] instead of clamping, wrapping, or
+    /// panicking. Allocation-bound counts (layer count, expert count, `hkv`
+    /// divisor enumeration) are rejected with typed validation before any
+    /// allocation, so adversarial graphs fail without OOM.
+    pub fn summary(&self) -> Result<ModelSummary, ModelsError> {
+        const CTX: &str = "ModelGraph::summary";
+        // Compute embedding weight bytes
+        let mut embed_bytes = 0u64;
+        let mut head_bytes = 0u64;
+        let mut vocab = 0u32;
+        let mut dm = 0u32;
+        let mut ngram_table_bytes = 0u64;
+
+        for w in &self.bound_weights {
+            if w.role == WeightRole::Embed || w.name == "token_embd.weight" {
+                let bytes = compute_tensor_bytes(&w.tensor, CTX)?;
+                embed_bytes = checked_add_u64(embed_bytes, bytes, CTX)?;
+                if let (Some(&Dim::Concrete(v)), Some(&Dim::Concrete(d))) =
+                    (w.shape.first(), w.shape.get(1))
+                {
+                    vocab = v;
+                    dm = d;
+                }
+            } else if w.role == WeightRole::LmHead || w.name == "output.weight" {
+                // If tied to embedding table, storage is shared (Spec 2 §4; Spec 8 §5)
+                let is_tied = self.tied_decls.iter().any(|t| t.head_name == w.name);
+                if !is_tied {
+                    head_bytes =
+                        checked_add_u64(head_bytes, compute_tensor_bytes(&w.tensor, CTX)?, CTX)?;
+                }
+            } else if w.role == WeightRole::NgramTable {
+                ngram_table_bytes = checked_add_u64(
+                    ngram_table_bytes,
+                    compute_tensor_bytes(&w.tensor, CTX)?,
+                    CTX,
+                )?;
+            }
+        }
+
+        // Find maximum layer index across bound weights and state specs
+        // (`None` when only graph-global weights such as the embedding table
+        // are bound, so no phantom layer is summarized).
+        let mut max_layer: Option<u32> = None;
+        let mut observe_layer = |layer: u32| {
+            max_layer = Some(max_layer.map_or(layer, |m| m.max(layer)));
+        };
+        for (layer, _, _) in &self.state_specs {
+            observe_layer(*layer);
+        }
+        for w in &self.bound_weights {
+            // MTP head-output tensors (`blk.N.mtp.output.weight`) name a
+            // prediction head, not a transformer layer; counting them appends
+            // phantom layers to the summary.
+            if w.name.ends_with(".mtp.output.weight") {
+                continue;
+            }
+            if let Some(layer_idx) = parse_layer_index(&w.name) {
+                observe_layer(layer_idx);
+            }
+        }
+
+        let num_layers = match max_layer {
+            None => 0u32,
+            Some(m) => m
+                .checked_add(1)
+                .ok_or_else(|| ModelsError::ArithmeticOverflow {
+                    context: CTX.to_string(),
+                    operation: format!("layer index {m} + 1"),
+                })?,
+        };
+        // Reject absurd layer ordinals before `Vec::with_capacity` below.
+        if num_layers > crate::spec::MAX_MODEL_LAYERS {
+            return Err(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "summary layer count {num_layers} exceeds implementation limit {}",
+                    crate::spec::MAX_MODEL_LAYERS
+                ),
+            });
+        }
+
+        let mut layers = Vec::with_capacity(num_layers as usize);
+        let mut global_hkv = 0u32;
+        let mut has_latent = false;
+
+        for l in 0..num_layers {
+            let mut weight_bytes_by_scheme: BTreeMap<SchemeKey, u64> = BTreeMap::new();
+            let mut state_per_token_bytes = 0u64;
+            let mut state_per_seq_bytes = 0u64;
+            let mut experts: Option<ExpertSummary> = None;
+            let mut mixer_kind = None;
+
+            for (layer, spec, _) in &self.state_specs {
+                if *layer == l {
+                    state_per_token_bytes =
+                        checked_add_u64(state_per_token_bytes, spec.state_per_token_bytes()?, CTX)?;
+                    state_per_seq_bytes =
+                        checked_add_u64(state_per_seq_bytes, spec.state_per_seq_bytes()?, CTX)?;
+                    match spec {
+                        StateSpec::KvPaged { hkv, .. } => {
+                            if *hkv > global_hkv {
+                                global_hkv = *hkv;
+                            }
+                            mixer_kind = Some(MixerKind::Attention);
+                        }
+                        StateSpec::KvLatent { .. } => {
+                            has_latent = true;
+                            mixer_kind = Some(MixerKind::Attention);
+                        }
+                        StateSpec::Recurrent { .. } | StateSpec::ConvWindow { .. } => {
+                            mixer_kind = Some(MixerKind::LinearAttention);
+                        }
+                    }
+                }
+            }
+
+            for w in &self.bound_weights {
+                if parse_layer_index(&w.name) == Some(l) {
+                    let bytes = compute_tensor_bytes(&w.tensor, CTX)?;
+                    let scheme_key = SchemeKey::from(w.tensor.quant());
+                    let entry = weight_bytes_by_scheme.entry(scheme_key).or_insert(0u64);
+                    *entry = checked_add_u64(*entry, bytes, CTX)?;
+
+                    if w.name.contains("ffn_gate_up_exps") || w.name.contains("ffn_down_exps") {
+                        if let Some(&Dim::Concrete(e)) = w.shape.first() {
+                            // Bound the expert count before sizing `hot_hint`
+                            // below; weight shapes are untrusted input here.
+                            if e > crate::spec::MAX_EXPERTS {
+                                return Err(ModelsError::InvalidModelSpec {
+                                    reason: format!(
+                                        "summary expert count {e} exceeds implementation limit {}",
+                                        crate::spec::MAX_EXPERTS
+                                    ),
+                                });
+                            }
+                            let added_bytes = if e > 0 {
+                                bytes.checked_div(u64::from(e)).ok_or_else(|| {
+                                    ModelsError::ArithmeticOverflow {
+                                        context: CTX.to_string(),
+                                        operation: format!("{bytes} / {e}"),
+                                    }
+                                })?
+                            } else {
+                                0
+                            };
+                            match &mut experts {
+                                Some(exp) => {
+                                    exp.bytes_each =
+                                        checked_add_u64(exp.bytes_each, added_bytes, CTX)?;
+                                }
+                                None => {
+                                    let hot_hint = if e > 0 {
+                                        vec![1.0 / (e as f32); e as usize]
+                                    } else {
+                                        Vec::new()
+                                    };
+                                    experts = Some(ExpertSummary {
+                                        e,
+                                        bytes_each: added_bytes,
+                                        hot_hint,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            layers.push(LayerSummary {
+                weight_bytes_by_scheme,
+                state_per_token_bytes,
+                state_per_seq_bytes,
+                experts,
+                mixer_kind,
+            });
+        }
+
+        // Tensor Parallel divisors of hkv (Spec 8 §7; Spec 5 §5.2)
+        // DECISION(A1.3): a pure-MLA model reports hkv 1 (one latent stream per
+        // layer) instead of 0; StateSpec::KvLatent carries no head count to
+        // derive TP degrees from. Rejected 0 (meaningless downstream) and the
+        // query-head count (not stored on the state spec). Spec 8 §7.
+        let summary_hkv = if global_hkv > 0 {
+            global_hkv
+        } else if has_latent {
+            1
+        } else {
+            0
+        };
+        // Reject absurd head counts before enumerating divisors below.
+        if summary_hkv > crate::spec::MAX_KV_HEADS {
+            return Err(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "summary hkv {summary_hkv} exceeds implementation limit {}",
+                    crate::spec::MAX_KV_HEADS
+                ),
+            });
+        }
+        let tp_divisors = if summary_hkv > 0 {
+            (1..=summary_hkv)
+                .filter(|d| summary_hkv.is_multiple_of(*d))
+                .collect()
+        } else {
+            vec![1]
+        };
+
+        let mtp = self.subgraphs.contains_key("mtp")
+            || self.subgraphs.keys().any(|k| k.starts_with("mtp"));
+        let export_hidden = self.exports.iter().any(|(name, _)| name == "hidden");
+
+        Ok(ModelSummary {
+            layers,
+            embed_bytes,
+            head_bytes,
+            vocab,
+            dm,
+            hkv: summary_hkv,
+            tp_divisors,
+            ngram_table_bytes,
+            mtp,
+            export_hidden,
+        })
+    }
+}
+
+fn parse_layer_index(name: &str) -> Option<u32> {
+    let blk = name.strip_prefix("blk.")?;
+    let dot = blk.find('.')?;
+    blk[..dot].parse::<u32>().ok()
+}
+
+/// Byte size of a bound tensor from shape metadata and dtype width
+/// (Spec 8 §7).
+///
+/// Checked: dimension products that overflow `u64` report
+/// [`ModelsError::ArithmeticOverflow`]. Symbolic extents (batch tokens)
+/// contribute a single element each.
+fn compute_tensor_bytes(tensor: &Tensor, context: &'static str) -> Result<u64, ModelsError> {
+    let mut elements = 1u64;
+    for &d in tensor.shape() {
+        if let Dim::Concrete(c) = d {
+            elements = checked_mul_u64(elements, u64::from(c), context)?;
+        }
+    }
+
+    match tensor.dtype() {
+        DType::F32 | DType::I32 | DType::U32 => checked_mul_u64(elements, 4, context),
+        DType::F16 | DType::Bf16 => checked_mul_u64(elements, 2, context),
+        DType::E4m3 | DType::E5m2 | DType::I8 | DType::Bool => Ok(elements),
+        DType::I4 => Ok(elements.div_ceil(2)),
+    }
+}

--- a/crates/r9v-models/src/error.rs
+++ b/crates/r9v-models/src/error.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Error types for model definitions and architecture building (Spec 8; card A1.3).
+//!
+//! Adheres to `CONVENTIONS.md` §1 (per-crate `ModelsError`, collect-all validation,
+//! no panics on untrusted input).
+
+use thiserror::Error;
+
+/// Domain error type for `r9v-models` (Spec 8; CONVENTIONS.md §1.1).
+#[derive(Debug, Error)]
+pub enum ModelsError {
+    /// Underlying IR error from graph construction, tensor validation, or op checking.
+    #[error(transparent)]
+    Ir(#[from] r9v_ir::IrError),
+
+    /// Common infrastructure error (hashing, byte sizes, identifiers).
+    #[error(transparent)]
+    Common(#[from] r9v_common::R9vError),
+
+    /// Missing required metadata key.
+    #[error("missing metadata key '{key}'; expected type {expected_type}")]
+    MissingMetaKey {
+        /// Metadata key path.
+        key: String,
+        /// Expected data type description.
+        expected_type: &'static str,
+    },
+
+    /// Metadata value type mismatch.
+    #[error("metadata key '{key}' type mismatch: expected {expected}, found {found}")]
+    MetaTypeMismatch {
+        /// Metadata key path.
+        key: String,
+        /// Expected type name.
+        expected: &'static str,
+        /// Description of found value.
+        found: String,
+    },
+
+    /// Missing weight tensor during validation or building.
+    #[error("missing required weight tensor '{name}'")]
+    MissingTensor {
+        /// Tensor name.
+        name: String,
+    },
+
+    /// Tensor shape mismatch.
+    #[error("tensor '{name}' shape mismatch: expected {expected:?}, got {actual:?}")]
+    TensorShapeMismatch {
+        /// Tensor name.
+        name: String,
+        /// Expected dimension extents.
+        expected: Vec<u64>,
+        /// Actual dimension extents.
+        actual: Vec<u64>,
+    },
+
+    /// Invalid model specification.
+    #[error("invalid model spec: {reason}")]
+    InvalidModelSpec {
+        /// Diagnostic reason.
+        reason: String,
+    },
+
+    /// Invalid layer specification.
+    #[error("invalid layer spec at layer {layer}: {reason}")]
+    InvalidLayerSpec {
+        /// Zero-based layer index.
+        layer: u32,
+        /// Diagnostic reason.
+        reason: String,
+    },
+
+    /// Invalid dimension constraint.
+    #[error("dimension '{name}' value {value} violates constraint: {requirement}")]
+    InvalidDimension {
+        /// Dimension name.
+        name: &'static str,
+        /// Value provided.
+        value: u32,
+        /// Requirement violated.
+        requirement: &'static str,
+    },
+
+    /// Unknown architecture string in metadata.
+    #[error("unknown architecture '{arch}'; nearest family is '{nearest}'")]
+    UnknownArchitecture {
+        /// Unknown architecture string.
+        arch: String,
+        /// Nearest known family name.
+        nearest: &'static str,
+    },
+
+    /// Subgraph not found or already exists.
+    #[error("subgraph error for '{name}': {reason}")]
+    SubgraphError {
+        /// Subgraph name.
+        name: String,
+        /// Diagnostic reason.
+        reason: String,
+    },
+
+    /// Tensor shape access failure while lowering (rank too small for the
+    /// requested dimension index, or an expected output missing).
+    #[error("tensor shape access failed in '{context}': {reason}")]
+    ShapeAccess {
+        /// Builder helper or op being lowered.
+        context: String,
+        /// What was requested and the rank found, with every value reported.
+        reason: String,
+    },
+
+    /// Untrusted dimension arithmetic overflowed instead of wrapping.
+    #[error("dimension arithmetic overflow in '{context}': {operation}")]
+    ArithmeticOverflow {
+        /// Builder helper or op being lowered.
+        context: String,
+        /// Operation with operands, e.g. `8 * 4294967295`.
+        operation: String,
+    },
+
+    /// Multiple collected errors (CONVENTIONS.md §1.4).
+    #[error("{} model building problem(s): {problems:?}", problems.len())]
+    Multiple {
+        /// All collected problems.
+        problems: Vec<ModelsError>,
+    },
+}
+
+impl ModelsError {
+    /// Collects a list of problems into a single `Result` (CONVENTIONS.md §1.4).
+    pub fn from_problems(problems: Vec<ModelsError>) -> Result<(), Self> {
+        if problems.is_empty() {
+            Ok(())
+        } else {
+            let mut iter = problems.into_iter();
+            let first = iter.next().unwrap_or(Self::InvalidModelSpec {
+                reason: "from_problems called with an empty list after the empty check".to_string(),
+            });
+            let rest: Vec<ModelsError> = iter.collect();
+            if rest.is_empty() {
+                Err(first)
+            } else {
+                let mut all = Vec::with_capacity(rest.len() + 1);
+                all.push(first);
+                all.extend(rest);
+                Err(Self::Multiple { problems: all })
+            }
+        }
+    }
+}

--- a/crates/r9v-models/src/generic.rs
+++ b/crates/r9v-models/src/generic.rs
@@ -1,0 +1,1212 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Generic transformer layer and model builder (Spec 8 §3, §3.1, §5; card A1.3).
+//!
+//! Emits the exact sequence of Op IR operations specified in Spec 8 §3.1 for every
+//! norm placement × mixer × ffn combination, including `LinearAttention`, `Moe`,
+//! `mla`, `output_gate`, `ngram` injection and the `MTP` subgraph.
+
+use r9v_ir::op::{
+    ActivationKind, AttentionMask, ConvActivation, MlaAttentionSpec, MlaLatent, MoeGroup,
+    NgramCombine, NgramSource, NormAxis,
+};
+use r9v_ir::tensor::{Dim, ShapeSymbol, Tensor};
+use r9v_ir::DType;
+
+use crate::builder::{
+    checked_add, checked_mul, checked_u32, FusionDecl, GraphBuilder, ModelGraph, SchemeClass,
+    WeightRole,
+};
+use crate::error::ModelsError;
+use crate::spec::{
+    Ffn, LayerSpec, Mixer, ModelSpec, MtpSource, MtpSpec, NormPlacement, Retain, StateSpec,
+};
+
+/// Lowers a full [`ModelSpec`] into an Op IR step graph (Spec 8 §2, §3, §5).
+pub fn build_model(
+    mut builder: GraphBuilder,
+    model: &ModelSpec,
+) -> Result<ModelGraph, ModelsError> {
+    model.validate()?;
+
+    // 1. External inputs
+    let tokens = builder.input_tokens()?;
+
+    // 2. Token embedding table lookup
+    let w_embed = builder.weight(
+        "token_embd.weight",
+        WeightRole::Embed,
+        &[Dim::Concrete(model.vocab), Dim::Concrete(model.dm)],
+        SchemeClass::Embed,
+    )?;
+    let mut x = builder.op_embed_gather(tokens.clone(), w_embed, model.embed_scale)?;
+
+    // 3. Build each layer sequentially
+    let mut captured_hidden_at_layer: Option<Tensor> = None;
+
+    for (i, layer_spec) in model.layers.iter().enumerate() {
+        let layer_idx = checked_u32(i, "build_model layer index")?;
+
+        // Check for n-gram speculative feature injection at inject_at
+        if let Some(ngram) = &model.ngram {
+            if ngram.inject_at == layer_idx {
+                let mut total_entries: u32 = 0;
+                for entries in ngram.table_sizes.iter() {
+                    total_entries =
+                        checked_add(total_entries, *entries, "build_model ngram tables")?;
+                }
+                // Table rows are `Dn` wide per Spec 1 §4.A; the explicit
+                // `NgramSpec::dim` carries it under the A1.3 n-gram-dimension decision.
+                let ngram_dim = ngram.dim;
+                let ngram_table = builder.weight(
+                    format!("blk.{layer_idx}.ngram_table.weight"),
+                    WeightRole::NgramTable,
+                    &[
+                        Dim::Concrete(total_entries.max(1)),
+                        Dim::Concrete(ngram_dim),
+                    ],
+                    SchemeClass::NgramTable,
+                )?;
+                let out_dim = match ngram.combine {
+                    NgramCombine::Concat => {
+                        checked_mul(ngram.heads, ngram_dim, "build_model ngram out_dim")?
+                    }
+                    NgramCombine::Sum => ngram_dim,
+                };
+                let ngram_out = builder.op_ngram_gather(
+                    NgramSource::Device,
+                    &[tokens.clone(), ngram_table],
+                    &ngram.orders,
+                    ngram.heads,
+                    ngram.hash,
+                    &ngram.table_sizes,
+                    ngram.combine,
+                    out_dim,
+                    DType::F16,
+                )?;
+                let w_proj = builder.weight(
+                    format!("blk.{layer_idx}.ngram_proj.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(out_dim)],
+                    SchemeClass::Matmul,
+                )?;
+                let proj = builder.op_matmul(ngram_out, w_proj, DType::F16)?;
+                x = builder.op_residual_add(x, proj, DType::F16)?;
+            }
+        }
+
+        // Build transformer block
+        x = build_layer(&mut builder, layer_idx, layer_spec, x, model)?;
+
+        // Check for MTP hidden state tap
+        if let Some(mtp) = &model.mtp {
+            if mtp.takes_hidden_from == MtpSource::Layer(layer_idx) {
+                captured_hidden_at_layer = Some(x.clone());
+            }
+        }
+    }
+
+    // 4. Final normalization
+    let w_final_norm = builder.weight(
+        "output_norm.weight",
+        WeightRole::Vector,
+        &[Dim::Concrete(model.dm)],
+        SchemeClass::Vector,
+    )?;
+    let h_final = builder.op_norm(
+        x,
+        w_final_norm,
+        model.final_norm,
+        NormAxis::Last,
+        DType::F16,
+    )?;
+
+    // 5. Export pre-lm_head final hidden states if requested
+    if model.export_hidden {
+        builder.export("hidden", h_final.clone())?;
+    }
+
+    // 6. Language model output head projection
+    let w_head = if model.tied_embeddings {
+        builder.declare_tied("token_embd.weight", "output.weight")?;
+        builder.weight(
+            "output.weight",
+            WeightRole::LmHead,
+            &[Dim::Concrete(model.vocab), Dim::Concrete(model.dm)],
+            SchemeClass::Embed,
+        )?
+    } else {
+        builder.weight(
+            "output.weight",
+            WeightRole::LmHead,
+            &[Dim::Concrete(model.vocab), Dim::Concrete(model.dm)],
+            SchemeClass::Matmul,
+        )?
+    };
+
+    let logits = builder.op_matmul(h_final.clone(), w_head, DType::F32)?;
+    builder.export("logits", logits)?;
+
+    // 7. Multi-Token Prediction (MTP) subgraph
+    if let Some(mtp) = &model.mtp {
+        // DECISION(A1.3): MTP heads emit dedicated subgraphs named 'mtp' or 'mtp.<head>' recording head index and consuming the specified hidden state tensor; rejected flattening MTP into the primary layer sequence. Spec 8 §2, §5.
+        let mtp_hidden_in = match mtp.takes_hidden_from {
+            MtpSource::Last => h_final,
+            MtpSource::Layer(_) => captured_hidden_at_layer.unwrap_or(h_final),
+        };
+        build_mtp_subgraph(&mut builder, mtp, mtp_hidden_in, model)?;
+    }
+
+    builder.finish()
+}
+
+/// Emits the Op IR nodes for a single transformer layer block (Spec 8 §3.1).
+///
+/// Spec-facing entry point: base-model weights live directly under `blk.N.`.
+/// MTP subgraph layers use the private namespace helper instead.
+pub fn build_layer(
+    builder: &mut GraphBuilder,
+    layer_idx: u32,
+    spec: &LayerSpec,
+    x: Tensor,
+    model: &ModelSpec,
+) -> Result<Tensor, ModelsError> {
+    build_layer_with_ns(builder, layer_idx, spec, x, model, "")
+}
+
+/// Emits one transformer layer block with `weight_ns` inserted after `blk.N.`
+/// (`""` for base layers, `"mtp."` for MTP subgraph layers per Spec 8 §5).
+fn build_layer_with_ns(
+    builder: &mut GraphBuilder,
+    layer_idx: u32,
+    spec: &LayerSpec,
+    mut x: Tensor,
+    model: &ModelSpec,
+    weight_ns: &str,
+) -> Result<Tensor, ModelsError> {
+    spec.validate(layer_idx)?;
+
+    match spec.norm {
+        NormPlacement::Pre => {
+            // Pre-norm: norm(x) -> sublayer -> residual_add
+            if spec.mixer != Mixer::None {
+                let w_attn_norm = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm)],
+                    SchemeClass::Vector,
+                )?;
+                let h = builder.op_norm(
+                    x.clone(),
+                    w_attn_norm,
+                    spec.norm_kind,
+                    NormAxis::Last,
+                    DType::F16,
+                )?;
+                let mixer_out =
+                    build_mixer_with_ns(builder, layer_idx, &spec.mixer, h, model, weight_ns)?;
+                x = builder.op_residual_add(x, mixer_out, DType::F16)?;
+            }
+
+            if spec.ffn != Ffn::None {
+                let w_ffn_norm = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm)],
+                    SchemeClass::Vector,
+                )?;
+                let h = builder.op_norm(
+                    x.clone(),
+                    w_ffn_norm,
+                    spec.norm_kind,
+                    NormAxis::Last,
+                    DType::F16,
+                )?;
+                let ffn_out =
+                    build_ffn_with_ns(builder, layer_idx, &spec.ffn, h, model, weight_ns)?;
+                x = builder.op_residual_add(x, ffn_out, DType::F16)?;
+            }
+        }
+        NormPlacement::Sandwich => {
+            // Sandwich-norm: pre-norm -> sublayer -> post-norm -> residual_add (Gemma-style)
+            if spec.mixer != Mixer::None {
+                let w_pre = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm)],
+                    SchemeClass::Vector,
+                )?;
+                let h = builder.op_norm(
+                    x.clone(),
+                    w_pre,
+                    spec.norm_kind,
+                    NormAxis::Last,
+                    DType::F16,
+                )?;
+                let mixer_out =
+                    build_mixer_with_ns(builder, layer_idx, &spec.mixer, h, model, weight_ns)?;
+                let w_post = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}post_attn_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm)],
+                    SchemeClass::Vector,
+                )?;
+                let post = builder.op_norm(
+                    mixer_out,
+                    w_post,
+                    spec.norm_kind,
+                    NormAxis::Last,
+                    DType::F16,
+                )?;
+                x = builder.op_residual_add(x, post, DType::F16)?;
+            }
+
+            if spec.ffn != Ffn::None {
+                let w_pre = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm)],
+                    SchemeClass::Vector,
+                )?;
+                let h = builder.op_norm(
+                    x.clone(),
+                    w_pre,
+                    spec.norm_kind,
+                    NormAxis::Last,
+                    DType::F16,
+                )?;
+                let ffn_out =
+                    build_ffn_with_ns(builder, layer_idx, &spec.ffn, h, model, weight_ns)?;
+                let w_post = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}post_ffn_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm)],
+                    SchemeClass::Vector,
+                )?;
+                let post =
+                    builder.op_norm(ffn_out, w_post, spec.norm_kind, NormAxis::Last, DType::F16)?;
+                x = builder.op_residual_add(x, post, DType::F16)?;
+            }
+        }
+        NormPlacement::Parallel => {
+            // Parallel: norm(x) once -> attention + ffn from same input -> add both
+            let w_norm = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}attn_norm.weight"),
+                WeightRole::Vector,
+                &[Dim::Concrete(model.dm)],
+                SchemeClass::Vector,
+            )?;
+            let h = builder.op_norm(
+                x.clone(),
+                w_norm,
+                spec.norm_kind,
+                NormAxis::Last,
+                DType::F16,
+            )?;
+
+            let mixer_out = if spec.mixer != Mixer::None {
+                Some(build_mixer_with_ns(
+                    builder,
+                    layer_idx,
+                    &spec.mixer,
+                    h.clone(),
+                    model,
+                    weight_ns,
+                )?)
+            } else {
+                None
+            };
+
+            let ffn_out = if spec.ffn != Ffn::None {
+                Some(build_ffn_with_ns(
+                    builder, layer_idx, &spec.ffn, h, model, weight_ns,
+                )?)
+            } else {
+                None
+            };
+
+            if let Some(m_out) = mixer_out {
+                x = builder.op_residual_add(x, m_out, DType::F16)?;
+            }
+            if let Some(f_out) = ffn_out {
+                x = builder.op_residual_add(x, f_out, DType::F16)?;
+            }
+        }
+    }
+
+    Ok(x)
+}
+
+/// Emits the token mixing sublayer (Attention, LinearAttention, MLA; Spec 8 §3.1).
+///
+/// Spec-facing entry point: base-model weights live directly under `blk.N.`.
+pub fn build_mixer(
+    builder: &mut GraphBuilder,
+    layer_idx: u32,
+    mixer: &Mixer,
+    h: Tensor,
+    model: &ModelSpec,
+) -> Result<Tensor, ModelsError> {
+    build_mixer_with_ns(builder, layer_idx, mixer, h, model, "")
+}
+
+/// Emits one token mixing sublayer with `weight_ns` inserted after `blk.N.`.
+fn build_mixer_with_ns(
+    builder: &mut GraphBuilder,
+    layer_idx: u32,
+    mixer: &Mixer,
+    h: Tensor,
+    model: &ModelSpec,
+    weight_ns: &str,
+) -> Result<Tensor, ModelsError> {
+    match mixer {
+        Mixer::Attention {
+            h: heads,
+            hkv,
+            d,
+            dv,
+            qkv_bias,
+            o_bias,
+            qk_norm,
+            rope,
+            window,
+            sinks,
+            logit_softcap,
+            output_gate,
+            mla,
+            cache,
+            ..
+        } => {
+            let h_heads = *heads;
+            let hkv_heads = *hkv;
+            let head_d = *d;
+            let head_dv = *dv;
+
+            if let Some(mla_spec) = mla {
+                // Defensive: `LayerSpec::validate` already rejects this
+                // combination, but `build_mixer` is public and takes a bare
+                // `Mixer`, so the lowering refuses it directly too rather
+                // than silently dropping the norm.
+                if qk_norm.is_some() {
+                    return Err(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "mla with qk_norm is unsupported: qk_norm applies to the per-head q/k pair and the MLA form has no per-head k tensor".to_string(),
+                    });
+                }
+                // Multi-Head Latent Attention (MLA, DeepSeek-style)
+                let w_q_a = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_q_a.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(mla_spec.q_lora_rank), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let c_q = if *qkv_bias {
+                    let b_q_a = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_q_a.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(mla_spec.q_lora_rank)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h.clone(), w_q_a, b_q_a, DType::F16)?
+                } else {
+                    builder.op_matmul(h.clone(), w_q_a, DType::F16)?
+                };
+
+                let qk_sum = checked_add(
+                    mla_spec.qk_nope_dim,
+                    mla_spec.qk_rope_dim,
+                    "mla query head dim",
+                )?;
+                let q_flat_dim = checked_mul(h_heads, qk_sum, "mla query projection")?;
+                let w_q_b = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_q_b.weight"),
+                    WeightRole::Matmul,
+                    &[
+                        Dim::Concrete(q_flat_dim),
+                        Dim::Concrete(mla_spec.q_lora_rank),
+                    ],
+                    SchemeClass::Matmul,
+                )?;
+                let q_flat = if *qkv_bias {
+                    let b_q_b = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_q_b.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(q_flat_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(c_q, w_q_b, b_q_b, DType::F16)?
+                } else {
+                    builder.op_matmul(c_q, w_q_b, DType::F16)?
+                };
+                let q_3d = builder.op_reshape(
+                    q_flat,
+                    vec![
+                        Dim::Symbolic(ShapeSymbol::T),
+                        Dim::Concrete(h_heads),
+                        Dim::Concrete(qk_sum),
+                    ],
+                )?;
+
+                let pos = builder.positions(model.positions)?;
+                let q = builder.op_rope(q_3d, pos.clone(), rope)?;
+
+                let kv_in_dim = checked_add(
+                    mla_spec.kv_lora_rank,
+                    mla_spec.qk_rope_dim,
+                    "mla kv input dim",
+                )?;
+                let w_kv_a = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_kv_a.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(kv_in_dim), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let c_kv_flat = if *qkv_bias {
+                    let b_kv_a = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_kv_a.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(kv_in_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h.clone(), w_kv_a, b_kv_a, DType::F16)?
+                } else {
+                    builder.op_matmul(h.clone(), w_kv_a, DType::F16)?
+                };
+                let c_kv = builder.op_reshape(
+                    c_kv_flat,
+                    vec![
+                        Dim::Symbolic(ShapeSymbol::T),
+                        Dim::Concrete(1),
+                        Dim::Concrete(kv_in_dim),
+                    ],
+                )?;
+                let k_rope = builder.op_rope(c_kv.clone(), pos, rope)?;
+
+                // Validated at the `LayerSpec` boundary; this `?` is the second
+                // line of defense for direct `build_mixer` callers.
+                let retain = Retain::from_window_sinks(*window, *sinks)?;
+                let handle = builder.state(
+                    layer_idx,
+                    StateSpec::KvLatent {
+                        latent: mla_spec.kv_lora_rank,
+                        rope: mla_spec.qk_rope_dim,
+                        cache: *cache,
+                        retain,
+                    },
+                )?;
+
+                let latent_info = Some(MlaLatent {
+                    kv_lora_rank: mla_spec.kv_lora_rank,
+                    rope_dim: mla_spec.qk_rope_dim,
+                });
+                builder.op_state_write_kv(c_kv, k_rope, handle, *cache, latent_info)?;
+
+                let mask = if let Some(w) = window {
+                    AttentionMask::CausalWindow(*w)
+                } else {
+                    AttentionMask::Causal
+                };
+                let softmax_scale = 1.0 / (qk_sum as f32).sqrt();
+                let mla_attention = Some(MlaAttentionSpec {
+                    q_lora_rank: Some(mla_spec.q_lora_rank),
+                    kv_lora_rank: mla_spec.kv_lora_rank,
+                    qk_nope_dim: mla_spec.qk_nope_dim,
+                    qk_rope_dim: mla_spec.qk_rope_dim,
+                    v_dim: mla_spec.v_dim,
+                });
+
+                let a_3d = builder.op_attention(
+                    q,
+                    handle,
+                    softmax_scale,
+                    mask,
+                    *sinks,
+                    *logit_softcap,
+                    mla_attention,
+                    DType::F16,
+                )?;
+
+                let out_flat_dim = checked_mul(h_heads, mla_spec.v_dim, "mla output projection")?;
+                let mut a = builder.op_reshape(
+                    a_3d,
+                    vec![Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(out_flat_dim)],
+                )?;
+
+                if *output_gate {
+                    let w_g = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_gate.weight"),
+                        WeightRole::Matmul,
+                        &[Dim::Concrete(out_flat_dim), Dim::Concrete(model.dm)],
+                        SchemeClass::Matmul,
+                    )?;
+                    let gate = builder.op_matmul(h, w_g, DType::F16)?;
+                    a = builder.op_act_mul(gate, a, ActivationKind::Silu)?;
+                }
+
+                let w_o = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_output.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(out_flat_dim)],
+                    SchemeClass::Matmul,
+                )?;
+                if *o_bias {
+                    let b_o = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_output.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(model.dm)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(a, w_o, b_o, DType::F16)
+                } else {
+                    builder.op_matmul(a, w_o, DType::F16)
+                }
+            } else {
+                // Standard Attention: MHA / GQA / MQA
+                builder.declare_fusion(FusionDecl::Qkv {
+                    q: format!("blk.{layer_idx}.{weight_ns}attn_q.weight"),
+                    k: format!("blk.{layer_idx}.{weight_ns}attn_k.weight"),
+                    v: format!("blk.{layer_idx}.{weight_ns}attn_v.weight"),
+                })?;
+
+                let q_dim = checked_mul(h_heads, head_d, "attention q projection")?;
+                let k_dim = checked_mul(hkv_heads, head_d, "attention k projection")?;
+                let v_flat_dim = checked_mul(hkv_heads, head_dv, "attention v projection")?;
+                let o_flat_dim = checked_mul(h_heads, head_dv, "attention output")?;
+                let w_q = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_q.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(q_dim), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let mut q_flat = if *qkv_bias {
+                    let b_q = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_q.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(q_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h.clone(), w_q, b_q, DType::F16)?
+                } else {
+                    builder.op_matmul(h.clone(), w_q, DType::F16)?
+                };
+
+                let w_k = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_k.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(k_dim), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let mut k_flat = if *qkv_bias {
+                    let b_k = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_k.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(k_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h.clone(), w_k, b_k, DType::F16)?
+                } else {
+                    builder.op_matmul(h.clone(), w_k, DType::F16)?
+                };
+
+                let w_v = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_v.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(v_flat_dim), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let v_flat = if *qkv_bias {
+                    let b_v = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_v.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(v_flat_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h.clone(), w_v, b_v, DType::F16)?
+                } else {
+                    builder.op_matmul(h.clone(), w_v, DType::F16)?
+                };
+
+                if let Some(norm) = qk_norm {
+                    let w_q_norm = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_q_norm.weight"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(q_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    let w_k_norm = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_k_norm.weight"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(k_dim)],
+                        SchemeClass::Vector,
+                    )?;
+                    q_flat = builder.op_norm(
+                        q_flat,
+                        w_q_norm,
+                        *norm,
+                        NormAxis::Head(head_d),
+                        DType::F16,
+                    )?;
+                    k_flat = builder.op_norm(
+                        k_flat,
+                        w_k_norm,
+                        *norm,
+                        NormAxis::Head(head_d),
+                        DType::F16,
+                    )?;
+                }
+
+                let mut q = builder.op_reshape(
+                    q_flat,
+                    vec![
+                        Dim::Symbolic(ShapeSymbol::T),
+                        Dim::Concrete(h_heads),
+                        Dim::Concrete(head_d),
+                    ],
+                )?;
+
+                let mut k = builder.op_reshape(
+                    k_flat,
+                    vec![
+                        Dim::Symbolic(ShapeSymbol::T),
+                        Dim::Concrete(hkv_heads),
+                        Dim::Concrete(head_d),
+                    ],
+                )?;
+
+                let v = builder.op_reshape(
+                    v_flat,
+                    vec![
+                        Dim::Symbolic(ShapeSymbol::T),
+                        Dim::Concrete(hkv_heads),
+                        Dim::Concrete(head_dv),
+                    ],
+                )?;
+
+                let pos = builder.positions(model.positions)?;
+                q = builder.op_rope(q, pos.clone(), rope)?;
+                k = builder.op_rope(k, pos, rope)?;
+
+                // Validated at the `LayerSpec` boundary; this `?` is the second
+                // line of defense for direct `build_mixer` callers.
+                let retain = Retain::from_window_sinks(*window, *sinks)?;
+                let handle = builder.state(
+                    layer_idx,
+                    StateSpec::KvPaged {
+                        hkv: hkv_heads,
+                        d: head_d,
+                        dv: head_dv,
+                        cache: *cache,
+                        retain,
+                    },
+                )?;
+
+                builder.op_state_write_kv(k, v, handle, *cache, None)?;
+
+                let mask = if let Some(w) = window {
+                    AttentionMask::CausalWindow(*w)
+                } else {
+                    AttentionMask::Causal
+                };
+                let softmax_scale = 1.0 / (head_d as f32).sqrt();
+                let a_3d = builder.op_attention(
+                    q,
+                    handle,
+                    softmax_scale,
+                    mask,
+                    *sinks,
+                    *logit_softcap,
+                    None,
+                    DType::F16,
+                )?;
+
+                let mut a = builder.op_reshape(
+                    a_3d,
+                    vec![Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(o_flat_dim)],
+                )?;
+
+                if *output_gate {
+                    let w_g = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_gate.weight"),
+                        WeightRole::Matmul,
+                        &[Dim::Concrete(o_flat_dim), Dim::Concrete(model.dm)],
+                        SchemeClass::Matmul,
+                    )?;
+                    let gate = builder.op_matmul(h, w_g, DType::F16)?;
+                    a = builder.op_act_mul(gate, a, ActivationKind::Silu)?;
+                }
+
+                let w_o = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}attn_output.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(o_flat_dim)],
+                    SchemeClass::Matmul,
+                )?;
+                if *o_bias {
+                    let b_o = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}attn_output.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(model.dm)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(a, w_o, b_o, DType::F16)
+                } else {
+                    builder.op_matmul(a, w_o, DType::F16)
+                }
+            }
+        }
+        Mixer::LinearAttention {
+            kind,
+            h: heads,
+            d,
+            dv,
+            conv,
+            gate_act,
+            output_norm,
+            output_gate,
+        } => {
+            let h_heads = *heads;
+            let head_d = *d;
+            let head_dv = *dv;
+            let mut scan_input = h.clone();
+
+            if let Some(kernel_len) = conv {
+                let handle_conv = builder.state(
+                    layer_idx,
+                    StateSpec::ConvWindow {
+                        c: model.dm,
+                        w: *kernel_len,
+                    },
+                )?;
+                let w_conv = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ssm_conv1d.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(*kernel_len)],
+                    SchemeClass::Vector,
+                )?;
+                scan_input = builder.op_causal_conv1d(
+                    scan_input,
+                    w_conv,
+                    None,
+                    *kernel_len,
+                    ConvActivation::Silu,
+                    handle_conv,
+                )?;
+            }
+
+            let scan_qk_dim = checked_mul(h_heads, head_d, "linear attention q/k")?;
+            let scan_v_dim = checked_mul(h_heads, head_dv, "linear attention v")?;
+            let w_q = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ssm_q.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(scan_qk_dim), Dim::Concrete(model.dm)],
+                SchemeClass::Matmul,
+            )?;
+            let q_flat = builder.op_matmul(scan_input.clone(), w_q, DType::F16)?;
+            let q = builder.op_reshape(
+                q_flat,
+                vec![
+                    Dim::Symbolic(ShapeSymbol::T),
+                    Dim::Concrete(h_heads),
+                    Dim::Concrete(head_d),
+                ],
+            )?;
+
+            let w_k = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ssm_k.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(scan_qk_dim), Dim::Concrete(model.dm)],
+                SchemeClass::Matmul,
+            )?;
+            let k_flat = builder.op_matmul(scan_input.clone(), w_k, DType::F16)?;
+            let k = builder.op_reshape(
+                k_flat,
+                vec![
+                    Dim::Symbolic(ShapeSymbol::T),
+                    Dim::Concrete(h_heads),
+                    Dim::Concrete(head_d),
+                ],
+            )?;
+
+            let w_v = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ssm_v.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(scan_v_dim), Dim::Concrete(model.dm)],
+                SchemeClass::Matmul,
+            )?;
+            let v_flat = builder.op_matmul(scan_input.clone(), w_v, DType::F16)?;
+            let v = builder.op_reshape(
+                v_flat,
+                vec![
+                    Dim::Symbolic(ShapeSymbol::T),
+                    Dim::Concrete(h_heads),
+                    Dim::Concrete(head_dv),
+                ],
+            )?;
+
+            let w_alpha = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ssm_alpha.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(h_heads), Dim::Concrete(model.dm)],
+                SchemeClass::Matmul,
+            )?;
+            let alpha = builder.op_matmul(scan_input.clone(), w_alpha, DType::F32)?;
+
+            let w_beta = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ssm_beta.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(h_heads), Dim::Concrete(model.dm)],
+                SchemeClass::Matmul,
+            )?;
+            let beta = builder.op_matmul(scan_input, w_beta, DType::F32)?;
+
+            let handle_rec = builder.state(
+                layer_idx,
+                StateSpec::Recurrent {
+                    h: h_heads,
+                    d: head_d,
+                    dv: head_dv,
+                },
+            )?;
+
+            let scan_3d = builder.op_linear_attn_scan(
+                q,
+                k,
+                v,
+                alpha,
+                beta,
+                *kind,
+                64,
+                DType::F16,
+                handle_rec,
+            )?;
+
+            let mut scan_out = builder.op_reshape(
+                scan_3d,
+                vec![Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(scan_v_dim)],
+            )?;
+
+            if let Some(norm) = output_norm {
+                let w_norm = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ssm_norm.weight"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(scan_v_dim)],
+                    SchemeClass::Vector,
+                )?;
+                scan_out = builder.op_norm(scan_out, w_norm, *norm, NormAxis::Last, DType::F16)?;
+            }
+
+            if *output_gate {
+                let w_gate = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ssm_gate.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(scan_v_dim), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let gate = builder.op_matmul(h, w_gate, DType::F16)?;
+                scan_out = builder.op_act_mul(gate, scan_out, *gate_act)?;
+            }
+
+            let w_o = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ssm_out.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(model.dm), Dim::Concrete(scan_v_dim)],
+                SchemeClass::Matmul,
+            )?;
+            builder.op_matmul(scan_out, w_o, DType::F16)
+        }
+        Mixer::None => Ok(h),
+    }
+}
+
+/// Emits the feed-forward network sublayer (Dense or MoE; Spec 8 §3.1).
+///
+/// Spec-facing entry point: base-model weights live directly under `blk.N.`.
+pub fn build_ffn(
+    builder: &mut GraphBuilder,
+    layer_idx: u32,
+    ffn: &Ffn,
+    h: Tensor,
+    model: &ModelSpec,
+) -> Result<Tensor, ModelsError> {
+    build_ffn_with_ns(builder, layer_idx, ffn, h, model, "")
+}
+
+/// Emits one feed-forward sublayer with `weight_ns` inserted after `blk.N.`.
+fn build_ffn_with_ns(
+    builder: &mut GraphBuilder,
+    layer_idx: u32,
+    ffn: &Ffn,
+    h: Tensor,
+    model: &ModelSpec,
+    weight_ns: &str,
+) -> Result<Tensor, ModelsError> {
+    match ffn {
+        Ffn::Dense {
+            dff,
+            act,
+            gated,
+            bias,
+        } => {
+            if *gated {
+                builder.declare_fusion(FusionDecl::GateUp {
+                    gate: format!("blk.{layer_idx}.{weight_ns}ffn_gate.weight"),
+                    up: format!("blk.{layer_idx}.{weight_ns}ffn_up.weight"),
+                })?;
+                let w_gate = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_gate.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(*dff), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                // DECISION(A1.3): gated `bias` lowers as bias epilogues on the
+                // gate and up projections (`ffn_gate.bias`, `ffn_up.bias`),
+                // matching the ungated path where `bias` rides `ffn_up`;
+                // rejected dropping the flag (previous behavior, silently
+                // wrong) and a down-projection bias (no ungated precedent).
+                // Spec 8 §3 names `bias` on `Dense` without exempting gated.
+                let g = if *bias {
+                    let b_gate = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}ffn_gate.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(*dff)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h.clone(), w_gate, b_gate, DType::F16)?
+                } else {
+                    builder.op_matmul(h.clone(), w_gate, DType::F16)?
+                };
+
+                let w_up = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_up.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(*dff), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let u = if *bias {
+                    let b_up = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}ffn_up.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(*dff)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h, w_up, b_up, DType::F16)?
+                } else {
+                    builder.op_matmul(h, w_up, DType::F16)?
+                };
+
+                let act_gu = builder.op_act_mul(g, u, *act)?;
+                let w_down = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_down.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(*dff)],
+                    SchemeClass::Matmul,
+                )?;
+                builder.op_matmul(act_gu, w_down, DType::F16)
+            } else {
+                let w_up = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_up.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(*dff), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let u = if *bias {
+                    let bias_w = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}ffn_up.bias"),
+                        WeightRole::Vector,
+                        &[Dim::Concrete(*dff)],
+                        SchemeClass::Vector,
+                    )?;
+                    builder.op_matmul_bias(h, w_up, bias_w, DType::F16)?
+                } else {
+                    builder.op_matmul(h, w_up, DType::F16)?
+                };
+                let act_u = builder.op_activation(u, *act)?;
+                let w_down = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_down.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(*dff)],
+                    SchemeClass::Matmul,
+                )?;
+                builder.op_matmul(act_u, w_down, DType::F16)
+            }
+        }
+        Ffn::Moe {
+            e,
+            k,
+            dff_e,
+            act,
+            scoring,
+            renormalize,
+            group,
+            route_bias,
+            route_scale,
+            shared,
+            shared_gate,
+        } => {
+            // Router
+            let w_router = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ffn_gate_inp.weight"),
+                WeightRole::Matmul,
+                &[Dim::Concrete(*e), Dim::Concrete(model.dm)],
+                SchemeClass::Matmul,
+            )?;
+            let router_logits = builder.op_matmul(h.clone(), w_router, DType::F32)?;
+            let bias = if *route_bias {
+                Some(builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_gate_inp.bias"),
+                    WeightRole::Vector,
+                    &[Dim::Concrete(*e)],
+                    SchemeClass::Vector,
+                )?)
+            } else {
+                None
+            };
+
+            let group_ir = group.map(|g| MoeGroup {
+                n_group: g.n_group,
+                topk_group: g.topk_group,
+            });
+            let (route_indices, route_weights) = builder.op_moe_route(
+                router_logits,
+                bias,
+                *k,
+                *scoring,
+                *renormalize,
+                group_ir,
+                *route_scale,
+            )?;
+
+            // Expert execution
+            let gate_up_dim = checked_mul(2, *dff_e, "moe gate_up experts")?;
+            let w_gate_up_exps = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ffn_gate_up_exps.weight"),
+                WeightRole::Matmul,
+                &[
+                    Dim::Concrete(*e),
+                    Dim::Concrete(gate_up_dim),
+                    Dim::Concrete(model.dm),
+                ],
+                SchemeClass::Matmul,
+            )?;
+            let w_down_exps = builder.weight(
+                format!("blk.{layer_idx}.{weight_ns}ffn_down_exps.weight"),
+                WeightRole::Matmul,
+                &[
+                    Dim::Concrete(*e),
+                    Dim::Concrete(model.dm),
+                    Dim::Concrete(*dff_e),
+                ],
+                SchemeClass::Matmul,
+            )?;
+
+            let shared_count = shared.map(|s| s.n).unwrap_or(0);
+            let mut moe_out = builder.op_moe_ffn(
+                h.clone(),
+                route_indices,
+                route_weights,
+                w_gate_up_exps,
+                w_down_exps,
+                *act,
+                DType::F16,
+                shared_count,
+            )?;
+
+            // Shared experts if present
+            if let Some(s) = shared {
+                let w_shared_gate = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_shared_gate.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(s.dff), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let sg = builder.op_matmul(h.clone(), w_shared_gate, DType::F16)?;
+
+                let w_shared_up = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_shared_up.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(s.dff), Dim::Concrete(model.dm)],
+                    SchemeClass::Matmul,
+                )?;
+                let su = builder.op_matmul(h.clone(), w_shared_up, DType::F16)?;
+
+                let mut s_act = builder.op_act_mul(sg, su, *act)?;
+
+                if *shared_gate {
+                    let w_sg = builder.weight(
+                        format!("blk.{layer_idx}.{weight_ns}ffn_shared_gate_routing.weight"),
+                        WeightRole::Matmul,
+                        &[Dim::Concrete(s.dff), Dim::Concrete(model.dm)],
+                        SchemeClass::Matmul,
+                    )?;
+                    let s_gate = builder.op_matmul(h, w_sg, DType::F16)?;
+                    s_act = builder.op_act_mul(s_gate, s_act, ActivationKind::Silu)?;
+                }
+
+                let w_shared_down = builder.weight(
+                    format!("blk.{layer_idx}.{weight_ns}ffn_shared_down.weight"),
+                    WeightRole::Matmul,
+                    &[Dim::Concrete(model.dm), Dim::Concrete(s.dff)],
+                    SchemeClass::Matmul,
+                )?;
+                let shared_out = builder.op_matmul(s_act, w_shared_down, DType::F16)?;
+                moe_out = builder.op_residual_add(moe_out, shared_out, DType::F16)?;
+            }
+
+            Ok(moe_out)
+        }
+        Ffn::None => Ok(h),
+    }
+}
+
+/// Builds the Multi-Token Prediction (MTP) subgraph (Spec 8 §2, §3, §5).
+pub fn build_mtp_subgraph(
+    parent_builder: &mut GraphBuilder,
+    mtp: &MtpSpec,
+    _hidden: Tensor,
+    model: &ModelSpec,
+) -> Result<(), ModelsError> {
+    // Validate before the head loop below: `heads` and `layers_per_head`
+    // drive allocation and loop counts, and this entry point is public, so
+    // adversarial dimensions must fail here rather than hang or OOM.
+    mtp.validate(model.layers.len())?;
+    let mut mtp_builder = parent_builder.subgraph("mtp")?;
+    // MTP subgraph consumes the hidden state via input_embed_override (Spec 8 §2)
+    let (sub_hidden, _) = mtp_builder.input_embed_override(model.dm)?;
+    // Parent-to-MTP capture wiring is A1.14's scope; this input is the
+    // per-head restart point so no head is built from another head's output
+    // value. Edge-level identity under descriptor-equality lookup is likewise
+    // A1.14's (SSA identity); heads keep disjoint `blk.N.mtp.*` weights here.
+    let head_input = sub_hidden;
+    let per_head = checked_u32(mtp.layers_per_head.len(), "mtp layers per head")?;
+    for head in 1..=mtp.heads {
+        let head_base = checked_mul(head - 1, per_head, "mtp head ordinal")?;
+        let mut head_hidden = head_input.clone();
+        for (i, layer_spec) in mtp.layers_per_head.iter().enumerate() {
+            let layer_idx = checked_add(
+                head_base,
+                checked_u32(i, "mtp layer index")?,
+                "mtp layer ordinal",
+            )?;
+            head_hidden = build_layer_with_ns(
+                &mut mtp_builder,
+                layer_idx,
+                layer_spec,
+                head_hidden,
+                model,
+                "mtp.",
+            )?;
+        }
+
+        let w_head = mtp_builder.weight(
+            format!("blk.{}.mtp.output.weight", head - 1),
+            WeightRole::LmHead,
+            &[Dim::Concrete(model.vocab), Dim::Concrete(model.dm)],
+            SchemeClass::Matmul,
+        )?;
+        let logits = mtp_builder.op_matmul(head_hidden.clone(), w_head, DType::F32)?;
+        mtp_builder.export(format!("mtp_logits_{head}"), logits)?;
+    }
+
+    let mtp_graph = mtp_builder.finish()?;
+    parent_builder.add_subgraph("mtp", mtp_graph)?;
+    Ok(())
+}

--- a/crates/r9v-models/src/lib.rs
+++ b/crates/r9v-models/src/lib.rs
@@ -1,1 +1,32 @@
-//! R9V model architecture builder and model families (Spec 8, Spec 14 §2).
+// SPDX-License-Identifier: Apache-2.0
+//! R9V model architecture builder and model families (Spec 8, Spec 14 §2; card A1.3).
+//!
+//! This crate owns the sealed [`GraphBuilder`], model and layer specifications ([`ModelSpec`],
+//! [`LayerSpec`]), the generic transformer layer builder emitting Spec 8 §3.1 op sequences,
+//! fusion declarations ([`FusionDecl`]), tied embeddings ([`TiedDecl`]), model summaries ([`ModelSummary`]),
+//! and the typed [`GgufMeta`] lookup trait without container dependencies.
+//!
+//! Repository standards: `CONVENTIONS.md`; engineering bar: `.agents/skills/r9v-engineering-standards`.
+
+pub mod builder;
+pub mod error;
+pub mod generic;
+pub mod meta;
+pub mod spec;
+pub mod summary;
+
+pub use builder::{
+    BoundWeight, FusionDecl, Graph, GraphBuilder, ModelGraph, SchemeClass, SealedGraphBuilder,
+    TiedDecl, WeightRole,
+};
+pub use error::ModelsError;
+pub use generic::{build_ffn, build_layer, build_mixer, build_model, build_mtp_subgraph};
+pub use meta::{GgufMeta, MetaValue, SyntheticGgufMeta};
+pub use spec::{
+    CacheDtype, Ffn, LayerSpec, Mixer, MlaSpec, ModelSpec, MoeGroupSpec, MoeSharedSpec, MtpSource,
+    MtpSpec, NgramSpec, NormPlacement, NormSpec, PositionEncoding, Retain, RopeSpec, StateSpec,
+    MAX_ATTENTION_HEADS, MAX_EXPERTS, MAX_FEATURE_DIM, MAX_KV_HEADS, MAX_MODEL_LAYERS,
+    MAX_MTP_HEADS, MAX_MTP_LAYERS_PER_HEAD, MAX_NGRAM_HEADS, MAX_NGRAM_TABLE_ENTRIES,
+    MAX_VOCAB_SIZE, MAX_WINDOW,
+};
+pub use summary::{ExpertSummary, LayerSummary, MixerKind, ModelSummary, SchemeKey};

--- a/crates/r9v-models/src/meta.rs
+++ b/crates/r9v-models/src/meta.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed GGUF metadata lookup interface without container dependency (Spec 8 §4, §10; card A1.3).
+//!
+//! Model definitions consume metadata exclusively through this trait.
+//! Implementations may read directly from parsed GGUF container headers
+//! or synthetic test fixtures without `r9v-models` depending on `r9v-format`.
+
+use std::collections::BTreeMap;
+
+use crate::error::ModelsError;
+
+/// Typed GGUF metadata lookup trait (Spec 8 §4, §10; card A1.3).
+///
+/// Model definitions consume metadata exclusively through this trait.
+/// Implementations may read directly from parsed GGUF container headers
+/// or synthetic test fixtures without `r9v-models` depending on `r9v-format`.
+// DECISION(A1.3): GgufMeta returns borrowed &str for string lookups and owned Vec for arrays to avoid allocations on scalar lookups while keeping array access safe; rejected returning an intermediate dynamic Value enum. Spec 8 §4, §10.
+pub trait GgufMeta {
+    /// Returns true if `key` exists in metadata.
+    fn has(&self, key: &str) -> bool;
+
+    /// Reads a string value by key.
+    fn str(&self, key: &str) -> Result<&str, ModelsError>;
+
+    /// Reads an unsigned 32-bit integer by key.
+    fn u32(&self, key: &str) -> Result<u32, ModelsError>;
+
+    /// Reads an unsigned 64-bit integer by key.
+    fn u64(&self, key: &str) -> Result<u64, ModelsError>;
+
+    /// Reads a signed 32-bit integer by key.
+    fn i32(&self, key: &str) -> Result<i32, ModelsError>;
+
+    /// Reads a 32-bit float by key.
+    fn f32(&self, key: &str) -> Result<f32, ModelsError>;
+
+    /// Reads a boolean by key.
+    fn bool(&self, key: &str) -> Result<bool, ModelsError>;
+
+    /// Reads a list of strings by key.
+    fn str_array(&self, key: &str) -> Result<Vec<String>, ModelsError>;
+
+    /// Reads a list of u32 values by key.
+    fn u32_array(&self, key: &str) -> Result<Vec<u32>, ModelsError>;
+
+    /// Reads an optional string value.
+    fn get_str(&self, key: &str) -> Result<Option<&str>, ModelsError> {
+        if self.has(key) {
+            self.str(key).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reads an optional u32 value.
+    fn get_u32(&self, key: &str) -> Result<Option<u32>, ModelsError> {
+        if self.has(key) {
+            self.u32(key).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reads an optional f32 value.
+    fn get_f32(&self, key: &str) -> Result<Option<f32>, ModelsError> {
+        if self.has(key) {
+            self.f32(key).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reads an optional bool value.
+    fn get_bool(&self, key: &str) -> Result<Option<bool>, ModelsError> {
+        if self.has(key) {
+            self.bool(key).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Dynamic value stored in [`SyntheticGgufMeta`] (Spec 8 §4; card A1.3).
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetaValue {
+    /// String metadata value.
+    Str(String),
+    /// Unsigned 32-bit integer metadata value.
+    U32(u32),
+    /// Unsigned 64-bit integer metadata value.
+    U64(u64),
+    /// Signed 32-bit integer metadata value.
+    I32(i32),
+    /// 32-bit float metadata value.
+    F32(f32),
+    /// Boolean metadata value.
+    Bool(bool),
+    /// List of string metadata values.
+    StrArray(Vec<String>),
+    /// List of u32 metadata values.
+    U32Array(Vec<u32>),
+}
+
+/// In-memory synthetic GGUF metadata implementation for testing and fixtures (Spec 8 §4, §8; card A1.3).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SyntheticGgufMeta {
+    entries: BTreeMap<String, MetaValue>,
+}
+
+impl SyntheticGgufMeta {
+    /// Creates an empty synthetic metadata container.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts a string key-value entry.
+    pub fn insert_str(&mut self, key: impl Into<String>, val: impl Into<String>) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::Str(val.into()));
+        self
+    }
+
+    /// Inserts an unsigned 32-bit integer key-value entry.
+    pub fn insert_u32(&mut self, key: impl Into<String>, val: u32) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::U32(val));
+        self
+    }
+
+    /// Inserts an unsigned 64-bit integer key-value entry.
+    pub fn insert_u64(&mut self, key: impl Into<String>, val: u64) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::U64(val));
+        self
+    }
+
+    /// Inserts a signed 32-bit integer key-value entry.
+    pub fn insert_i32(&mut self, key: impl Into<String>, val: i32) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::I32(val));
+        self
+    }
+
+    /// Inserts a 32-bit floating point key-value entry.
+    pub fn insert_f32(&mut self, key: impl Into<String>, val: f32) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::F32(val));
+        self
+    }
+
+    /// Inserts a boolean key-value entry.
+    pub fn insert_bool(&mut self, key: impl Into<String>, val: bool) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::Bool(val));
+        self
+    }
+
+    /// Inserts an array of string values.
+    pub fn insert_str_array(&mut self, key: impl Into<String>, val: Vec<String>) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::StrArray(val));
+        self
+    }
+
+    /// Inserts an array of u32 values.
+    pub fn insert_u32_array(&mut self, key: impl Into<String>, val: Vec<u32>) -> &mut Self {
+        self.entries.insert(key.into(), MetaValue::U32Array(val));
+        self
+    }
+}
+
+impl GgufMeta for SyntheticGgufMeta {
+    fn has(&self, key: &str) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    fn str(&self, key: &str) -> Result<&str, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::Str(s)) => Ok(s.as_str()),
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "string",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "string",
+            }),
+        }
+    }
+
+    fn u32(&self, key: &str) -> Result<u32, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::U32(v)) => Ok(*v),
+            Some(MetaValue::U64(v)) => {
+                u32::try_from(*v).map_err(|_| ModelsError::MetaTypeMismatch {
+                    key: key.to_string(),
+                    expected: "u32",
+                    found: format!("u64({v}) out of u32 range"),
+                })
+            }
+            Some(MetaValue::I32(v)) => {
+                u32::try_from(*v).map_err(|_| ModelsError::MetaTypeMismatch {
+                    key: key.to_string(),
+                    expected: "u32",
+                    found: format!("i32({v}) negative"),
+                })
+            }
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "u32",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "u32",
+            }),
+        }
+    }
+
+    fn u64(&self, key: &str) -> Result<u64, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::U64(v)) => Ok(*v),
+            Some(MetaValue::U32(v)) => Ok(*v as u64),
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "u64",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "u64",
+            }),
+        }
+    }
+
+    fn i32(&self, key: &str) -> Result<i32, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::I32(v)) => Ok(*v),
+            Some(MetaValue::U32(v)) => {
+                i32::try_from(*v).map_err(|_| ModelsError::MetaTypeMismatch {
+                    key: key.to_string(),
+                    expected: "i32",
+                    found: format!("u32({v}) out of i32 range"),
+                })
+            }
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "i32",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "i32",
+            }),
+        }
+    }
+
+    fn f32(&self, key: &str) -> Result<f32, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::F32(v)) => Ok(*v),
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "f32",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "f32",
+            }),
+        }
+    }
+
+    fn bool(&self, key: &str) -> Result<bool, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::Bool(v)) => Ok(*v),
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "bool",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "bool",
+            }),
+        }
+    }
+
+    fn str_array(&self, key: &str) -> Result<Vec<String>, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::StrArray(v)) => Ok(v.clone()),
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "array of string",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "array of string",
+            }),
+        }
+    }
+
+    fn u32_array(&self, key: &str) -> Result<Vec<u32>, ModelsError> {
+        match self.entries.get(key) {
+            Some(MetaValue::U32Array(v)) => Ok(v.clone()),
+            Some(other) => Err(ModelsError::MetaTypeMismatch {
+                key: key.to_string(),
+                expected: "array of u32",
+                found: format!("{other:?}"),
+            }),
+            None => Err(ModelsError::MissingMetaKey {
+                key: key.to_string(),
+                expected_type: "array of u32",
+            }),
+        }
+    }
+}

--- a/crates/r9v-models/src/spec.rs
+++ b/crates/r9v-models/src/spec.rs
@@ -1,0 +1,1135 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Model architecture and layer specifications (Spec 8 §3, §3.1, §6; card A1.3).
+//!
+//! A model definition produces a [`ModelSpec`] containing a sequence of [`LayerSpec`]s.
+//! The generic layer builder lowers these specifications into an Op IR step graph.
+
+use r9v_ir::op::{
+    ActivationKind, HashId, LinearAttnKind, MoeScoring, NgramCombine, NormKind, RopeScaling,
+    RopeStyle,
+};
+use r9v_ir::state::StateKind;
+
+use crate::error::ModelsError;
+
+use crate::builder::{checked_add_u64, checked_mul_u64};
+
+/// Implementation limits for allocation- and loop-bound dimensions (Spec 8 §6;
+/// card A1.3).
+///
+/// Every bound below guards a Rust allocation, a loop trip count, or a tensor
+/// extent the loader will later materialize (stacked `[E, ...]` experts,
+/// `hot_hint` of length `E`, TP-divisor enumeration over `hkv`, the MTP head
+/// loop, the layer loop). Each value carries wide margin above every v1
+/// family in Spec 8 §4 and exists so untrusted metadata fails with typed
+/// validation *before* allocation, never with a panic or OOM. Raise one only
+/// when a family needs it, with the family named at the change.
+// DECISION(A1.3): powers-of-two caps with wide margin above v1 families, not
+// exact family maxima; rejected exact maxima (a new checkpoint would turn
+// into a spurious rejection) and no caps (u32::MAX metadata could drive
+// allocations and loops). Spec 8 §6 is silent on numeric caps.
+/// Maximum transformer layers in one [`ModelSpec`].
+pub const MAX_MODEL_LAYERS: u32 = 1024;
+/// Maximum query heads `h` per attention layer.
+pub const MAX_ATTENTION_HEADS: u32 = 4096;
+/// Maximum key/value heads `hkv` per attention layer.
+pub const MAX_KV_HEADS: u32 = 4096;
+/// Maximum feature dimension (`dm`, `d`, `dv`, `dff`, `dff_e`, MLA ranks and
+/// dims, SSM conv width).
+pub const MAX_FEATURE_DIM: u32 = 1 << 20;
+/// Maximum vocabulary size `V`.
+pub const MAX_VOCAB_SIZE: u32 = 1 << 24;
+/// Maximum routed experts `e` (stacked `[E, ...]` residency unit, Spec 8 §5).
+pub const MAX_EXPERTS: u32 = 4096;
+/// Maximum MTP prediction heads.
+pub const MAX_MTP_HEADS: u32 = 64;
+/// Maximum layers executed per MTP head.
+pub const MAX_MTP_LAYERS_PER_HEAD: u32 = 64;
+/// Maximum n-gram hash heads.
+pub const MAX_NGRAM_HEADS: u32 = 1024;
+/// Maximum entries in one n-gram hash table.
+pub const MAX_NGRAM_TABLE_ENTRIES: u32 = 1 << 28;
+/// Maximum sliding-window length / attention sinks (retained-token counts).
+pub const MAX_WINDOW: u32 = 1 << 28;
+
+/// Pushes an invalid-layer problem when `value` exceeds the implementation
+/// `limit` (CONVENTIONS.md §1.4; Spec 8 §6).
+fn check_layer_dim(
+    problems: &mut Vec<ModelsError>,
+    layer: u32,
+    name: &'static str,
+    value: u32,
+    limit: u32,
+) {
+    if value > limit {
+        problems.push(ModelsError::InvalidLayerSpec {
+            layer,
+            reason: format!(
+                "dimension '{name}' value {value} exceeds implementation limit {limit}"
+            ),
+        });
+    }
+}
+
+/// Pushes an invalid-model problem when `value` exceeds the implementation
+/// `limit` (CONVENTIONS.md §1.4; Spec 8 §6).
+fn check_model_dim(problems: &mut Vec<ModelsError>, name: &'static str, value: u32, limit: u32) {
+    if value > limit {
+        problems.push(ModelsError::InvalidModelSpec {
+            reason: format!(
+                "dimension '{name}' value {value} exceeds implementation limit {limit}"
+            ),
+        });
+    }
+}
+
+/// Placement strategy for normalization layers within a transformer block (Spec 8 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum NormPlacement {
+    /// Pre-layer normalization: `norm(x)` before each sublayer (standard LLaMA/Mistral).
+    #[default]
+    Pre,
+    /// Sandwich normalization: norm before and after each sublayer before residual (Gemma-style).
+    Sandwich,
+    /// Parallel formulation: attention and FFN both compute from the same pre-norm input (GPT-J/Falcon).
+    Parallel,
+}
+
+/// Parameterized normalization specification (Spec 8 §3; Spec 1 §4.B).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NormSpec {
+    /// Normalization kind: RMSNorm or LayerNorm (Spec 1 §4.B).
+    pub kind: NormKind,
+    /// Epsilon variance floor (Spec 1 §4.B).
+    pub eps: f32,
+    /// Weight offset (e.g. 1.0 for Gemma's 1+w parameterization, 0.0 for standard).
+    pub weight_offset: f32,
+}
+
+impl NormSpec {
+    /// Creates a standard RMSNorm specification with offset 0.0.
+    pub const fn rms(eps: f32) -> Self {
+        Self {
+            kind: NormKind::Rms,
+            eps,
+            weight_offset: 0.0,
+        }
+    }
+
+    /// Creates a standard LayerNorm specification with offset 0.0.
+    pub const fn layer(eps: f32) -> Self {
+        Self {
+            kind: NormKind::Layer,
+            eps,
+            weight_offset: 0.0,
+        }
+    }
+
+    /// Creates a Gemma-style RMSNorm specification with offset 1.0.
+    pub const fn gemma(eps: f32) -> Self {
+        Self {
+            kind: NormKind::Rms,
+            eps,
+            weight_offset: 1.0,
+        }
+    }
+
+    /// Validates normalization specification fields (CONVENTIONS.md §1.4).
+    pub fn validate(&self, context: &'static str) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+        if !self.eps.is_finite() || self.eps <= 0.0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "{context}: norm eps must be finite and > 0, got {}",
+                    self.eps
+                ),
+            });
+        }
+        if !self.weight_offset.is_finite() {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "{context}: norm weight_offset must be finite, got {}",
+                    self.weight_offset
+                ),
+            });
+        }
+        ModelsError::from_problems(problems)
+    }
+}
+
+/// Rotary Position Embedding (RoPE) specification (Spec 8 §3; Spec 1 §4.B).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RopeSpec {
+    /// Base theta frequency.
+    pub theta: f32,
+    /// Dimension to which rotary embedding is applied.
+    pub rot_dim: u32,
+    /// Interleaved (LLaMA) or NeoX style pairs.
+    pub style: RopeStyle,
+    /// Context frequency scaling algorithm.
+    pub scaling: RopeScaling,
+    /// Multimodal RoPE section dimensions [T, H, W], if applicable.
+    pub mrope_sections: Option<[u32; 3]>,
+}
+
+impl RopeSpec {
+    /// Validates RoPE specification fields.
+    pub fn validate(&self, context: &'static str) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+        if !self.theta.is_finite() || self.theta <= 0.0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "{context}: rope theta must be finite and > 0, got {}",
+                    self.theta
+                ),
+            });
+        }
+        if self.rot_dim == 0 || !self.rot_dim.is_multiple_of(2) {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "{context}: rope rot_dim must be positive and even, got {}",
+                    self.rot_dim
+                ),
+            });
+        }
+        ModelsError::from_problems(problems)
+    }
+}
+
+/// Multi-Head Latent Attention (MLA) low-rank compression specification (Spec 8 §3; Spec 1 §4.D).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MlaSpec {
+    /// Query low-rank compression rank `d_c`.
+    pub q_lora_rank: u32,
+    /// Key/Value low-rank compression rank `d_c'`.
+    pub kv_lora_rank: u32,
+    /// Decoupled Query/Key non-rotary feature dimension.
+    pub qk_nope_dim: u32,
+    /// Decoupled Query/Key rotary feature dimension.
+    pub qk_rope_dim: u32,
+    /// Value feature dimension per head.
+    pub v_dim: u32,
+}
+
+impl MlaSpec {
+    /// Validates MLA specification dimensions.
+    pub fn validate(&self, context: &'static str) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+        if self.q_lora_rank == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!("{context}: mla q_lora_rank must be > 0"),
+            });
+        }
+        if self.kv_lora_rank == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!("{context}: mla kv_lora_rank must be > 0"),
+            });
+        }
+        if self.qk_nope_dim == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!("{context}: mla qk_nope_dim must be > 0"),
+            });
+        }
+        if self.qk_rope_dim == 0 || !self.qk_rope_dim.is_multiple_of(2) {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "{context}: mla qk_rope_dim must be positive and even, got {}",
+                    self.qk_rope_dim
+                ),
+            });
+        }
+        if self.v_dim == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!("{context}: mla v_dim must be > 0"),
+            });
+        }
+        for (name, value) in [
+            ("mla q_lora_rank", self.q_lora_rank),
+            ("mla kv_lora_rank", self.kv_lora_rank),
+            ("mla qk_nope_dim", self.qk_nope_dim),
+            ("mla qk_rope_dim", self.qk_rope_dim),
+            ("mla v_dim", self.v_dim),
+        ] {
+            if value > MAX_FEATURE_DIM {
+                problems.push(ModelsError::InvalidModelSpec {
+                    reason: format!(
+                        "{context}: dimension '{name}' value {value} exceeds implementation limit {MAX_FEATURE_DIM}"
+                    ),
+                });
+            }
+        }
+        ModelsError::from_problems(problems)
+    }
+}
+
+/// KV cache storage element dtype (Spec 3 §2; Spec 8 §3).
+// DECISION(A1.3): StateSpec, CacheDtype, and Retain are defined in r9v-models to satisfy Card A1.3 deliverables and Spec 3 §2 / Spec 8 without creating a premature dependency on unimplemented card A1.11 r9v-state; rejected waiting for A1.11 or touching crates/r9v-state. Spec 8 §2, §7, Spec 3 §2, phase-a-agent-breakdown A1.3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CacheDtype {
+    /// 8-bit FP8 E4M3 with PerTokenHead scaling (default per Spec 3 §2).
+    #[default]
+    E4m3,
+    /// 8-bit integer with PerTokenHead scaling.
+    I8,
+    /// 16-bit uncompressed float.
+    F16,
+}
+
+impl CacheDtype {
+    /// Returns element byte size in KV cache storage.
+    pub const fn element_bytes(self) -> usize {
+        match self {
+            Self::E4m3 | Self::I8 => 1,
+            Self::F16 => 2,
+        }
+    }
+}
+
+/// Cache retention policy (Spec 3 §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Retain {
+    /// Retain all past tokens across sequence length.
+    #[default]
+    All,
+    /// Sliding window of `w` tokens.
+    Window(u32),
+    /// Retain `sinks` initial attention sinks and a sliding window of `window` tokens.
+    SinkAndWindow {
+        /// Attention sink token count.
+        sinks: u32,
+        /// Sliding window length.
+        window: u32,
+    },
+}
+
+impl Retain {
+    /// Convenience constructor from optional window and sink counts (Spec 3 §2).
+    ///
+    /// Checked: `sinks > 0` without a window has no `Retain` form (Spec 3 §2
+    /// admits only `All`, `Window(w)`, and `Sink(n) + Window(w)`), so it
+    /// reports [`ModelsError::InvalidModelSpec`] instead of inventing a
+    /// sink-only retention the kernels cannot execute.
+    pub fn from_window_sinks(window: Option<u32>, sinks: u32) -> Result<Self, ModelsError> {
+        match (window, sinks) {
+            (None, 0) => Ok(Self::All),
+            (Some(w), 0) => Ok(Self::Window(w)),
+            (Some(w), s) => Ok(Self::SinkAndWindow {
+                sinks: s,
+                window: w,
+            }),
+            (None, s) => Err(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "attention sinks ({s}) require a sliding window (window is None); Spec 3 §2 has no sink-only Retain form"
+                ),
+            }),
+        }
+    }
+}
+
+/// Parameterized per-layer state specification (Spec 3 §2; Spec 8 §2, §3, §7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StateSpec {
+    /// Standard paged KV cache (Spec 3 §2, §3).
+    KvPaged {
+        /// Number of key/value heads.
+        hkv: u32,
+        /// Head key dimension.
+        d: u32,
+        /// Head value dimension.
+        dv: u32,
+        /// Storage data type.
+        cache: CacheDtype,
+        /// Retention policy.
+        retain: Retain,
+    },
+    /// Multi-Head Latent Attention (MLA) compressed latent cache (Spec 3 §2, §3).
+    KvLatent {
+        /// Compressed latent dimension.
+        latent: u32,
+        /// Decoupled rotary dimension.
+        rope: u32,
+        /// Storage data type.
+        cache: CacheDtype,
+        /// Retention policy.
+        retain: Retain,
+    },
+    /// Recurrent linear attention / state space model state (Spec 3 §2, §4).
+    Recurrent {
+        /// Number of recurrent heads.
+        h: u32,
+        /// State matrix input dimension.
+        d: u32,
+        /// State matrix output dimension.
+        dv: u32,
+    },
+    /// Causal 1D convolution window state (Spec 3 §2, §4).
+    ConvWindow {
+        /// Channel dimension.
+        c: u32,
+        /// Window size `W_k`.
+        w: u32,
+    },
+}
+
+impl StateSpec {
+    /// Associated state kind in Op IR (Spec 1 §2.6).
+    pub const fn kind(&self) -> StateKind {
+        match self {
+            Self::KvPaged { .. } => StateKind::KvPaged,
+            Self::KvLatent { .. } => StateKind::KvLatent,
+            Self::Recurrent { .. } => StateKind::Recurrent,
+            Self::ConvWindow { .. } => StateKind::ConvWindow,
+        }
+    }
+
+    /// Per-token state memory cost in bytes (Spec 3 §6.2).
+    ///
+    /// Checked: untrusted dimensions that overflow `u64` report
+    /// [`ModelsError::ArithmeticOverflow`] instead of clamping, wrapping, or
+    /// panicking.
+    pub fn state_per_token_bytes(&self) -> Result<u64, ModelsError> {
+        const CTX: &str = "state_per_token_bytes";
+        match self {
+            Self::KvPaged {
+                hkv, d, dv, cache, ..
+            } => {
+                let bytes_elem = cache.element_bytes() as u64;
+                let scale_bytes = match cache {
+                    CacheDtype::E4m3 | CacheDtype::I8 => 4u64, // two f16 scales
+                    CacheDtype::F16 => 0u64,
+                };
+                let per_head = checked_add_u64(
+                    checked_mul_u64(
+                        checked_add_u64(u64::from(*d), u64::from(*dv), CTX)?,
+                        bytes_elem,
+                        CTX,
+                    )?,
+                    scale_bytes,
+                    CTX,
+                )?;
+                checked_mul_u64(u64::from(*hkv), per_head, CTX)
+            }
+            Self::KvLatent {
+                latent,
+                rope,
+                cache,
+                ..
+            } => {
+                let bytes_elem = cache.element_bytes() as u64;
+                let scale_bytes = match cache {
+                    CacheDtype::E4m3 | CacheDtype::I8 => 2u64, // one f16 scale for latent
+                    CacheDtype::F16 => 0u64,
+                };
+                let latent_bytes = checked_mul_u64(u64::from(*latent), bytes_elem, CTX)?;
+                // rope part is always f16
+                let rope_bytes = checked_mul_u64(u64::from(*rope), 2, CTX)?;
+                checked_add_u64(
+                    checked_add_u64(latent_bytes, scale_bytes, CTX)?,
+                    rope_bytes,
+                    CTX,
+                )
+            }
+            Self::Recurrent { .. } | Self::ConvWindow { .. } => Ok(0),
+        }
+    }
+
+    /// Per-sequence state memory cost in bytes (Spec 3 §6.2).
+    ///
+    /// Checked: see [`Self::state_per_token_bytes`].
+    pub fn state_per_seq_bytes(&self) -> Result<u64, ModelsError> {
+        const CTX: &str = "state_per_seq_bytes";
+        match self {
+            Self::Recurrent { h, d, dv } => {
+                // Double buffered f32 [h, d, dv] per Spec 3 §6.2: h * d * dv * 4 * 2
+                let bytes = checked_mul_u64(u64::from(*h), u64::from(*d), CTX)?;
+                let bytes = checked_mul_u64(bytes, u64::from(*dv), CTX)?;
+                let bytes = checked_mul_u64(bytes, 4, CTX)?;
+                checked_mul_u64(bytes, 2, CTX)
+            }
+            Self::ConvWindow { c, w } => {
+                // f16 [w - 1, c] per Spec 3 §2: (w - 1) * c * 2
+                if *w > 1 {
+                    // Exact: guarded by `*w > 1`, so `w - 1` cannot underflow.
+                    let words = u64::from(*w) - 1;
+                    let bytes = checked_mul_u64(words, u64::from(*c), CTX)?;
+                    checked_mul_u64(bytes, 2, CTX)
+                } else {
+                    Ok(0)
+                }
+            }
+            Self::KvPaged { .. } | Self::KvLatent { .. } => Ok(0),
+        }
+    }
+}
+
+/// Token mixing sublayer specification (Spec 8 §3).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Mixer {
+    /// Multi-Head Attention, Grouped-Query Attention, or Multi-Head Latent Attention (Spec 8 §3).
+    Attention {
+        /// Number of query heads `H`.
+        h: u32,
+        /// Number of key/value heads `Hkv`.
+        hkv: u32,
+        /// Head query/key dimension `D`.
+        d: u32,
+        /// Head value dimension `Dv`.
+        dv: u32,
+        /// Whether QKV projection includes bias vectors.
+        qkv_bias: bool,
+        /// Whether output projection includes a bias vector.
+        o_bias: bool,
+        /// Optional per-head Q/K normalization after projection (e.g. Qwen2, Gemma2).
+        qk_norm: Option<NormSpec>,
+        /// Rotary position embedding parameters.
+        rope: RopeSpec,
+        /// Optional sliding window context length.
+        window: Option<u32>,
+        /// Number of initial attention sinks.
+        sinks: u32,
+        /// Optional attention logit soft-capping threshold (e.g. 50.0 for Gemma2).
+        logit_softcap: Option<f32>,
+        /// Output gating: `o = attn ⊙ σ(W_g x)` (Qwen3-Next style).
+        output_gate: bool,
+        /// Multi-Head Latent Attention compression parameters, if enabled.
+        mla: Option<MlaSpec>,
+        /// Cache storage data type.
+        cache: CacheDtype,
+    },
+    /// Linear Attention or Structured State-Space Model scan (Spec 8 §3).
+    LinearAttention {
+        /// Scan recurrence kind (GatedDeltaNet, GLA, or Mamba2).
+        kind: LinearAttnKind,
+        /// Number of scan heads.
+        h: u32,
+        /// Input head dimension `D`.
+        d: u32,
+        /// Output head dimension `Dv`.
+        dv: u32,
+        /// Optional causal 1D convolution kernel width before the scan.
+        conv: Option<u32>,
+        /// Gating activation function (e.g. SiLU).
+        gate_act: ActivationKind,
+        /// Optional normalization applied to scan output.
+        output_norm: Option<NormSpec>,
+        /// Output gating: `o = scan ⊙ act(W_g x)`.
+        output_gate: bool,
+    },
+    /// Sublayer omitted (e.g. pure feed-forward layer).
+    None,
+}
+
+/// Grouped routing parameters for MoE architectures (Spec 8 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MoeGroupSpec {
+    /// Number of expert groups `n_group`.
+    pub n_group: u32,
+    /// Number of experts selected per group `topk_group`.
+    pub topk_group: u32,
+}
+
+/// Shared expert parameters executed unconditionally (Spec 8 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MoeSharedSpec {
+    /// Number of shared experts.
+    pub n: u32,
+    /// Intermediate hidden dimension of shared expert FFN.
+    pub dff: u32,
+}
+
+/// Feed-forward network sublayer specification (Spec 8 §3).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ffn {
+    /// Standard dense feed-forward network (Spec 8 §3).
+    Dense {
+        /// Intermediate hidden dimension `Dff`.
+        dff: u32,
+        /// Non-linear activation function.
+        act: ActivationKind,
+        /// Gated formulation: `act(W_gate x) ⊙ W_up x`.
+        gated: bool,
+        /// Whether projections include bias vectors.
+        bias: bool,
+    },
+    /// Mixture of Experts feed-forward network (Spec 8 §3).
+    Moe {
+        /// Total number of routed experts `E`.
+        e: u32,
+        /// Number of active experts selected per token `K`.
+        k: u32,
+        /// Intermediate hidden dimension per expert `Dff_e`.
+        dff_e: u32,
+        /// Expert MLP activation function.
+        act: ActivationKind,
+        /// Router scoring function (Softmax or Sigmoid).
+        scoring: MoeScoring,
+        /// Whether router weights are renormalized to sum to 1.
+        renormalize: bool,
+        /// Grouped expert routing constraints, if applicable.
+        group: Option<MoeGroupSpec>,
+        /// Whether router projection includes a bias vector.
+        route_bias: bool,
+        /// Router scaling factor.
+        route_scale: f32,
+        /// Shared expert parameters, if present.
+        shared: Option<MoeSharedSpec>,
+        /// Gated shared expert activation: `σ(W_sg x) ⊙ shared_ffn(x)`.
+        shared_gate: bool,
+    },
+    /// Sublayer omitted (e.g. pure attention block).
+    None,
+}
+
+/// Transformer layer block specification (Spec 8 §3).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LayerSpec {
+    /// Normalization layer placement strategy.
+    pub norm: NormPlacement,
+    /// Normalization parameters.
+    pub norm_kind: NormSpec,
+    /// Token mixing sublayer.
+    pub mixer: Mixer,
+    /// Feed-forward network sublayer.
+    pub ffn: Ffn,
+    /// Residual stream scaling factor (typically 1.0).
+    pub residual_scale: f32,
+}
+
+impl LayerSpec {
+    /// Validates layer specification parameters (Spec 8 §6; CONVENTIONS.md §1.4).
+    pub fn validate(&self, layer_idx: u32) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+
+        if !self.residual_scale.is_finite() || self.residual_scale == 0.0 {
+            problems.push(ModelsError::InvalidLayerSpec {
+                layer: layer_idx,
+                reason: format!(
+                    "residual_scale must be finite and non-zero, got {}",
+                    self.residual_scale
+                ),
+            });
+        }
+
+        if let Err(e) = self.norm_kind.validate("layer norm") {
+            problems.push(e);
+        }
+
+        match &self.mixer {
+            Mixer::Attention {
+                h,
+                hkv,
+                d,
+                dv,
+                qk_norm,
+                rope,
+                window,
+                sinks,
+                logit_softcap,
+                mla,
+                ..
+            } => {
+                if *h == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "attention head count h must be > 0".to_string(),
+                    });
+                }
+                if *hkv == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "attention KV head count hkv must be > 0".to_string(),
+                    });
+                }
+                if *hkv > *h {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: format!("hkv ({hkv}) cannot exceed h ({h})"),
+                    });
+                }
+                if !h.is_multiple_of(*hkv) {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: format!("h ({h}) must be divisible by hkv ({hkv})"),
+                    });
+                }
+                if *d == 0 || !d.is_multiple_of(16) {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: format!("head dimension d ({d}) must be > 0 and divisible by 16"),
+                    });
+                }
+                if *dv == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "head value dimension dv must be > 0".to_string(),
+                    });
+                }
+                if let Some(norm) = qk_norm {
+                    if let Err(e) = norm.validate("qk_norm") {
+                        problems.push(e);
+                    }
+                }
+                if let Err(e) = rope.validate("attention rope") {
+                    problems.push(e);
+                }
+                if let Some(cap) = logit_softcap {
+                    if !cap.is_finite() || *cap <= 0.0 {
+                        problems.push(ModelsError::InvalidLayerSpec {
+                            layer: layer_idx,
+                            reason: format!("logit_softcap must be finite and > 0, got {cap}"),
+                        });
+                    }
+                }
+                if let Some(mla_spec) = mla {
+                    if let Err(e) = mla_spec.validate("attention mla") {
+                        problems.push(e);
+                    }
+                    // Spec 8 §3.1 defines qk_norm on the per-head q/k pair,
+                    // which the low-rank MLA form has no per-head k for; the
+                    // combination is rejected instead of silently ignored.
+                    if qk_norm.is_some() {
+                        problems.push(ModelsError::InvalidLayerSpec {
+                            layer: layer_idx,
+                            reason: "mla with qk_norm is unsupported: qk_norm applies to the per-head q/k pair and the MLA form has no per-head k tensor".to_string(),
+                        });
+                    }
+                }
+                check_layer_dim(&mut problems, layer_idx, "h", *h, MAX_ATTENTION_HEADS);
+                check_layer_dim(&mut problems, layer_idx, "hkv", *hkv, MAX_KV_HEADS);
+                check_layer_dim(&mut problems, layer_idx, "d", *d, MAX_FEATURE_DIM);
+                check_layer_dim(&mut problems, layer_idx, "dv", *dv, MAX_FEATURE_DIM);
+                // Spec 3 §2 admits no sink-only form: sinks are only meaningful
+                // with a window, so the combination is rejected, never ignored.
+                if *sinks > 0 && window.is_none() {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: format!(
+                            "attention sinks ({sinks}) require a sliding window (window is None); Spec 3 §2 has no sink-only Retain form"
+                        ),
+                    });
+                }
+                if let Some(w) = window {
+                    check_layer_dim(&mut problems, layer_idx, "window", *w, MAX_WINDOW);
+                }
+                check_layer_dim(&mut problems, layer_idx, "sinks", *sinks, MAX_WINDOW);
+            }
+            Mixer::LinearAttention {
+                h,
+                d,
+                dv,
+                conv,
+                output_norm,
+                ..
+            } => {
+                if *h == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "linear attention head count h must be > 0".to_string(),
+                    });
+                }
+                if *d == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "linear attention d must be > 0".to_string(),
+                    });
+                }
+                if *dv == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "linear attention dv must be > 0".to_string(),
+                    });
+                }
+                if let Some(w) = conv {
+                    if *w == 0 {
+                        problems.push(ModelsError::InvalidLayerSpec {
+                            layer: layer_idx,
+                            reason: "linear attention conv kernel must be > 0".to_string(),
+                        });
+                    }
+                    check_layer_dim(&mut problems, layer_idx, "conv", *w, MAX_FEATURE_DIM);
+                }
+                if let Some(norm) = output_norm {
+                    if let Err(e) = norm.validate("linear attention output_norm") {
+                        problems.push(e);
+                    }
+                }
+                check_layer_dim(&mut problems, layer_idx, "h", *h, MAX_ATTENTION_HEADS);
+                check_layer_dim(&mut problems, layer_idx, "d", *d, MAX_FEATURE_DIM);
+                check_layer_dim(&mut problems, layer_idx, "dv", *dv, MAX_FEATURE_DIM);
+            }
+            Mixer::None => {}
+        }
+
+        match &self.ffn {
+            Ffn::Dense { dff, .. } => {
+                if *dff == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "dense FFN intermediate dimension dff must be > 0".to_string(),
+                    });
+                }
+                check_layer_dim(&mut problems, layer_idx, "dff", *dff, MAX_FEATURE_DIM);
+            }
+            Ffn::Moe {
+                e,
+                k,
+                dff_e,
+                route_scale,
+                group,
+                shared,
+                shared_gate,
+                ..
+            } => {
+                if *e == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "MoE expert count e must be > 0".to_string(),
+                    });
+                }
+                if *k == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "MoE active experts k must be > 0".to_string(),
+                    });
+                }
+                if *k > *e {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: format!("MoE top_k ({k}) cannot exceed total experts e ({e})"),
+                    });
+                }
+                if *dff_e == 0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "MoE expert intermediate dimension dff_e must be > 0".to_string(),
+                    });
+                }
+                check_layer_dim(&mut problems, layer_idx, "e", *e, MAX_EXPERTS);
+                check_layer_dim(&mut problems, layer_idx, "dff_e", *dff_e, MAX_FEATURE_DIM);
+                if !route_scale.is_finite() || *route_scale <= 0.0 {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: format!(
+                            "MoE route_scale must be finite and > 0, got {route_scale}"
+                        ),
+                    });
+                }
+                if let Some(g) = group {
+                    if g.n_group == 0 || g.topk_group == 0 || g.topk_group > *k {
+                        problems.push(ModelsError::InvalidLayerSpec {
+                            layer: layer_idx,
+                            reason: format!("invalid MoE group spec: {g:?}"),
+                        });
+                    }
+                    check_layer_dim(&mut problems, layer_idx, "n_group", g.n_group, MAX_EXPERTS);
+                }
+                if let Some(s) = shared {
+                    if s.n == 0 || s.dff == 0 {
+                        problems.push(ModelsError::InvalidLayerSpec {
+                            layer: layer_idx,
+                            reason: format!("invalid MoE shared expert spec: {s:?}"),
+                        });
+                    }
+                    check_layer_dim(&mut problems, layer_idx, "shared n", s.n, MAX_EXPERTS);
+                    check_layer_dim(
+                        &mut problems,
+                        layer_idx,
+                        "shared dff",
+                        s.dff,
+                        MAX_FEATURE_DIM,
+                    );
+                }
+                // A gated shared path with no shared experts has nothing to
+                // gate; rejecting beats silently ignoring the flag.
+                if *shared_gate && shared.is_none() {
+                    problems.push(ModelsError::InvalidLayerSpec {
+                        layer: layer_idx,
+                        reason: "MoE shared_gate is true but shared is None; the gate would be silently ignored".to_string(),
+                    });
+                }
+            }
+            Ffn::None => {}
+        }
+
+        ModelsError::from_problems(problems)
+    }
+}
+
+/// Token position encoding scheme (Spec 8 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PositionEncoding {
+    /// Scalar 1D token position `[T]`.
+    Scalar,
+    /// Multimodal 3D rotary position sections `[T, 3]` (Spec 8 §3: MRope([u32; 3])).
+    MRope([u32; 3]),
+}
+
+/// Speculative decoding N-gram specification (Spec 8 §3; Spec 1 §4.A; Spec 7 §6).
+// DECISION(A1.3): explicit `dim` (Dn) instead of the hardcoded 32. Spec 1 §4.A
+// requires `gather_staging [T, Np, Dn]` and `x [T, Np·Dn]`, but Spec 8 §3 omits
+// Dn from NgramSpec; the table/projection shapes need it. Rejected keeping the
+// unexplained `ngram_dim = 32` (unverifiable against either spec) and rejected
+// inferring Dn from weights (shapes are declared before the loader binds).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NgramSpec {
+    /// N-gram orders evaluated by hash heads.
+    pub orders: Vec<u32>,
+    /// Number of parallel hash heads `Np`.
+    pub heads: u32,
+    /// Row dimension `Dn` of each n-gram hash-table row (Spec 1 §4.A).
+    pub dim: u32,
+    /// Table sizes per head.
+    pub table_sizes: Vec<u32>,
+    /// Hash algorithm identifier.
+    pub hash: HashId,
+    /// Head combination method.
+    pub combine: NgramCombine,
+    /// Zero-indexed layer index at which n-gram embedding is injected.
+    pub inject_at: u32,
+}
+
+impl NgramSpec {
+    /// Validates n-gram specification fields.
+    pub fn validate(&self, total_layers: usize) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+        if self.heads == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "ngram heads count must be > 0".to_string(),
+            });
+        }
+        check_model_dim(&mut problems, "ngram heads", self.heads, MAX_NGRAM_HEADS);
+        if self.dim == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "ngram dim (Dn) must be > 0".to_string(),
+            });
+        }
+        check_model_dim(&mut problems, "ngram dim", self.dim, MAX_FEATURE_DIM);
+        if self.orders.is_empty() || self.orders.contains(&0) {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "ngram orders must be non-empty and all > 0".to_string(),
+            });
+        }
+        if self.orders.len() != self.heads as usize {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "ngram orders length ({}) must equal heads ({})",
+                    self.orders.len(),
+                    self.heads
+                ),
+            });
+        }
+        if self.table_sizes.is_empty() || self.table_sizes.contains(&0) {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "ngram table_sizes must be non-empty and all > 0".to_string(),
+            });
+        }
+        if self.table_sizes.len() != self.heads as usize {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "ngram table_sizes length ({}) must equal heads ({})",
+                    self.table_sizes.len(),
+                    self.heads
+                ),
+            });
+        }
+        for entries in &self.table_sizes {
+            check_model_dim(
+                &mut problems,
+                "ngram table entries",
+                *entries,
+                MAX_NGRAM_TABLE_ENTRIES,
+            );
+        }
+        if (self.inject_at as usize) >= total_layers {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "ngram inject_at ({}) out of bounds for total layers ({total_layers})",
+                    self.inject_at
+                ),
+            });
+        }
+        ModelsError::from_problems(problems)
+    }
+}
+
+/// Source of hidden states for multi-token prediction heads (Spec 8 §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MtpSource {
+    /// Consumes the post-final-norm hidden state from the last base model layer.
+    Last,
+    /// Consumes the hidden state output after base model layer `n`.
+    Layer(u32),
+}
+
+/// Multi-Token Prediction (MTP) specification (Spec 8 §3, §5; Spec 7 §6).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MtpSpec {
+    /// Number of prediction heads.
+    pub heads: u32,
+    /// Layer specifications executed for each MTP head.
+    pub layers_per_head: Vec<LayerSpec>,
+    /// Where the initial hidden state for the MTP heads originates.
+    pub takes_hidden_from: MtpSource,
+}
+
+impl MtpSpec {
+    /// Validates MTP specification fields.
+    pub fn validate(&self, total_layers: usize) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+        if self.heads == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "mtp heads count must be > 0".to_string(),
+            });
+        }
+        check_model_dim(&mut problems, "mtp heads", self.heads, MAX_MTP_HEADS);
+        if self.layers_per_head.is_empty() {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "mtp layers_per_head must be non-empty".to_string(),
+            });
+        }
+        if self.layers_per_head.len() > MAX_MTP_LAYERS_PER_HEAD as usize {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "mtp layers_per_head length {} exceeds implementation limit {MAX_MTP_LAYERS_PER_HEAD}",
+                    self.layers_per_head.len()
+                ),
+            });
+        }
+        if let MtpSource::Layer(n) = self.takes_hidden_from {
+            if (n as usize) >= total_layers {
+                problems.push(ModelsError::InvalidModelSpec {
+                    reason: format!(
+                        "mtp takes_hidden_from layer {n} exceeds total layers ({total_layers})"
+                    ),
+                });
+            }
+        }
+        for (i, layer) in self.layers_per_head.iter().enumerate() {
+            match u32::try_from(i) {
+                Ok(idx) => {
+                    if let Err(e) = layer.validate(idx) {
+                        problems.push(e);
+                    }
+                }
+                Err(_) => problems.push(ModelsError::InvalidModelSpec {
+                    reason: format!("mtp layer ordinal {i} exceeds u32 range"),
+                }),
+            }
+        }
+        ModelsError::from_problems(problems)
+    }
+}
+
+/// Top-level model architecture specification (Spec 8 §3).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelSpec {
+    /// Model hidden dimension `Dm`.
+    pub dm: u32,
+    /// Layer specifications for each transformer block.
+    pub layers: Vec<LayerSpec>,
+    /// Vocabulary size `V`.
+    pub vocab: u32,
+    /// Embedding scaling factor (1.0 for standard, sqrt(Dm) for Gemma).
+    pub embed_scale: f32,
+    /// Whether the output LM head projection weight is tied to the embedding weight.
+    pub tied_embeddings: bool,
+    /// Final normalization layer specification.
+    pub final_norm: NormSpec,
+    /// Optional final output logit soft-capping threshold.
+    pub final_logit_softcap: Option<f32>,
+    /// Position encoding kind.
+    pub positions: PositionEncoding,
+    /// Optional n-gram speculative feature injection.
+    pub ngram: Option<NgramSpec>,
+    /// Optional multi-token prediction head specification.
+    pub mtp: Option<MtpSpec>,
+    /// Whether to export pre-lm_head final hidden states for external proposers (Eagle, block drafters).
+    pub export_hidden: bool,
+    /// End-of-sequence token IDs.
+    pub eos_ids: Vec<u32>,
+    /// Beginning-of-sequence token ID, if defined.
+    pub bos_id: Option<u32>,
+}
+
+impl ModelSpec {
+    /// Validates model specification parameters against Spec 8 §6 constraints.
+    pub fn validate(&self) -> Result<(), ModelsError> {
+        let mut problems = Vec::new();
+
+        if self.dm == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "model dimension dm must be > 0".to_string(),
+            });
+        }
+        check_model_dim(&mut problems, "dm", self.dm, MAX_FEATURE_DIM);
+        if self.vocab == 0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "model vocab size must be > 0".to_string(),
+            });
+        }
+        check_model_dim(&mut problems, "vocab", self.vocab, MAX_VOCAB_SIZE);
+        if self.layers.is_empty() {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: "model must contain at least one layer".to_string(),
+            });
+        }
+        if self.layers.len() > MAX_MODEL_LAYERS as usize {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "model layer count {} exceeds implementation limit {MAX_MODEL_LAYERS}",
+                    self.layers.len()
+                ),
+            });
+        }
+        if !self.embed_scale.is_finite() || self.embed_scale <= 0.0 {
+            problems.push(ModelsError::InvalidModelSpec {
+                reason: format!(
+                    "embed_scale must be finite and > 0, got {}",
+                    self.embed_scale
+                ),
+            });
+        }
+        if let Err(e) = self.final_norm.validate("final_norm") {
+            problems.push(e);
+        }
+        if let Some(cap) = self.final_logit_softcap {
+            if !cap.is_finite() || cap <= 0.0 {
+                problems.push(ModelsError::InvalidModelSpec {
+                    reason: format!("final_logit_softcap must be finite and > 0, got {cap}"),
+                });
+            }
+        }
+        if let PositionEncoding::MRope(sections) = self.positions {
+            if sections.contains(&0) || sections.iter().any(|&s| !s.is_multiple_of(2)) {
+                problems.push(ModelsError::InvalidModelSpec {
+                    reason: format!("invalid mrope sections {sections:?}"),
+                });
+            }
+        }
+        if let Some(ngram) = &self.ngram {
+            if let Err(e) = ngram.validate(self.layers.len()) {
+                problems.push(e);
+            }
+        }
+        if let Some(mtp) = &self.mtp {
+            if let Err(e) = mtp.validate(self.layers.len()) {
+                problems.push(e);
+            }
+        }
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            match u32::try_from(i) {
+                Ok(idx) => {
+                    if let Err(e) = layer.validate(idx) {
+                        problems.push(e);
+                    }
+                }
+                Err(_) => problems.push(ModelsError::InvalidModelSpec {
+                    reason: format!("model layer ordinal {i} exceeds u32 range"),
+                }),
+            }
+        }
+
+        ModelsError::from_problems(problems)
+    }
+}

--- a/crates/r9v-models/src/summary.rs
+++ b/crates/r9v-models/src/summary.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Model architecture summary for the partitioner and planner (Spec 8 §7; Spec 5 §5; card A1.3).
+
+use std::collections::BTreeMap;
+
+use r9v_ir::QuantScheme;
+
+use crate::builder::checked_add_u64;
+use crate::error::ModelsError;
+
+/// Quantization scheme key with canonical ordering for deterministic summaries (Spec 8 §7; CONVENTIONS.md §3.2).
+// DECISION(A1.3): SchemeKey implements Ord to enable deterministic BTreeMap ordering of weight bytes by scheme; rejected HashMap or unordered iteration to satisfy determinism rules. Spec 8 §7, CONVENTIONS.md §3.2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SchemeKey {
+    /// Unquantized weight tensors.
+    None,
+    /// Per-row scale quantization.
+    PerRow,
+    /// Spec 2 native scheme by opaque scheme ID.
+    Scheme(u64),
+    /// Per-token activation scheme.
+    PerToken,
+    /// Per-block-32 activation scheme.
+    PerBlock32,
+}
+
+impl From<QuantScheme> for SchemeKey {
+    fn from(scheme: QuantScheme) -> Self {
+        match scheme {
+            QuantScheme::None => Self::None,
+            QuantScheme::PerRow => Self::PerRow,
+            QuantScheme::Scheme(id) => Self::Scheme(id.as_u64()),
+            QuantScheme::PerToken => Self::PerToken,
+            QuantScheme::PerBlock32 => Self::PerBlock32,
+        }
+    }
+}
+
+/// Token mixing sublayer classification for resource planning (Spec 8 §7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MixerKind {
+    /// Multi-Head Attention or variant.
+    Attention,
+    /// Linear Attention or SSM scan.
+    LinearAttention,
+}
+
+/// MoE expert memory summary for a layer (Spec 8 §7).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExpertSummary {
+    /// Total routed experts count `E`.
+    pub e: u32,
+    /// Memory weight bytes per individual expert.
+    pub bytes_each: u64,
+    /// Expert activation frequency hint (uniform if unrecorded by quant tool).
+    pub hot_hint: Vec<f32>,
+}
+
+/// Memory and state summary for an individual transformer layer (Spec 8 §7).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LayerSummary {
+    /// Weight bytes bucketed by quantization scheme in deterministic order.
+    pub weight_bytes_by_scheme: BTreeMap<SchemeKey, u64>,
+    /// State memory cost in bytes per token (KV cache).
+    pub state_per_token_bytes: u64,
+    /// State memory cost in bytes per sequence (Recurrent/Conv window).
+    pub state_per_seq_bytes: u64,
+    /// MoE expert parameters, if present.
+    pub experts: Option<ExpertSummary>,
+    /// Mixer classification.
+    pub mixer_kind: Option<MixerKind>,
+}
+
+impl LayerSummary {
+    /// Total weight memory bytes in this layer.
+    ///
+    /// Checked: bucket totals that overflow `u64` report
+    /// [`ModelsError::ArithmeticOverflow`] instead of clamping, wrapping, or
+    /// panicking.
+    pub fn total_weight_bytes(&self) -> Result<u64, ModelsError> {
+        const CTX: &str = "LayerSummary::total_weight_bytes";
+        let mut total = 0u64;
+        for bytes in self.weight_bytes_by_scheme.values() {
+            total = checked_add_u64(total, *bytes, CTX)?;
+        }
+        Ok(total)
+    }
+}
+
+/// Comprehensive model summary consumed by the partitioner and planner (Spec 8 §7; Spec 5 §5.1).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelSummary {
+    /// Per-layer summaries.
+    pub layers: Vec<LayerSummary>,
+    /// Token embedding table weight bytes.
+    pub embed_bytes: u64,
+    /// Language model output head weight bytes (0 if tied to embeddings).
+    pub head_bytes: u64,
+    /// Vocabulary size `V`.
+    pub vocab: u32,
+    /// Hidden dimension `Dm`.
+    pub dm: u32,
+    /// Key/Value head count `Hkv`.
+    pub hkv: u32,
+    /// Divisors of `Hkv` defining valid Tensor Parallel degrees (Spec 8 §7; Spec 5 §5.2).
+    pub tp_divisors: Vec<u32>,
+    /// Speculative n-gram table weight bytes, if present.
+    pub ngram_table_bytes: u64,
+    /// Whether Multi-Token Prediction (MTP) heads are present.
+    pub mtp: bool,
+    /// Whether pre-lm_head final hidden states are exported.
+    pub export_hidden: bool,
+}
+
+impl ModelSummary {
+    /// Total model weight memory bytes across all layers, embeddings, head, and n-gram tables.
+    ///
+    /// Checked: see [`LayerSummary::total_weight_bytes`].
+    pub fn total_weight_bytes(&self) -> Result<u64, ModelsError> {
+        const CTX: &str = "ModelSummary::total_weight_bytes";
+        let mut total = 0u64;
+        for layer in &self.layers {
+            total = checked_add_u64(total, layer.total_weight_bytes()?, CTX)?;
+        }
+        total = checked_add_u64(total, self.embed_bytes, CTX)?;
+        total = checked_add_u64(total, self.head_bytes, CTX)?;
+        total = checked_add_u64(total, self.ngram_table_bytes, CTX)?;
+        Ok(total)
+    }
+
+    /// Total state memory cost in bytes per token across all layers.
+    ///
+    /// Checked: see [`LayerSummary::total_weight_bytes`].
+    pub fn total_state_per_token_bytes(&self) -> Result<u64, ModelsError> {
+        const CTX: &str = "ModelSummary::total_state_per_token_bytes";
+        let mut total = 0u64;
+        for layer in &self.layers {
+            total = checked_add_u64(total, layer.state_per_token_bytes, CTX)?;
+        }
+        Ok(total)
+    }
+
+    /// Total state memory cost in bytes per sequence across all layers.
+    ///
+    /// Checked: see [`LayerSummary::total_weight_bytes`].
+    pub fn total_state_per_seq_bytes(&self) -> Result<u64, ModelsError> {
+        const CTX: &str = "ModelSummary::total_state_per_seq_bytes";
+        let mut total = 0u64;
+        for layer in &self.layers {
+            total = checked_add_u64(total, layer.state_per_seq_bytes, CTX)?;
+        }
+        Ok(total)
+    }
+}

--- a/crates/r9v-models/tests/adversarial.rs
+++ b/crates/r9v-models/tests/adversarial.rs
@@ -1,0 +1,853 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Adversarial regression tests for A1.3 release blockers (Spec 8 §6, §7;
+//! card A1.3).
+//!
+//! Every test here feeds hostile dimensions (`u32::MAX`, over-limit counts)
+//! and asserts a typed error — never a panic, wrap, clamp, hang, or OOM.
+//! Tests that must not allocate bind one small tensor or none at all; the
+//! rejection always fires before any size-driven allocation or loop.
+
+use std::collections::BTreeMap;
+
+use r9v_ir::op::{ActivationKind, Epilogue, HashId, NgramCombine, Op, RopeScaling, RopeStyle};
+use r9v_ir::tensor::{Dim, ShapeSymbol};
+use r9v_ir::version::IrVersion;
+use r9v_models::{
+    build_ffn, build_layer, build_mixer, build_model, build_mtp_subgraph, CacheDtype, Ffn, Graph,
+    GraphBuilder, LayerSpec, LayerSummary, Mixer, MlaSpec, ModelSpec, ModelSummary, ModelsError,
+    MtpSource, MtpSpec, NgramSpec, NormPlacement, NormSpec, PositionEncoding, Retain, RopeSpec,
+    SchemeClass, SchemeKey, StateSpec, WeightRole, MAX_EXPERTS, MAX_FEATURE_DIM, MAX_KV_HEADS,
+    MAX_MODEL_LAYERS,
+};
+
+fn tiny_rope() -> RopeSpec {
+    RopeSpec {
+        theta: 10000.0,
+        rot_dim: 32,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+    }
+}
+
+fn tiny_layer() -> LayerSpec {
+    LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::None,
+        ffn: Ffn::None,
+        residual_scale: 1.0,
+    }
+}
+
+fn tiny_model(layers: Vec<LayerSpec>) -> ModelSpec {
+    ModelSpec {
+        dm: 64,
+        layers,
+        vocab: 64,
+        embed_scale: 1.0,
+        tied_embeddings: false,
+        final_norm: NormSpec::rms(1e-5),
+        final_logit_softcap: None,
+        positions: PositionEncoding::Scalar,
+        ngram: None,
+        mtp: None,
+        export_hidden: false,
+        eos_ids: vec![2],
+        bos_id: Some(1),
+    }
+}
+
+fn plain_attention() -> Mixer {
+    Mixer::Attention {
+        h: 4,
+        hkv: 2,
+        d: 32,
+        dv: 32,
+        qkv_bias: false,
+        o_bias: false,
+        qk_norm: None,
+        rope: tiny_rope(),
+        window: None,
+        sinks: 0,
+        logit_softcap: None,
+        output_gate: false,
+        mla: None,
+        cache: CacheDtype::E4m3,
+    }
+}
+
+/// Tensor byte products that overflow `u64` report `ArithmeticOverflow`.
+#[test]
+fn summary_tensor_bytes_overflow_returns_typed_error() {
+    let mut builder = Graph::new(IrVersion::CURRENT, "adv-bytes-overflow");
+    builder
+        .weight(
+            "blk.0.attn_q.weight",
+            WeightRole::Matmul,
+            &[
+                Dim::Concrete(u32::MAX),
+                Dim::Concrete(u32::MAX),
+                Dim::Concrete(u32::MAX),
+            ],
+            SchemeClass::Matmul,
+        )
+        .expect("metadata-only weight bind must succeed");
+    let graph = builder.finish().expect("op-free graph must finish");
+    let err = graph.summary().unwrap_err();
+    assert!(
+        matches!(err, ModelsError::ArithmeticOverflow { .. }),
+        "expected ArithmeticOverflow, got {err:?}"
+    );
+    assert!(
+        format!("{err:?}").contains("4294967295"),
+        "operands reported: {err:?}"
+    );
+}
+
+/// Layer index `u32::MAX` overflows the `max + 1` layer count as typed error.
+#[test]
+fn summary_max_layer_ordinal_overflow_returns_typed_error() {
+    let mut builder = Graph::new(IrVersion::CURRENT, "adv-layer-ordinal");
+    builder
+        .weight(
+            "blk.4294967295.attn_q.weight",
+            WeightRole::Matmul,
+            &[Dim::Concrete(8), Dim::Concrete(8)],
+            SchemeClass::Matmul,
+        )
+        .expect("metadata-only weight bind must succeed");
+    let graph = builder.finish().expect("op-free graph must finish");
+    let err = graph.summary().unwrap_err();
+    assert!(
+        matches!(err, ModelsError::ArithmeticOverflow { .. }),
+        "expected ArithmeticOverflow, got {err:?}"
+    );
+}
+
+/// Absurd layer ordinals are rejected before `Vec::with_capacity`, not OOM.
+#[test]
+fn summary_absurd_layer_ordinal_rejected_before_alloc() {
+    let mut builder = Graph::new(IrVersion::CURRENT, "adv-layer-count");
+    builder
+        .weight(
+            "blk.2000000.attn_q.weight",
+            WeightRole::Matmul,
+            &[Dim::Concrete(8), Dim::Concrete(8)],
+            SchemeClass::Matmul,
+        )
+        .expect("metadata-only weight bind must succeed");
+    let graph = builder.finish().expect("op-free graph must finish");
+    let err = graph.summary().unwrap_err();
+    assert!(
+        matches!(err, ModelsError::InvalidModelSpec { .. }),
+        "expected InvalidModelSpec, got {err:?}"
+    );
+    assert!(
+        format!("{err:?}").contains(&MAX_MODEL_LAYERS.to_string()),
+        "limit reported: {err:?}"
+    );
+}
+
+/// Absurd `hkv` is rejected before the TP-divisor enumeration, not looped.
+#[test]
+fn summary_absurd_hkv_rejected_before_divisor_loop() {
+    let mut builder = Graph::new(IrVersion::CURRENT, "adv-hkv");
+    builder
+        .state(
+            0,
+            StateSpec::KvPaged {
+                hkv: u32::MAX,
+                d: 16,
+                dv: 16,
+                cache: CacheDtype::F16,
+                retain: Retain::All,
+            },
+        )
+        .expect("state declare must succeed");
+    let graph = builder.finish().expect("op-free graph must finish");
+    let err = graph.summary().unwrap_err();
+    assert!(
+        matches!(err, ModelsError::InvalidModelSpec { .. }),
+        "expected InvalidModelSpec, got {err:?}"
+    );
+    assert!(
+        format!("{err:?}").contains(&MAX_KV_HEADS.to_string()),
+        "limit reported: {err:?}"
+    );
+}
+
+/// Absurd expert counts are rejected before the `hot_hint` allocation.
+#[test]
+fn summary_absurd_expert_count_rejected_before_hot_hint_alloc() {
+    let mut builder = Graph::new(IrVersion::CURRENT, "adv-experts");
+    builder
+        .weight(
+            "blk.0.ffn_gate_up_exps.weight",
+            WeightRole::Matmul,
+            &[Dim::Concrete(u32::MAX), Dim::Concrete(8), Dim::Concrete(8)],
+            SchemeClass::Matmul,
+        )
+        .expect("metadata-only weight bind must succeed");
+    let graph = builder.finish().expect("op-free graph must finish");
+    let err = graph.summary().unwrap_err();
+    assert!(
+        matches!(err, ModelsError::InvalidModelSpec { .. }),
+        "expected InvalidModelSpec, got {err:?}"
+    );
+    assert!(
+        format!("{err:?}").contains(&MAX_EXPERTS.to_string()),
+        "limit reported: {err:?}"
+    );
+}
+
+/// Graph-global weights alone summarize zero layers: no phantom layer.
+#[test]
+fn summary_with_only_global_weights_has_no_layers() {
+    let mut builder = Graph::new(IrVersion::CURRENT, "adv-globals-only");
+    builder
+        .weight(
+            "token_embd.weight",
+            WeightRole::Embed,
+            &[Dim::Concrete(64), Dim::Concrete(64)],
+            SchemeClass::Embed,
+        )
+        .expect("embed bind must succeed");
+    builder
+        .weight(
+            "output.weight",
+            WeightRole::LmHead,
+            &[Dim::Concrete(64), Dim::Concrete(64)],
+            SchemeClass::Matmul,
+        )
+        .expect("head bind must succeed");
+    builder
+        .weight(
+            "output_norm.weight",
+            WeightRole::Vector,
+            &[Dim::Concrete(64)],
+            SchemeClass::Vector,
+        )
+        .expect("norm bind must succeed");
+    let graph = builder.finish().expect("op-free graph must finish");
+    let summary = graph.summary().expect("global-only summary must compute");
+    assert!(summary.layers.is_empty(), "no phantom layer for globals");
+    assert_eq!(summary.embed_bytes, 64 * 64 * 2);
+    assert_eq!(summary.head_bytes, 64 * 64 * 2);
+    assert_eq!(
+        summary.total_state_per_token_bytes().expect("state total"),
+        0
+    );
+    assert_eq!(
+        summary.total_weight_bytes().expect("weight total"),
+        2 * 64 * 64 * 2
+    );
+}
+
+/// `StateSpec` byte math overflows as typed error and stays exact otherwise.
+#[test]
+fn state_spec_byte_overflow_returns_typed_error() {
+    let huge_paged = StateSpec::KvPaged {
+        hkv: u32::MAX,
+        d: u32::MAX,
+        dv: u32::MAX,
+        cache: CacheDtype::E4m3,
+        retain: Retain::All,
+    };
+    assert!(
+        matches!(
+            huge_paged.state_per_token_bytes().unwrap_err(),
+            ModelsError::ArithmeticOverflow { .. }
+        ),
+        "paged KV overflow must be typed"
+    );
+
+    let huge_recurrent = StateSpec::Recurrent {
+        h: u32::MAX,
+        d: u32::MAX,
+        dv: u32::MAX,
+    };
+    assert!(
+        matches!(
+            huge_recurrent.state_per_seq_bytes().unwrap_err(),
+            ModelsError::ArithmeticOverflow { .. }
+        ),
+        "recurrent overflow must be typed"
+    );
+
+    let huge_conv = StateSpec::ConvWindow {
+        c: u32::MAX,
+        w: u32::MAX,
+    };
+    assert!(
+        matches!(
+            huge_conv.state_per_seq_bytes().unwrap_err(),
+            ModelsError::ArithmeticOverflow { .. }
+        ),
+        "conv window overflow must be typed"
+    );
+
+    // Exactness oracle (Spec 3 §6.2): hkv * ((d + dv) * elem + scales).
+    let paged = StateSpec::KvPaged {
+        hkv: 4,
+        d: 32,
+        dv: 32,
+        cache: CacheDtype::E4m3,
+        retain: Retain::All,
+    };
+    assert_eq!(paged.state_per_token_bytes().expect("exact"), 272);
+    let latent = StateSpec::KvLatent {
+        latent: 64,
+        rope: 32,
+        cache: CacheDtype::E4m3,
+        retain: Retain::All,
+    };
+    assert_eq!(latent.state_per_token_bytes().expect("exact"), 130);
+    let recurrent = StateSpec::Recurrent {
+        h: 4,
+        d: 16,
+        dv: 16,
+    };
+    assert_eq!(recurrent.state_per_seq_bytes().expect("exact"), 8192);
+    let conv = StateSpec::ConvWindow { c: 256, w: 4 };
+    assert_eq!(conv.state_per_seq_bytes().expect("exact"), 1536);
+}
+
+/// Summary totals that overflow `u64` report `ArithmeticOverflow`.
+#[test]
+fn summary_totals_overflow_returns_typed_error() {
+    let mut buckets = BTreeMap::new();
+    buckets.insert(SchemeKey::None, u64::MAX);
+    buckets.insert(SchemeKey::PerRow, 1);
+    let layer = LayerSummary {
+        weight_bytes_by_scheme: buckets,
+        state_per_token_bytes: 0,
+        state_per_seq_bytes: 0,
+        experts: None,
+        mixer_kind: None,
+    };
+    assert!(
+        matches!(
+            layer.total_weight_bytes().unwrap_err(),
+            ModelsError::ArithmeticOverflow { .. }
+        ),
+        "layer bucket overflow must be typed"
+    );
+
+    // Totals overflow across layers even when each layer alone fits: two
+    // layers at `u64::MAX` each cannot sum.
+    let mut single = BTreeMap::new();
+    single.insert(SchemeKey::None, u64::MAX);
+    let max_layer = LayerSummary {
+        weight_bytes_by_scheme: single,
+        state_per_token_bytes: u64::MAX,
+        state_per_seq_bytes: u64::MAX,
+        experts: None,
+        mixer_kind: None,
+    };
+    assert_eq!(
+        max_layer
+            .total_weight_bytes()
+            .expect("single max layer fits"),
+        u64::MAX
+    );
+    let summary = ModelSummary {
+        layers: vec![max_layer.clone(), max_layer],
+        embed_bytes: 0,
+        head_bytes: 0,
+        vocab: 64,
+        dm: 64,
+        hkv: 0,
+        tp_divisors: vec![1],
+        ngram_table_bytes: 0,
+        mtp: false,
+        export_hidden: false,
+    };
+    for total in [
+        summary.total_weight_bytes().unwrap_err(),
+        summary.total_state_per_token_bytes().unwrap_err(),
+        summary.total_state_per_seq_bytes().unwrap_err(),
+    ] {
+        assert!(
+            matches!(total, ModelsError::ArithmeticOverflow { .. }),
+            "summary total overflow must be typed, got {total:?}"
+        );
+    }
+}
+
+/// Huge MoE expert counts fail validation before any allocation, all at once.
+#[test]
+fn huge_expert_count_rejected_before_allocation() {
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::Attention {
+            h: u32::MAX,
+            hkv: u32::MAX,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: tiny_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        ffn: Ffn::Moe {
+            e: u32::MAX,
+            k: 1,
+            dff_e: 16,
+            act: ActivationKind::Silu,
+            scoring: r9v_ir::op::MoeScoring::Softmax,
+            renormalize: true,
+            group: None,
+            route_bias: false,
+            route_scale: 1.0,
+            shared: None,
+            shared_gate: false,
+        },
+        residual_scale: 1.0,
+    };
+    // Collect-all: h, hkv, and e violations arrive together, not first-only.
+    let err = layer.validate(0).unwrap_err();
+    let text = format!("{err:?}");
+    for dim in ["dimension 'h' ", "dimension 'hkv' ", "dimension 'e' "] {
+        assert!(text.contains(dim), "missing {dim}problem in: {text}");
+    }
+
+    // Lowering refuses the same spec without building (no hang, no OOM).
+    let model = tiny_model(vec![tiny_layer()]);
+    let mut builder = GraphBuilder::new(IrVersion::CURRENT, "adv-huge-experts");
+    let (x, _) = builder.input_embed_override(model.dm).expect("override");
+    assert!(build_layer(&mut builder, 0, &layer, x, &model).is_err());
+}
+
+/// Huge MTP head counts fail before the head loop runs.
+#[test]
+fn huge_mtp_heads_rejected_without_building() {
+    let mtp = MtpSpec {
+        heads: u32::MAX,
+        layers_per_head: vec![tiny_layer()],
+        takes_hidden_from: MtpSource::Last,
+    };
+    let err = mtp.validate(1).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("mtp heads"),
+        "mtp heads violation reported: {err:?}"
+    );
+
+    let model = tiny_model(vec![tiny_layer()]);
+    let mut parent = Graph::new(IrVersion::CURRENT, "adv-huge-mtp");
+    let (hidden, _) = parent.input_embed_override(model.dm).expect("override");
+    assert!(build_mtp_subgraph(&mut parent, &mtp, hidden, &model).is_err());
+}
+
+/// Over-limit layer counts fail validation (and the build) up front.
+#[test]
+fn huge_layer_count_rejected_up_front() {
+    let layers = vec![tiny_layer(); MAX_MODEL_LAYERS as usize + 1];
+    let model = tiny_model(layers);
+    let err = model.validate().unwrap_err();
+    assert!(
+        format!("{err:?}").contains(&MAX_MODEL_LAYERS.to_string()),
+        "layer count violation reported: {err:?}"
+    );
+    let builder = Graph::new(IrVersion::CURRENT, "adv-huge-layers");
+    assert!(build_model(builder, &model).is_err());
+}
+
+/// Huge n-gram dimensions fail validation before table weights bind.
+#[test]
+fn huge_ngram_dims_rejected_before_binding() {
+    let ngram = NgramSpec {
+        orders: vec![2],
+        heads: u32::MAX,
+        dim: 32,
+        table_sizes: vec![u32::MAX],
+        hash: HashId::new(1),
+        combine: NgramCombine::Sum,
+        inject_at: 0,
+    };
+    let err = ngram.validate(1).unwrap_err();
+    let text = format!("{err:?}");
+    assert!(text.contains("ngram heads"), "heads violation: {text}");
+    assert!(
+        text.contains("ngram table entries"),
+        "table violation: {text}"
+    );
+
+    let mut model = tiny_model(vec![tiny_layer()]);
+    model.ngram = Some(ngram);
+    let builder = Graph::new(IrVersion::CURRENT, "adv-huge-ngram");
+    assert!(build_model(builder, &model).is_err());
+}
+
+/// Model-level dimension caps collect every violation together.
+#[test]
+fn model_level_dim_caps_collect_all_problems() {
+    let model = ModelSpec {
+        dm: u32::MAX,
+        vocab: u32::MAX,
+        ..tiny_model(vec![tiny_layer()])
+    };
+    let err = model.validate().unwrap_err();
+    let text = format!("{err:?}");
+    assert!(text.contains("dimension 'dm'"), "dm violation: {text}");
+    assert!(
+        text.contains("dimension 'vocab'"),
+        "vocab violation: {text}"
+    );
+}
+
+/// Dense `gated` plus `bias` lowers both biases through the matmul epilogue.
+#[test]
+fn dense_gated_bias_lowers_through_bias_epilogue() {
+    let mixer = plain_attention();
+    let ffn = Ffn::Dense {
+        dff: 64,
+        act: ActivationKind::Silu,
+        gated: true,
+        bias: true,
+    };
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: mixer.clone(),
+        ffn: ffn.clone(),
+        residual_scale: 1.0,
+    };
+    let mut model = tiny_model(vec![layer]);
+    model.dm = 128;
+    let graph = build_model(Graph::new(IrVersion::CURRENT, "adv-gated-bias"), &model)
+        .expect("gated-bias model must build and validate");
+
+    // Canonical bias weights with exact shapes and F32 vector dtype.
+    // `dm` (128) differs from `dff` (64) so bias shapes are unambiguous.
+    for name in ["blk.0.ffn_gate.bias", "blk.0.ffn_up.bias"] {
+        let w = graph
+            .bound_weights()
+            .iter()
+            .find(|w| w.name == name)
+            .unwrap_or_else(|| panic!("missing bias weight {name}"));
+        assert_eq!(w.shape, vec![Dim::Concrete(64)], "shape of {name}");
+        assert_eq!(w.tensor.dtype(), r9v_ir::DType::F32, "dtype of {name}");
+    }
+
+    // Exactly the gate and up projections carry the bias epilogue, fed by
+    // the bias weight edges; every other matmul stays epilogue-free.
+    let graph_ref = graph.graph();
+    let bias_names: Vec<&str> = graph
+        .bound_weights()
+        .iter()
+        .filter(|w| w.name.ends_with(".bias"))
+        .map(|w| w.name.as_str())
+        .collect();
+    assert_eq!(
+        bias_names.len(),
+        2,
+        "only gate and up biases: {bias_names:?}"
+    );
+    let mut bias_epilogues = 0;
+    for node in graph_ref.nodes() {
+        if let Op::Matmul(m) = &node.op {
+            match m.epilogue {
+                Epilogue::Bias => {
+                    bias_epilogues += 1;
+                    let last = node.inputs.last().expect("bias input edge");
+                    let input = &graph_ref.edges()[last.0].tensor;
+                    assert_eq!(input.dtype(), r9v_ir::DType::F32);
+                    assert_eq!(input.shape().to_vec(), vec![Dim::Concrete(64)]);
+                }
+                Epilogue::None => {}
+                _ => panic!("unexpected matmul epilogue {:?}", m.epilogue),
+            }
+        }
+    }
+    assert_eq!(bias_epilogues, 2, "gate and up projections");
+}
+
+/// MLA with `qk_norm` is rejected at validation and at lowering, never
+/// silently dropped.
+#[test]
+fn mla_qk_norm_rejected_not_ignored() {
+    let mixer = Mixer::Attention {
+        h: 4,
+        hkv: 1,
+        d: 32,
+        dv: 32,
+        qkv_bias: false,
+        o_bias: false,
+        qk_norm: Some(NormSpec::rms(1e-5)),
+        rope: tiny_rope(),
+        window: None,
+        sinks: 0,
+        logit_softcap: None,
+        output_gate: false,
+        mla: Some(MlaSpec {
+            q_lora_rank: 32,
+            kv_lora_rank: 16,
+            qk_nope_dim: 16,
+            qk_rope_dim: 16,
+            v_dim: 32,
+        }),
+        cache: CacheDtype::E4m3,
+    };
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: mixer.clone(),
+        ffn: Ffn::None,
+        residual_scale: 1.0,
+    };
+    let err = layer.validate(0).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("qk_norm"),
+        "validation names qk_norm: {err:?}"
+    );
+
+    let model = tiny_model(vec![tiny_layer()]);
+    let mut builder = GraphBuilder::new(IrVersion::CURRENT, "adv-mla-qknorm");
+    let (x, _) = builder.input_embed_override(model.dm).expect("override");
+    let err = build_layer(&mut builder, 0, &layer, x, &model).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("qk_norm"),
+        "layer lowering names qk_norm: {err:?}"
+    );
+
+    // The bare-mixer entry point refuses it too (defense past validation).
+    let mut direct = GraphBuilder::new(IrVersion::CURRENT, "adv-mla-qknorm-direct");
+    let (h, _) = direct.input_embed_override(model.dm).expect("override");
+    let err = build_mixer(&mut direct, 0, &mixer, h, &model).unwrap_err();
+    assert!(
+        matches!(err, ModelsError::InvalidLayerSpec { .. }),
+        "mixer lowering rejects MLA qk_norm: {err:?}"
+    );
+}
+
+/// The public spec-facing builders take no namespace plumbing and lower.
+#[test]
+fn public_build_apis_lower_without_namespace_arg() {
+    let mut model = tiny_model(vec![tiny_layer()]);
+    model.dm = 128;
+    let mixer = Mixer::Attention {
+        h: 4,
+        hkv: 2,
+        d: 32,
+        dv: 32,
+        qkv_bias: false,
+        o_bias: false,
+        qk_norm: None,
+        rope: tiny_rope(),
+        window: None,
+        sinks: 0,
+        logit_softcap: None,
+        output_gate: false,
+        mla: None,
+        cache: CacheDtype::E4m3,
+    };
+    let ffn = Ffn::Dense {
+        dff: 64,
+        act: ActivationKind::Silu,
+        gated: true,
+        bias: false,
+    };
+
+    let mut builder = GraphBuilder::new(IrVersion::CURRENT, "adv-public-api");
+    let (h, _) = builder.input_embed_override(model.dm).expect("override");
+    let mixer_out =
+        build_mixer(&mut builder, 0, &mixer, h.clone(), &model).expect("public build_mixer lowers");
+    assert_eq!(
+        mixer_out.shape(),
+        &[Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(model.dm)],
+        "mixer output is [T, Dm]"
+    );
+    let ffn_out = build_ffn(&mut builder, 0, &ffn, h, &model).expect("public build_ffn lowers");
+    assert_eq!(
+        ffn_out.shape(),
+        &[Dim::Symbolic(ShapeSymbol::T), Dim::Concrete(model.dm)],
+        "ffn output is [T, Dm]"
+    );
+    let _ = mixer_out;
+    let _ = ffn_out;
+}
+
+/// `shared_gate = true` with `shared = None` is rejected at validation and at
+/// lowering, never silently ignored.
+#[test]
+fn moe_shared_gate_without_shared_rejected_not_ignored() {
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::None,
+        ffn: Ffn::Moe {
+            e: 4,
+            k: 1,
+            dff_e: 16,
+            act: ActivationKind::Silu,
+            scoring: r9v_ir::op::MoeScoring::Softmax,
+            renormalize: true,
+            group: None,
+            route_bias: false,
+            route_scale: 1.0,
+            shared: None,
+            shared_gate: true,
+        },
+        residual_scale: 1.0,
+    };
+    let err = layer.validate(0).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("shared_gate"),
+        "validation names shared_gate: {err:?}"
+    );
+
+    let model = tiny_model(vec![tiny_layer()]);
+    let mut builder = GraphBuilder::new(IrVersion::CURRENT, "adv-shared-gate");
+    let (x, _) = builder.input_embed_override(model.dm).expect("override");
+    let err = build_layer(&mut builder, 0, &layer, x, &model).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("shared_gate"),
+        "layer lowering names shared_gate: {err:?}"
+    );
+}
+
+/// `sinks > 0` without a window is rejected: Spec 3 §2 has no sink-only
+/// `Retain` form and sinks are only meaningful with a window.
+#[test]
+fn attention_sinks_without_window_rejected() {
+    let mixer = Mixer::Attention {
+        h: 4,
+        hkv: 2,
+        d: 32,
+        dv: 32,
+        qkv_bias: false,
+        o_bias: false,
+        qk_norm: None,
+        rope: tiny_rope(),
+        window: None,
+        sinks: 4,
+        logit_softcap: None,
+        output_gate: false,
+        mla: None,
+        cache: CacheDtype::E4m3,
+    };
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: mixer.clone(),
+        ffn: Ffn::None,
+        residual_scale: 1.0,
+    };
+    let err = layer.validate(0).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("sinks"),
+        "validation names sinks: {err:?}"
+    );
+
+    let model = tiny_model(vec![tiny_layer()]);
+    let mut builder = GraphBuilder::new(IrVersion::CURRENT, "adv-sink-only");
+    let (x, _) = builder.input_embed_override(model.dm).expect("override");
+    let err = build_layer(&mut builder, 0, &layer, x, &model).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("sinks"),
+        "layer lowering names sinks: {err:?}"
+    );
+
+    // The bare-mixer entry point refuses it too (defense past validation).
+    let mut direct = GraphBuilder::new(IrVersion::CURRENT, "adv-sink-only-direct");
+    let (h, _) = direct.input_embed_override(model.dm).expect("override");
+    let err = build_mixer(&mut direct, 0, &mixer, h, &model).unwrap_err();
+    assert!(
+        matches!(err, ModelsError::InvalidModelSpec { .. }),
+        "mixer lowering rejects sink-only retention: {err:?}"
+    );
+}
+
+/// `Retain::from_window_sinks` covers the Spec 3 §2 forms exactly; sink-only
+/// input is a typed error, never a `u32::MAX` window.
+#[test]
+fn retain_sink_only_returns_typed_error_not_sentinel() {
+    assert_eq!(
+        Retain::from_window_sinks(None, 0).expect("all"),
+        Retain::All
+    );
+    assert_eq!(
+        Retain::from_window_sinks(Some(128), 0).expect("window"),
+        Retain::Window(128)
+    );
+    assert_eq!(
+        Retain::from_window_sinks(Some(128), 4).expect("sink plus window"),
+        Retain::SinkAndWindow {
+            sinks: 4,
+            window: 128
+        }
+    );
+    let err = Retain::from_window_sinks(None, 4).unwrap_err();
+    assert!(
+        matches!(err, ModelsError::InvalidModelSpec { .. }),
+        "sink-only retention is InvalidModelSpec: {err:?}"
+    );
+    let text = format!("{err:?}");
+    assert!(
+        !text.contains("4294967295"),
+        "no u32::MAX sentinel leaks into the error: {text}"
+    );
+}
+
+/// N-gram `dim` (Dn) is nonzero and bounded; `orders` and `table_sizes`
+/// lengths each equal `heads`, collected together rather than first-only.
+#[test]
+fn ngram_dim_and_head_lengths_validated() {
+    let zero_dim = NgramSpec {
+        orders: vec![2],
+        heads: 1,
+        dim: 0,
+        table_sizes: vec![64],
+        hash: HashId::new(1),
+        combine: NgramCombine::Sum,
+        inject_at: 0,
+    };
+    let err = zero_dim.validate(1).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("ngram dim"),
+        "zero dim rejected: {err:?}"
+    );
+
+    let huge_dim = NgramSpec {
+        orders: vec![2],
+        heads: 1,
+        dim: MAX_FEATURE_DIM + 1,
+        table_sizes: vec![64],
+        hash: HashId::new(1),
+        combine: NgramCombine::Sum,
+        inject_at: 0,
+    };
+    let err = huge_dim.validate(1).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("ngram dim"),
+        "over-limit dim rejected: {err:?}"
+    );
+
+    let mismatched = NgramSpec {
+        orders: vec![2],
+        heads: 2,
+        dim: 32,
+        table_sizes: vec![64],
+        hash: HashId::new(1),
+        combine: NgramCombine::Sum,
+        inject_at: 0,
+    };
+    let err = mismatched.validate(1).unwrap_err();
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("orders length"),
+        "orders/heads mismatch reported: {text}"
+    );
+    assert!(
+        text.contains("table_sizes length"),
+        "tables/heads mismatch reported: {text}"
+    );
+}

--- a/crates/r9v-models/tests/api_shape.rs
+++ b/crates/r9v-models/tests/api_shape.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//! API-shape and trait boundary tests for `r9v-models` (Spec 8; card A1.3; CONVENTIONS.md §4.1).
+
+use r9v_ir::version::IrVersion;
+use r9v_models::{
+    BoundWeight, CacheDtype, ExpertSummary, Ffn, FusionDecl, GgufMeta, Graph, GraphBuilder,
+    LayerSpec, LayerSummary, MetaValue, Mixer, MixerKind, MlaSpec, ModelGraph, ModelSpec,
+    ModelSummary, ModelsError, MoeGroupSpec, MoeSharedSpec, MtpSource, MtpSpec, NgramSpec,
+    NormPlacement, NormSpec, PositionEncoding, Retain, RopeSpec, SchemeClass, SchemeKey,
+    SealedGraphBuilder, StateSpec, SyntheticGgufMeta, TiedDecl, WeightRole,
+};
+
+fn assert_send<T: Send>() {}
+fn assert_sync<T: Sync>() {}
+
+#[test]
+fn test_all_public_types_send_sync() {
+    assert_send::<GraphBuilder>();
+    assert_sync::<GraphBuilder>();
+
+    assert_send::<ModelGraph>();
+    assert_sync::<ModelGraph>();
+
+    assert_send::<BoundWeight>();
+    assert_sync::<BoundWeight>();
+
+    assert_send::<FusionDecl>();
+    assert_sync::<FusionDecl>();
+
+    assert_send::<TiedDecl>();
+    assert_sync::<TiedDecl>();
+
+    assert_send::<WeightRole>();
+    assert_sync::<WeightRole>();
+
+    assert_send::<SchemeClass>();
+    assert_sync::<SchemeClass>();
+
+    assert_send::<NormPlacement>();
+    assert_sync::<NormPlacement>();
+
+    assert_send::<NormSpec>();
+    assert_sync::<NormSpec>();
+
+    assert_send::<RopeSpec>();
+    assert_sync::<RopeSpec>();
+
+    assert_send::<MlaSpec>();
+    assert_sync::<MlaSpec>();
+
+    assert_send::<CacheDtype>();
+    assert_sync::<CacheDtype>();
+
+    assert_send::<Retain>();
+    assert_sync::<Retain>();
+
+    assert_send::<StateSpec>();
+    assert_sync::<StateSpec>();
+
+    assert_send::<Mixer>();
+    assert_sync::<Mixer>();
+
+    assert_send::<Ffn>();
+    assert_sync::<Ffn>();
+
+    assert_send::<MoeGroupSpec>();
+    assert_sync::<MoeGroupSpec>();
+
+    assert_send::<MoeSharedSpec>();
+    assert_sync::<MoeSharedSpec>();
+
+    assert_send::<LayerSpec>();
+    assert_sync::<LayerSpec>();
+
+    assert_send::<PositionEncoding>();
+    assert_sync::<PositionEncoding>();
+
+    assert_send::<NgramSpec>();
+    assert_sync::<NgramSpec>();
+
+    assert_send::<MtpSource>();
+    assert_sync::<MtpSource>();
+
+    assert_send::<MtpSpec>();
+    assert_sync::<MtpSpec>();
+
+    assert_send::<ModelSpec>();
+    assert_sync::<ModelSpec>();
+
+    assert_send::<SchemeKey>();
+    assert_sync::<SchemeKey>();
+
+    assert_send::<MixerKind>();
+    assert_sync::<MixerKind>();
+
+    assert_send::<ExpertSummary>();
+    assert_sync::<ExpertSummary>();
+
+    assert_send::<LayerSummary>();
+    assert_sync::<LayerSummary>();
+
+    assert_send::<ModelSummary>();
+    assert_sync::<ModelSummary>();
+
+    assert_send::<ModelsError>();
+    assert_sync::<ModelsError>();
+
+    assert_send::<SyntheticGgufMeta>();
+    assert_sync::<SyntheticGgufMeta>();
+
+    assert_send::<MetaValue>();
+    assert_sync::<MetaValue>();
+}
+
+#[test]
+fn test_sealed_builder_trait_implemented() {
+    fn check_sealed<T: SealedGraphBuilder>() {}
+    check_sealed::<GraphBuilder>();
+}
+
+#[test]
+fn test_synthetic_gguf_meta_typed_access() {
+    let mut meta = SyntheticGgufMeta::new();
+    meta.insert_str("general.architecture", "llama");
+    meta.insert_u32("llama.context_length", 8192);
+    meta.insert_u64("llama.embedding_length", 4096);
+    meta.insert_f32("llama.attention.layer_norm_rms_epsilon", 1e-5);
+    meta.insert_bool("llama.rope.dimension_count", true);
+    meta.insert_str_array(
+        "tokenizer.ggml.tokens",
+        vec!["<s>".to_string(), "</s>".to_string()],
+    );
+    meta.insert_u32_array("tokenizer.ggml.merges", vec![10, 20, 30]);
+
+    assert!(meta.has("general.architecture"));
+    assert!(!meta.has("nonexistent"));
+
+    assert_eq!(meta.str("general.architecture").unwrap(), "llama");
+    assert_eq!(meta.u32("llama.context_length").unwrap(), 8192);
+    assert_eq!(meta.u64("llama.embedding_length").unwrap(), 4096);
+    assert!((meta.f32("llama.attention.layer_norm_rms_epsilon").unwrap() - 1e-5).abs() < 1e-7);
+    assert!(meta.bool("llama.rope.dimension_count").unwrap());
+    assert_eq!(
+        meta.str_array("tokenizer.ggml.tokens").unwrap(),
+        vec!["<s>", "</s>"]
+    );
+    assert_eq!(
+        meta.u32_array("tokenizer.ggml.merges").unwrap(),
+        vec![10, 20, 30]
+    );
+
+    // Optional getters
+    assert_eq!(meta.get_str("general.architecture").unwrap(), Some("llama"));
+    assert_eq!(meta.get_str("nonexistent").unwrap(), None);
+    assert_eq!(meta.get_u32("llama.context_length").unwrap(), Some(8192));
+    assert_eq!(meta.get_u32("nonexistent").unwrap(), None);
+
+    // Missing key error
+    let err = meta.str("missing.key").unwrap_err();
+    assert!(matches!(err, ModelsError::MissingMetaKey { .. }));
+
+    // Type mismatch error
+    let err = meta.u32("general.architecture").unwrap_err();
+    assert!(matches!(err, ModelsError::MetaTypeMismatch { .. }));
+}
+
+#[test]
+fn test_builder_creation_via_graph_factory() {
+    let builder = Graph::new(IrVersion::CURRENT, "test-model");
+    assert_eq!(builder.ir_version(), IrVersion::CURRENT);
+    assert_eq!(builder.model_id(), "test-model");
+}

--- a/crates/r9v-models/tests/byte_summary.rs
+++ b/crates/r9v-models/tests/byte_summary.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hand-computed byte summary tests for `ModelSummary` (Spec 8 §7; Spec 3 §6.2; card A1.3).
+
+use r9v_ir::op::{
+    ActivationKind, HashId, LinearAttnKind, MoeScoring, NgramCombine, RopeScaling, RopeStyle,
+};
+use r9v_ir::version::IrVersion;
+use r9v_models::{
+    build_model, CacheDtype, Ffn, Graph, LayerSpec, Mixer, MixerKind, ModelSpec, MoeSharedSpec,
+    NgramSpec, NormPlacement, NormSpec, PositionEncoding, RopeSpec, SchemeKey,
+};
+
+#[test]
+fn test_synthetic_model_byte_summary() {
+    let rope = RopeSpec {
+        theta: 10000.0,
+        rot_dim: 32,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+    };
+
+    // Layer 0: Attention (KV cache E4m3) + Gated Dense FFN
+    let layer0 = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::Attention {
+            h: 8,
+            hkv: 4,
+            d: 32,
+            dv: 32,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope,
+            window: Some(1024),
+            sinks: 4,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        ffn: Ffn::Dense {
+            dff: 512,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+
+    // Layer 1: MoE (4 experts, top-2, shared expert)
+    let layer1 = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::None,
+        ffn: Ffn::Moe {
+            e: 4,
+            k: 2,
+            dff_e: 128,
+            act: ActivationKind::Silu,
+            scoring: MoeScoring::Softmax,
+            renormalize: true,
+            group: None,
+            route_bias: false,
+            route_scale: 1.0,
+            shared: Some(MoeSharedSpec { n: 1, dff: 128 }),
+            shared_gate: false,
+        },
+        residual_scale: 1.0,
+    };
+
+    // Layer 2: Linear Attention (conv + recurrent scan)
+    let layer2 = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::LinearAttention {
+            kind: LinearAttnKind::GatedDeltaNet,
+            h: 4,
+            d: 16,
+            dv: 16,
+            conv: Some(4),
+            gate_act: ActivationKind::Silu,
+            output_norm: None,
+            output_gate: false,
+        },
+        ffn: Ffn::None,
+        residual_scale: 1.0,
+    };
+
+    let model = ModelSpec {
+        dm: 256,
+        layers: vec![layer0, layer1, layer2],
+        vocab: 1000,
+        embed_scale: 1.0,
+        tied_embeddings: false,
+        final_norm: NormSpec::rms(1e-5),
+        final_logit_softcap: None,
+        positions: PositionEncoding::Scalar,
+        ngram: Some(NgramSpec {
+            orders: vec![2, 3],
+            heads: 2,
+            dim: 32,
+            table_sizes: vec![64, 64],
+            hash: HashId::new(1),
+            combine: NgramCombine::Sum,
+            inject_at: 0,
+        }),
+        mtp: None,
+        export_hidden: true,
+        eos_ids: vec![2],
+        bos_id: Some(1),
+    };
+
+    let builder = Graph::new(IrVersion::CURRENT, "synthetic-byte-model");
+    let model_graph = build_model(builder, &model).expect("model must build");
+    let summary = model_graph.summary().expect("summary must compute");
+
+    // 1. Hand-computed global dimensions and flags
+    assert_eq!(summary.vocab, 1000);
+    assert_eq!(summary.dm, 256);
+    assert_eq!(summary.hkv, 4);
+    assert_eq!(summary.tp_divisors, vec![1, 2, 4]);
+    assert!(!summary.mtp);
+    assert!(summary.export_hidden);
+
+    // 2. Embed and Head bytes: vocab * dm * sizeof(F16) = 1000 * 256 * 2 = 512,000 bytes
+    assert_eq!(summary.embed_bytes, 512_000);
+    assert_eq!(summary.head_bytes, 512_000);
+
+    // 3. N-gram table: 128 entries * 32 dim * sizeof(F16) = 8,192 bytes
+    assert_eq!(summary.ngram_table_bytes, 8_192);
+
+    // 4. Layer summaries
+    assert_eq!(summary.layers.len(), 3);
+
+    // Layer 0 assertions:
+    let l0 = &summary.layers[0];
+    assert_eq!(l0.mixer_kind, Some(MixerKind::Attention));
+    // state_per_token_bytes: hkv * ((d + dv) * 1 + 4) = 4 * ((32 + 32) * 1 + 4) = 4 * 68 = 272 bytes
+    assert_eq!(l0.state_per_token_bytes, 272);
+    assert_eq!(l0.state_per_seq_bytes, 0);
+    assert_eq!(l0.experts, None);
+
+    // Layer 1 assertions (MoE):
+    let l1 = &summary.layers[1];
+    assert_eq!(l1.mixer_kind, None);
+    assert_eq!(l1.state_per_token_bytes, 0);
+    assert_eq!(l1.state_per_seq_bytes, 0);
+    let exp = l1
+        .experts
+        .as_ref()
+        .expect("layer 1 must have expert summary");
+    assert_eq!(exp.e, 4);
+    // bytes_each = gate_up (256 * 256 * 2) + down (256 * 128 * 2) = 131,072 + 65,536 = 196,608 bytes
+    assert_eq!(exp.bytes_each, 196_608);
+
+    // Layer 2 assertions (Linear Attention):
+    let l2 = &summary.layers[2];
+    assert_eq!(l2.mixer_kind, Some(MixerKind::LinearAttention));
+    assert_eq!(l2.state_per_token_bytes, 0);
+    // state_per_seq_bytes: conv ((4-1)*256*2 = 1,536) + recurrent (4 * 16 * 16 * 4 * 2 = 8,192) = 9,728 bytes
+    assert_eq!(l2.state_per_seq_bytes, 9_728);
+
+    // 5. Total model state memory budgets
+    assert_eq!(
+        summary.total_state_per_token_bytes().expect("state totals"),
+        272
+    );
+    assert_eq!(
+        summary.total_state_per_seq_bytes().expect("state totals"),
+        9_728
+    );
+
+    // 6. Total weight bytes is > 0 and bucketed schemes are valid
+    let total_weights = summary.total_weight_bytes().expect("weight total");
+    assert!(total_weights > 0, "total weight bytes must be positive");
+    for (scheme, bytes) in &summary.layers[0].weight_bytes_by_scheme {
+        assert!(
+            matches!(scheme, SchemeKey::None),
+            "unquantized weights belong to SchemeKey::None"
+        );
+        assert!(*bytes > 0);
+    }
+}

--- a/crates/r9v-models/tests/structural.rs
+++ b/crates/r9v-models/tests/structural.rs
@@ -1,0 +1,1129 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exhaustive structural tests for all norm × mixer × ffn combinations (Spec 8 §3, §3.1; card A1.3).
+//!
+//! Verifies that the generic layer builder emits the exact Op IR structures required
+//! and that the resulting graph validates under the Op IR specification.
+
+use r9v_ir::op::{
+    ActivationKind, Epilogue, HashId, LinearAttnKind, MoeScoring, NgramCombine, Op, RopeScaling,
+    RopeStyle,
+};
+use r9v_ir::tensor::{Dim, ShapeSymbol};
+use r9v_ir::version::IrVersion;
+use r9v_ir::DType;
+use r9v_models::{
+    build_layer, build_model, CacheDtype, Ffn, Graph, GraphBuilder, LayerSpec, Mixer, MlaSpec,
+    ModelSpec, MoeGroupSpec, MoeSharedSpec, MtpSource, MtpSpec, NgramSpec, NormPlacement, NormSpec,
+    PositionEncoding, RopeSpec,
+};
+
+fn base_rope() -> RopeSpec {
+    RopeSpec {
+        theta: 10000.0,
+        rot_dim: 64,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+    }
+}
+
+fn dummy_model_spec(layers: Vec<LayerSpec>) -> ModelSpec {
+    ModelSpec {
+        dm: 512,
+        layers,
+        vocab: 1000,
+        embed_scale: 1.0,
+        tied_embeddings: false,
+        final_norm: NormSpec::rms(1e-5),
+        final_logit_softcap: None,
+        positions: PositionEncoding::Scalar,
+        ngram: None,
+        mtp: None,
+        export_hidden: false,
+        eos_ids: vec![2],
+        bos_id: Some(1),
+    }
+}
+
+/// Hand-derived expected tallies for one `build_layer` graph (Spec 8 §3.1).
+///
+/// Restated from the spec pattern, not copied from the builder, so a dropped
+/// or duplicated op, weight, or edge fails the matrix. Reshapes are edges,
+/// not nodes. Bias flags change weights and epilogues, never op counts.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct LayerTallies {
+    matmul: usize,
+    norm: usize,
+    rope: usize,
+    state_write_kv: usize,
+    attention: usize,
+    residual_add: usize,
+    act_mul: usize,
+    activation: usize,
+    moe_route: usize,
+    moe_ffn: usize,
+    causal_conv1d: usize,
+    linear_attn_scan: usize,
+    /// Bound weight edges by dtype (matmul weights F16, vectors/biases F32).
+    w_f16: usize,
+    w_f32: usize,
+    /// Op-output and reshape-view edges by dtype (externals added separately).
+    o_f16: usize,
+    o_f32: usize,
+    o_u32: usize,
+}
+
+impl LayerTallies {
+    fn total_nodes(&self) -> usize {
+        self.matmul
+            + self.norm
+            + self.rope
+            + self.state_write_kv
+            + self.attention
+            + self.residual_add
+            + self.act_mul
+            + self.activation
+            + self.moe_route
+            + self.moe_ffn
+            + self.causal_conv1d
+            + self.linear_attn_scan
+    }
+}
+
+/// Expected mixer contribution: op nodes, weight edges, and output edges.
+fn mixer_tallies(m: &Mixer) -> LayerTallies {
+    let mut t = LayerTallies::default();
+    match m {
+        Mixer::Attention {
+            qk_norm,
+            output_gate,
+            qkv_bias,
+            o_bias,
+            mla,
+            ..
+        } => {
+            let gate = usize::from(*output_gate);
+            let qkv = usize::from(*qkv_bias);
+            let ob = usize::from(*o_bias);
+            // Q/K/V/output projections, Q/K rotary pair, one cache write, one
+            // attention read, optional output gate. Reshapes (q, k, v, a) are
+            // edges; MLA reshapes (q, latent, a) likewise.
+            t.matmul = 4 + gate;
+            t.rope = 2;
+            t.state_write_kv = 1;
+            t.attention = 1;
+            t.act_mul = gate;
+            t.w_f16 = 4 + gate;
+            if mla.is_some() {
+                // The MLA path rejects qk_norm (see `LayerSpec::validate`);
+                // its biases cover the down/up projections (q_a, q_b, kv_a).
+                t.w_f32 = 3 * qkv + ob;
+                t.o_f16 = 10 + 2 * gate;
+            } else {
+                let qk = usize::from(qk_norm.is_some());
+                t.norm = 2 * qk;
+                t.w_f32 = 2 * qk + 3 * qkv + ob;
+                t.o_f16 = 11 + 2 * qk + 2 * gate;
+            }
+        }
+        Mixer::LinearAttention {
+            conv,
+            output_norm,
+            output_gate,
+            ..
+        } => {
+            let conv = usize::from(conv.is_some());
+            let on = usize::from(output_norm.is_some());
+            let gate = usize::from(*output_gate);
+            // Q/K/V/alpha/beta/output projections, one scan, optional conv,
+            // output norm, and gate. Alpha/beta matmuls emit F32.
+            t.matmul = 6 + gate;
+            t.causal_conv1d = conv;
+            t.linear_attn_scan = 1;
+            t.norm = on;
+            t.act_mul = gate;
+            t.w_f16 = 6 + gate;
+            t.w_f32 = conv + on;
+            t.o_f16 = 9 + conv + on + 2 * gate;
+            t.o_f32 = 2;
+        }
+        Mixer::None => {}
+    }
+    t
+}
+
+/// Expected FFN contribution: op nodes, weight edges, and output edges.
+fn ffn_tallies(f: &Ffn) -> LayerTallies {
+    let mut t = LayerTallies::default();
+    match f {
+        Ffn::Dense { gated, bias, .. } => {
+            if *gated {
+                t.matmul = 3;
+                t.act_mul = 1;
+                t.w_f16 = 3;
+                // Gated bias lowers as bias epilogues on gate and up.
+                t.w_f32 = 2 * usize::from(*bias);
+                t.o_f16 = 4;
+            } else {
+                t.matmul = 2;
+                t.activation = 1;
+                t.w_f16 = 2;
+                t.w_f32 = usize::from(*bias);
+                t.o_f16 = 3;
+            }
+        }
+        Ffn::Moe {
+            route_bias,
+            shared,
+            shared_gate,
+            ..
+        } => {
+            // Router matmul (F32 logits), route, expert execution, plus an
+            // optional shared-expert path combined by residual_add.
+            let shared_gate = usize::from(*shared_gate);
+            t.matmul = 1;
+            t.moe_route = 1;
+            t.moe_ffn = 1;
+            t.w_f16 = 3;
+            t.w_f32 = usize::from(*route_bias);
+            t.o_f16 = 1;
+            t.o_f32 = 2;
+            t.o_u32 = 1;
+            if shared.is_some() {
+                t.matmul += 3 + shared_gate;
+                t.act_mul += 1 + shared_gate;
+                t.residual_add += 1;
+                t.w_f16 += 3 + shared_gate;
+                t.o_f16 += 5 + 2 * shared_gate;
+            }
+        }
+        Ffn::None => {}
+    }
+    t
+}
+
+/// Full expected tallies for one layer graph, including placement norms and
+/// residuals plus the three external inputs (embed F16, mask Bool, tokens U32).
+fn expected_layer(norm: NormPlacement, mixer: &Mixer, ffn: &Ffn) -> LayerTallies {
+    let m = mixer_tallies(mixer);
+    let f = ffn_tallies(ffn);
+    let has_mixer = *mixer != Mixer::None;
+    let has_ffn = *ffn != Ffn::None;
+    let (n_norms, n_res) = match norm {
+        NormPlacement::Pre => (
+            usize::from(has_mixer) + usize::from(has_ffn),
+            usize::from(has_mixer) + usize::from(has_ffn),
+        ),
+        NormPlacement::Sandwich => (
+            2 * usize::from(has_mixer) + 2 * usize::from(has_ffn),
+            usize::from(has_mixer) + usize::from(has_ffn),
+        ),
+        NormPlacement::Parallel => (1, usize::from(has_mixer) + usize::from(has_ffn)),
+    };
+    LayerTallies {
+        matmul: m.matmul + f.matmul,
+        norm: m.norm + f.norm + n_norms,
+        rope: m.rope,
+        state_write_kv: m.state_write_kv,
+        attention: m.attention,
+        residual_add: m.residual_add + f.residual_add + n_res,
+        act_mul: m.act_mul + f.act_mul,
+        activation: f.activation,
+        moe_route: f.moe_route,
+        moe_ffn: f.moe_ffn,
+        causal_conv1d: m.causal_conv1d,
+        linear_attn_scan: m.linear_attn_scan,
+        w_f16: m.w_f16 + f.w_f16,
+        w_f32: m.w_f32 + f.w_f32 + n_norms,
+        o_f16: m.o_f16 + f.o_f16 + n_norms + n_res,
+        o_f32: m.o_f32 + f.o_f32,
+        o_u32: m.o_u32 + f.o_u32,
+    }
+}
+
+/// Actual op-node tallies folded from a built graph; any unexpected op kind
+/// fails the caller via the returned `other` count.
+fn actual_nodes(graph: &r9v_models::ModelGraph) -> (LayerTallies, usize) {
+    let mut t = LayerTallies::default();
+    let mut other = 0usize;
+    for node in graph.graph().nodes() {
+        match &node.op {
+            Op::Matmul(_) => t.matmul += 1,
+            Op::Norm(_) => t.norm += 1,
+            Op::Rope(_) => t.rope += 1,
+            Op::StateWriteKv(_) => t.state_write_kv += 1,
+            Op::Attention(_) => t.attention += 1,
+            Op::ResidualAdd(_) => t.residual_add += 1,
+            Op::ActMul(_) => t.act_mul += 1,
+            Op::Activation(_) => t.activation += 1,
+            Op::MoeRoute(_) => t.moe_route += 1,
+            Op::MoeFfn(_) => t.moe_ffn += 1,
+            Op::CausalConv1d(_) => t.causal_conv1d += 1,
+            Op::LinearAttnScan(_) => t.linear_attn_scan += 1,
+            _ => other += 1,
+        }
+    }
+    (t, other)
+}
+
+/// Actual edge-dtype histogram folded from a built graph.
+fn actual_dtypes(graph: &r9v_models::ModelGraph) -> (usize, usize, usize, usize, usize) {
+    let (mut f16, mut f32, mut u32, mut bool, mut other) = (0, 0, 0, 0, 0);
+    for edge in graph.graph().edges() {
+        match edge.tensor.dtype() {
+            DType::F16 => f16 += 1,
+            DType::F32 => f32 += 1,
+            DType::U32 => u32 += 1,
+            DType::Bool => bool += 1,
+            _ => other += 1,
+        }
+    }
+    (f16, f32, u32, bool, other)
+}
+
+/// Asserts exact per-op counts for one matrix cell.
+fn assert_op_counts(actual: &LayerTallies, expected: &LayerTallies, tag: &str) {
+    assert_eq!(actual.matmul, expected.matmul, "matmul nodes for {tag}");
+    assert_eq!(actual.norm, expected.norm, "norm nodes for {tag}");
+    assert_eq!(actual.rope, expected.rope, "rope nodes for {tag}");
+    assert_eq!(
+        actual.state_write_kv, expected.state_write_kv,
+        "state_write_kv nodes for {tag}"
+    );
+    assert_eq!(
+        actual.attention, expected.attention,
+        "attention nodes for {tag}"
+    );
+    assert_eq!(
+        actual.residual_add, expected.residual_add,
+        "residual_add nodes for {tag}"
+    );
+    assert_eq!(actual.act_mul, expected.act_mul, "act_mul nodes for {tag}");
+    assert_eq!(
+        actual.activation, expected.activation,
+        "activation nodes for {tag}"
+    );
+    assert_eq!(
+        actual.moe_route, expected.moe_route,
+        "moe_route nodes for {tag}"
+    );
+    assert_eq!(actual.moe_ffn, expected.moe_ffn, "moe_ffn nodes for {tag}");
+    assert_eq!(
+        actual.causal_conv1d, expected.causal_conv1d,
+        "causal_conv1d nodes for {tag}"
+    );
+    assert_eq!(
+        actual.linear_attn_scan, expected.linear_attn_scan,
+        "linear_attn_scan nodes for {tag}"
+    );
+    assert_eq!(
+        actual.total_nodes(),
+        expected.total_nodes(),
+        "total nodes for {tag}"
+    );
+}
+
+#[test]
+fn test_exhaustive_layer_combinations_matrix() {
+    let norm_placements = [
+        NormPlacement::Pre,
+        NormPlacement::Sandwich,
+        NormPlacement::Parallel,
+    ];
+
+    let mixers = [
+        // 1. Standard Attention
+        Mixer::Attention {
+            h: 8,
+            hkv: 4,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        // 2. Attention with MLA
+        Mixer::Attention {
+            h: 8,
+            hkv: 1,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: Some(MlaSpec {
+                q_lora_rank: 128,
+                kv_lora_rank: 64,
+                qk_nope_dim: 32,
+                qk_rope_dim: 32,
+                v_dim: 64,
+            }),
+            cache: CacheDtype::E4m3,
+        },
+        // 3. Attention with output_gate
+        Mixer::Attention {
+            h: 8,
+            hkv: 4,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: true,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        // 4. Attention with qk_norm
+        Mixer::Attention {
+            h: 8,
+            hkv: 4,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: Some(NormSpec::rms(1e-5)),
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        // 5. Attention with window + sinks + logit_softcap
+        Mixer::Attention {
+            h: 8,
+            hkv: 4,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: Some(512),
+            sinks: 4,
+            logit_softcap: Some(50.0),
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::F16,
+        },
+        // 6. LinearAttention with Conv + output_norm + output_gate
+        Mixer::LinearAttention {
+            kind: LinearAttnKind::GatedDeltaNet,
+            h: 4,
+            d: 32,
+            dv: 32,
+            conv: Some(4),
+            gate_act: ActivationKind::Silu,
+            output_norm: Some(NormSpec::rms(1e-5)),
+            output_gate: true,
+        },
+        // 7. LinearAttention without conv
+        Mixer::LinearAttention {
+            kind: LinearAttnKind::Mamba2,
+            h: 4,
+            d: 32,
+            dv: 32,
+            conv: None,
+            gate_act: ActivationKind::Silu,
+            output_norm: None,
+            output_gate: false,
+        },
+        // 8. Mixer::None
+        Mixer::None,
+    ];
+
+    let ffns = [
+        // 1. Dense gated
+        Ffn::Dense {
+            dff: 1024,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        // 2. Dense ungated with bias
+        Ffn::Dense {
+            dff: 1024,
+            act: ActivationKind::Gelu,
+            gated: false,
+            bias: true,
+        },
+        // 3. Moe with shared experts + shared gate + group
+        Ffn::Moe {
+            e: 8,
+            k: 2,
+            dff_e: 512,
+            act: ActivationKind::Silu,
+            scoring: MoeScoring::Softmax,
+            renormalize: true,
+            group: Some(MoeGroupSpec {
+                n_group: 2,
+                topk_group: 1,
+            }),
+            route_bias: true,
+            route_scale: 1.0,
+            shared: Some(MoeSharedSpec { n: 1, dff: 512 }),
+            shared_gate: true,
+        },
+        // 4. Moe standard without shared
+        Ffn::Moe {
+            e: 4,
+            k: 1,
+            dff_e: 256,
+            act: ActivationKind::Silu,
+            scoring: MoeScoring::Sigmoid,
+            renormalize: false,
+            group: None,
+            route_bias: false,
+            route_scale: 2.0,
+            shared: None,
+            shared_gate: false,
+        },
+        // 5. Ffn::None
+        Ffn::None,
+    ];
+
+    let mut tested_combinations = 0;
+
+    for norm in norm_placements {
+        for (m_idx, mixer) in mixers.iter().enumerate() {
+            for (f_idx, ffn) in ffns.iter().enumerate() {
+                // Skip combinations where both mixer and ffn are None
+                if *mixer == Mixer::None && *ffn == Ffn::None {
+                    continue;
+                }
+
+                let expected = expected_layer(norm, mixer, ffn);
+                let tag = format!("norm={norm:?}, mixer={m_idx}, ffn={f_idx}");
+
+                let layer_spec = LayerSpec {
+                    norm,
+                    norm_kind: NormSpec::rms(1e-5),
+                    mixer: mixer.clone(),
+                    ffn: ffn.clone(),
+                    residual_scale: 1.0,
+                };
+
+                let model = dummy_model_spec(vec![layer_spec.clone()]);
+                let mut builder = GraphBuilder::new(
+                    IrVersion::CURRENT,
+                    format!("test-norm-{norm:?}-m{m_idx}-f{f_idx}"),
+                );
+
+                let (x, _) = builder.input_embed_override(model.dm).unwrap();
+                let _ = builder.input_tokens().unwrap();
+
+                let out = build_layer(&mut builder, 0, &layer_spec, x, &model);
+                assert!(out.is_ok(), "build_layer failed for {tag}: {:?}", out.err());
+
+                let model_graph = builder
+                    .finish()
+                    .unwrap_or_else(|e| panic!("builder.finish() failed for {tag}: {e:?}"));
+
+                // Exact op counts per §3.1: no missing, duplicated, or alien ops.
+                let (actual, other) = actual_nodes(&model_graph);
+                assert_eq!(other, 0, "unexpected op kind for {tag}");
+                assert_op_counts(&actual, &expected, &tag);
+
+                // Exact edge-dtype table: weights + op outputs + reshape views
+                // + the three external inputs (embed F16, mask Bool, tokens U32).
+                let (f16, f32, u32, boolean, other_dt) = actual_dtypes(&model_graph);
+                assert_eq!(other_dt, 0, "unexpected edge dtype for {tag}");
+                assert_eq!(
+                    f16,
+                    expected.o_f16 + expected.w_f16 + 1,
+                    "F16 edge count for {tag}"
+                );
+                assert_eq!(
+                    f32,
+                    expected.o_f32 + expected.w_f32,
+                    "F32 edge count for {tag}"
+                );
+                assert_eq!(u32, expected.o_u32 + 1, "U32 edge count for {tag}");
+                assert_eq!(boolean, 1, "Bool edge count for {tag}");
+
+                tested_combinations += 1;
+            }
+        }
+    }
+
+    // 3 norm placements * (8 mixers * 5 ffns - 1 both none) = 3 * 39 = 117 combinations
+    assert_eq!(tested_combinations, 117);
+}
+
+#[test]
+fn test_ngram_speculative_injection() {
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::Attention {
+            h: 4,
+            hkv: 2,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        ffn: Ffn::Dense {
+            dff: 512,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+
+    let mut model = dummy_model_spec(vec![layer.clone(), layer.clone()]);
+    model.ngram = Some(NgramSpec {
+        orders: vec![2, 3],
+        heads: 2,
+        dim: 32,
+        table_sizes: vec![1024, 2048],
+        hash: HashId::new(1),
+        combine: NgramCombine::Sum,
+        inject_at: 1,
+    });
+
+    let builder = Graph::new(IrVersion::CURRENT, "test-ngram");
+    let model_graph = build_model(builder, &model).expect("ngram model must build successfully");
+
+    // Verify NgramGatherOp is present in the graph
+    let has_ngram_gather = model_graph
+        .graph()
+        .nodes()
+        .iter()
+        .any(|node| matches!(node.op, r9v_ir::op::Op::NgramGather(_)));
+    assert!(has_ngram_gather, "graph must contain NgramGatherOp");
+
+    // Verify ngram table weight was bound
+    let has_ngram_table = model_graph
+        .bound_weights()
+        .iter()
+        .any(|w| w.role == r9v_models::WeightRole::NgramTable);
+    assert!(has_ngram_table, "must contain bound NgramTable weight");
+}
+
+#[test]
+fn test_multi_token_prediction_subgraph() {
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::Attention {
+            h: 4,
+            hkv: 2,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        ffn: Ffn::Dense {
+            dff: 512,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+
+    let mut model = dummy_model_spec(vec![layer.clone()]);
+    model.mtp = Some(MtpSpec {
+        heads: 2,
+        layers_per_head: vec![layer.clone()],
+        takes_hidden_from: MtpSource::Last,
+    });
+
+    let builder = Graph::new(IrVersion::CURRENT, "test-mtp");
+    let model_graph = build_model(builder, &model).expect("mtp model must build successfully");
+
+    assert!(
+        model_graph.subgraphs().contains_key("mtp"),
+        "model graph must register mtp subgraph"
+    );
+    let mtp_subgraph = &model_graph.subgraphs()["mtp"];
+    assert!(
+        mtp_subgraph
+            .exports()
+            .iter()
+            .any(|(name, _)| name == "mtp_logits_1"),
+        "mtp subgraph must export mtp_logits_1"
+    );
+    assert!(
+        mtp_subgraph
+            .exports()
+            .iter()
+            .any(|(name, _)| name == "mtp_logits_2"),
+        "mtp subgraph must export mtp_logits_2"
+    );
+
+    // Every subgraph weight lives in the `blk.N.mtp.*` namespace (Spec 8 §5).
+    let sub_names: Vec<&str> = mtp_subgraph
+        .bound_weights()
+        .iter()
+        .map(|w| w.name.as_str())
+        .collect();
+    assert!(
+        sub_names.iter().all(|n| n.contains(".mtp.")),
+        "all MTP weights must use the mtp namespace: {sub_names:?}"
+    );
+    let mut unique = sub_names.clone();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        sub_names.len(),
+        "MTP head weights must be independent, not shared: {sub_names:?}"
+    );
+    assert!(
+        sub_names.contains(&"blk.0.mtp.output.weight"),
+        "head 1 output weight: {sub_names:?}"
+    );
+    assert!(
+        sub_names.contains(&"blk.1.mtp.output.weight"),
+        "head 2 output weight: {sub_names:?}"
+    );
+    // No phantom layers: two ordinals built, two layers summarized.
+    assert_eq!(mtp_subgraph.summary().expect("mtp summary").layers.len(), 2);
+    assert_eq!(
+        model_graph.summary().expect("model summary").layers.len(),
+        1
+    );
+}
+
+#[test]
+fn test_tied_embeddings_and_fusions() {
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::Attention {
+            h: 4,
+            hkv: 2,
+            d: 64,
+            dv: 64,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: base_rope(),
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        ffn: Ffn::Dense {
+            dff: 512,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+
+    let mut model = dummy_model_spec(vec![layer]);
+    model.tied_embeddings = true;
+    model.export_hidden = true;
+
+    let builder = Graph::new(IrVersion::CURRENT, "test-tied");
+    let model_graph = build_model(builder, &model).expect("model must build successfully");
+
+    // Verify tied embeddings declaration
+    assert_eq!(model_graph.tied_decls().len(), 1);
+    assert_eq!(model_graph.tied_decls()[0].embed_name, "token_embd.weight");
+    assert_eq!(model_graph.tied_decls()[0].head_name, "output.weight");
+
+    // Verify fusion declarations: Qkv and GateUp
+    assert!(model_graph
+        .fusion_decls()
+        .iter()
+        .any(|f| matches!(f, r9v_models::FusionDecl::Qkv { .. })));
+    assert!(model_graph
+        .fusion_decls()
+        .iter()
+        .any(|f| matches!(f, r9v_models::FusionDecl::GateUp { .. })));
+
+    // Verify exports
+    assert!(model_graph
+        .exports()
+        .iter()
+        .any(|(name, _)| name == "hidden"));
+    assert!(model_graph
+        .exports()
+        .iter()
+        .any(|(name, _)| name == "logits"));
+}
+
+/// Attention bias flags bind canonical GGUF-convention bias weights and lower
+/// through the matmul bias epilogue without changing op counts (Spec 8 §3).
+#[test]
+fn test_attention_bias_weights_and_epilogues() {
+    let bias_rope = RopeSpec {
+        theta: 10000.0,
+        rot_dim: 32,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+    };
+    let biased_mixer = || Mixer::Attention {
+        h: 4,
+        hkv: 2,
+        d: 32,
+        dv: 32,
+        qkv_bias: true,
+        o_bias: true,
+        qk_norm: None,
+        rope: bias_rope.clone(),
+        window: None,
+        sinks: 0,
+        logit_softcap: None,
+        output_gate: false,
+        mla: None,
+        cache: CacheDtype::E4m3,
+    };
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: biased_mixer(),
+        ffn: Ffn::Dense {
+            dff: 128,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+    let model = dummy_model_spec(vec![layer]);
+    let graph = build_model(Graph::new(IrVersion::CURRENT, "test-bias"), &model)
+        .expect("biased model must build");
+
+    // Exact op counts match the unbiased pattern; biases ride the epilogue.
+    // A full model adds the embedding lookup, the final norm, and the LM head
+    // around the layer pattern.
+    let mut expected = expected_layer(
+        NormPlacement::Pre,
+        &biased_mixer(),
+        &Ffn::Dense {
+            dff: 128,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+    );
+    expected.matmul += 1;
+    expected.norm += 1;
+    let (actual, other) = actual_nodes(&graph);
+    assert_eq!(other, 1, "only the embedding lookup is outside the tallies");
+    assert_eq!(
+        graph
+            .graph()
+            .nodes()
+            .iter()
+            .filter(|n| matches!(&n.op, Op::EmbedGather(_)))
+            .count(),
+        1,
+        "the uncounted node is the embedding lookup"
+    );
+    assert_op_counts(&actual, &expected, "biased attention");
+
+    // Canonical bias weights with exact shapes and F32 vector dtype.
+    for (name, dim) in [
+        ("blk.0.attn_q.bias", 128u32),
+        ("blk.0.attn_k.bias", 64u32),
+        ("blk.0.attn_v.bias", 64u32),
+        ("blk.0.attn_output.bias", 512u32),
+    ] {
+        let w = graph
+            .bound_weights()
+            .iter()
+            .find(|w| w.name == name)
+            .unwrap_or_else(|| panic!("missing bias weight {name}"));
+        assert_eq!(w.shape, vec![Dim::Concrete(dim)], "shape of {name}");
+        assert_eq!(w.tensor.dtype(), DType::F32, "dtype of {name}");
+    }
+
+    // Exactly the Q/K/V/output projections carry the bias epilogue.
+    let mut bias_epilogues = 0;
+    let mut plain = 0;
+    for node in graph.graph().nodes() {
+        if let Op::Matmul(m) = &node.op {
+            match m.epilogue {
+                Epilogue::Bias => bias_epilogues += 1,
+                Epilogue::None => plain += 1,
+                _ => panic!("unexpected matmul epilogue {:?}", m.epilogue),
+            }
+        }
+    }
+    assert_eq!(bias_epilogues, 4, "q, k, v, and output projections");
+    assert!(plain > 0, "ffn projections stay epilogue-free");
+
+    // Negative case: flags off binds no bias weights and no Bias epilogue.
+    let plain_mixer = Mixer::Attention {
+        h: 4,
+        hkv: 2,
+        d: 32,
+        dv: 32,
+        qkv_bias: false,
+        o_bias: false,
+        qk_norm: None,
+        rope: bias_rope,
+        window: None,
+        sinks: 0,
+        logit_softcap: None,
+        output_gate: false,
+        mla: None,
+        cache: CacheDtype::E4m3,
+    };
+    let plain_layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: plain_mixer,
+        ffn: Ffn::Dense {
+            dff: 128,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+    let plain_model = dummy_model_spec(vec![plain_layer]);
+    let plain_graph = build_model(Graph::new(IrVersion::CURRENT, "test-nobias"), &plain_model)
+        .expect("unbiased model must build");
+    assert!(
+        plain_graph
+            .bound_weights()
+            .iter()
+            .all(|w| !w.name.ends_with(".bias")),
+        "no bias weights when flags are off"
+    );
+    assert!(
+        plain_graph.graph().nodes().iter().all(|n| !matches!(
+            &n.op,
+            Op::Matmul(m) if m.epilogue == Epilogue::Bias
+        )),
+        "no Bias epilogue when flags are off"
+    );
+}
+
+/// MLA with query/value dimensions that differ must build, validate, and emit
+/// an attention output of head dim `v_dim` (Spec 1 §4.D; Spec 8 §3).
+#[test]
+fn test_mla_unequal_dims_and_bias() {
+    let mla_rope = RopeSpec {
+        theta: 10000.0,
+        rot_dim: 32,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+    };
+    let mixer = Mixer::Attention {
+        h: 4,
+        hkv: 1,
+        d: 32,
+        dv: 32,
+        qkv_bias: true,
+        o_bias: true,
+        qk_norm: None,
+        rope: mla_rope,
+        window: None,
+        sinks: 0,
+        logit_softcap: None,
+        output_gate: false,
+        mla: Some(MlaSpec {
+            q_lora_rank: 32,
+            kv_lora_rank: 16,
+            qk_nope_dim: 16,
+            qk_rope_dim: 16,
+            v_dim: 48,
+        }),
+        cache: CacheDtype::E4m3,
+    };
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: mixer.clone(),
+        ffn: Ffn::None,
+        residual_scale: 1.0,
+    };
+    let model = dummy_model_spec(vec![layer]);
+    // Unequal qk (16 + 16) and v (48) dims previously failed IR validation
+    // (`o head dim 32 != v_dim 48`); the builder now emits `[T, H, v_dim]`.
+    let graph = build_model(Graph::new(IrVersion::CURRENT, "test-mla-unequal"), &model)
+        .expect("unequal-dim MLA model must build and validate");
+
+    let mut expected = expected_layer(NormPlacement::Pre, &mixer, &Ffn::None);
+    expected.matmul += 1;
+    expected.norm += 1;
+    let (actual, other) = actual_nodes(&graph);
+    assert_eq!(other, 1, "only the embedding lookup is outside the tallies");
+    assert_op_counts(&actual, &expected, "unequal-dim mla");
+
+    // The single attention op carries v_dim and emits a v_dim head.
+    let mut attentions = 0;
+    for node in graph.graph().nodes() {
+        if let Op::Attention(a) = &node.op {
+            attentions += 1;
+            let mla = a.mla.as_ref().expect("mla config on attention op");
+            assert_eq!(mla.v_dim, 48);
+            let out_id = node.outputs.first().expect("attention output edge");
+            let out_shape = graph.graph().edges()[out_id.0].tensor.shape().to_vec();
+            assert_eq!(
+                out_shape,
+                vec![
+                    Dim::Symbolic(ShapeSymbol::T),
+                    Dim::Concrete(4),
+                    Dim::Concrete(48),
+                ],
+                "attention output is [T, H, v_dim]"
+            );
+        }
+    }
+    assert_eq!(attentions, 1);
+
+    // Up/down projections reflect the split dimensions.
+    for (name, rows, cols) in [
+        ("blk.0.attn_q_b.weight", 128u32, 32u32),
+        ("blk.0.attn_output.weight", 512u32, 192u32),
+    ] {
+        let w = graph
+            .bound_weights()
+            .iter()
+            .find(|w| w.name == name)
+            .unwrap_or_else(|| panic!("missing weight {name}"));
+        assert_eq!(
+            w.shape,
+            vec![Dim::Concrete(rows), Dim::Concrete(cols)],
+            "shape of {name}"
+        );
+    }
+    for name in [
+        "blk.0.attn_q_a.bias",
+        "blk.0.attn_q_b.bias",
+        "blk.0.attn_kv_a.bias",
+        "blk.0.attn_output.bias",
+    ] {
+        assert!(
+            graph.bound_weights().iter().any(|w| w.name == name),
+            "missing MLA bias weight {name}"
+        );
+    }
+    // Latent cache reports a single stream instead of hkv 0.
+    assert_eq!(graph.summary().expect("mla summary").hkv, 1);
+}
+
+/// MTP heads bind disjoint, complete per-head weight sets in their own
+/// ordinal namespace instead of sharing or chaining weights (Spec 8 §2, §5).
+///
+/// Edge-level capture identity (which physical edge each head reads) is
+/// A1.14's scope: `GraphBuilder` resolves tensors by descriptor equality, so
+/// same-shaped activations alias until SSA identity lands there.
+#[test]
+fn test_mtp_heads_bind_disjoint_weights() {
+    let mtp_rope = RopeSpec {
+        theta: 10000.0,
+        rot_dim: 32,
+        style: RopeStyle::Neox,
+        scaling: RopeScaling::None,
+        mrope_sections: None,
+    };
+    let layer = LayerSpec {
+        norm: NormPlacement::Pre,
+        norm_kind: NormSpec::rms(1e-5),
+        mixer: Mixer::Attention {
+            h: 4,
+            hkv: 2,
+            d: 32,
+            dv: 32,
+            qkv_bias: false,
+            o_bias: false,
+            qk_norm: None,
+            rope: mtp_rope,
+            window: None,
+            sinks: 0,
+            logit_softcap: None,
+            output_gate: false,
+            mla: None,
+            cache: CacheDtype::E4m3,
+        },
+        ffn: Ffn::Dense {
+            dff: 64,
+            act: ActivationKind::Silu,
+            gated: true,
+            bias: false,
+        },
+        residual_scale: 1.0,
+    };
+    let mut model = dummy_model_spec(vec![layer.clone()]);
+    model.dm = 64;
+    model.mtp = Some(MtpSpec {
+        heads: 2,
+        layers_per_head: vec![layer],
+        takes_hidden_from: MtpSource::Last,
+    });
+    let graph = build_model(Graph::new(IrVersion::CURRENT, "test-mtp-shared"), &model)
+        .expect("mtp model must build");
+    let sub = &graph.subgraphs()["mtp"];
+
+    // Each head owns a complete layer's weights under its own ordinal; the
+    // two sets are disjoint, so no head reuses the other's projections.
+    let names: Vec<&str> = sub
+        .bound_weights()
+        .iter()
+        .map(|w| w.name.as_str())
+        .collect();
+    for head in [0u32, 1u32] {
+        for leaf in [
+            "attn_norm.weight",
+            "attn_q.weight",
+            "attn_k.weight",
+            "attn_v.weight",
+            "attn_output.weight",
+            "ffn_norm.weight",
+            "ffn_gate.weight",
+            "ffn_up.weight",
+            "ffn_down.weight",
+            "output.weight",
+        ] {
+            let name = format!("blk.{head}.mtp.{leaf}");
+            assert!(
+                names.contains(&name.as_str()),
+                "head {head} owns {name}: {names:?}"
+            );
+        }
+    }
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), 20, "two disjoint complete sets: {names:?}");
+    assert_eq!(names.len(), 20, "no extra weights beyond the two heads");
+}


### PR DESCRIPTION
## Card
A1.3 — models builder   (kind: API + implementation; GPU: no; size: L)

## Spec sections implemented
- spec 8 §2: sealed pure graph builder, typed weight/state binding, graph exports, tied weights, and fusion declarations.
- spec 8 §3, §3.1: generic transformer-layer lowering across norm, mixer, FFN, MLA, linear-attention, MoE, output-gate, and n-gram combinations.
- spec 8 §5: MTP subgraph construction and dedicated weight namespaces.
- spec 8 §7: deterministic checked model summaries for planner and partitioner inputs.

## Deliverables
- [x] Sealed `GraphBuilder` and typed `GgufMeta` boundary.
- [x] `LayerSpec`, `Mixer`, `Ffn`, `ModelSpec`, `NormPlacement`, `RopeSpec`, `MlaSpec`, `MtpSpec`, and `NgramSpec`.
- [x] Generic layer builder for every norm-placement × mixer × FFN structural combination.
- [x] Linear attention, MoE, MLA, output gate, n-gram injection, and MTP subgraphs.
- [x] Fusion, tied-weight, export, and deterministic summary APIs.
- [x] Checked arithmetic, bounded untrusted dimensions, and collect-all typed validation.
- [x] Cross-crate graph-value cohesion gaps are isolated in follow-up card A1.14 and merge immediately after this card.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| exhaustive structural combination matrix with exact op counts and dtypes | crates/r9v-models/tests/structural.rs | cpu-only | green |
| hand-computed synthetic model byte summary | crates/r9v-models/tests/byte_summary.rs | cpu-only | green |
| public API shape and trait bounds | crates/r9v-models/tests/api_shape.rs | cpu-only | green |
| overflow, allocation-bound, and exact-lowering adversarial cases | crates/r9v-models/tests/adversarial.rs | cpu-only | green |

## Decisions
- crates/r9v-models/src/builder.rs:33 — seal `GraphBuilder` so graph construction remains controlled and pure.
- crates/r9v-models/src/builder.rs:1263 — report one KV stream for pure MLA summaries rather than zero or query-head count.
- crates/r9v-models/src/generic.rs:149 — represent MTP heads as dedicated named subgraphs rather than flattening them into the base layer sequence.
- crates/r9v-models/src/generic.rs:954 — lower gated dense bias on both gate and up projection epilogues.
- crates/r9v-models/src/meta.rs:17 — borrow scalar metadata strings while returning owned arrays instead of a dynamic value enum.
- crates/r9v-models/src/spec.rs:27 — enforce wide power-of-two implementation caps on allocation and loop dimensions.
- crates/r9v-models/src/spec.rs:266 — keep provisional state descriptors in `r9v-models` until A1.11 owns runtime state.
- crates/r9v-models/src/spec.rs:868 — carry the n-gram row dimension Dn explicitly instead of hardcoding 32 or inferring it from unbound weights.
- crates/r9v-models/src/summary.rs:12 — use ordered scheme keys for deterministic summary iteration.

## SPEC-ISSUES filed
- SI-16: Spec 8 omits the n-gram row dimension Dn required by Spec 1 to shape table and projection tensors; `NgramSpec::dim` supplies it explicitly.

## New dependencies
- r9v-ir: existing workspace crate consumed for typed graph and operation contracts.
- thiserror: existing workspace dependency consumed for structured model-builder errors.

## Hardware
Tests run here: hosted cpu-only plus existing stub-device workspace tests
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command `cargo test --workspace`, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- Cross-crate SSA identity, typed positions projection, exact MTP capture wiring, full MLA split/state semantics, and scale/softcap lowering are intentionally assigned to A1.14; that cohesion card merges immediately after A1.3 and before A1.4 or any graph consumer begins.
- Performance receipt: no; this is a CPU-only API and structural-lowering card with no performance gate.

## Size check
Diff size vs card size class: 6,681 changed lines vs L — consistent with the card's exhaustive builder surface, typed validation, summaries, and structural/adversarial test matrix.
