### PR TITLE
ci: ignore generated merge commits in DCO checks

### DIFF
--- a/.github/workflows/cpu-only.yml
+++ b/.github/workflows/cpu-only.yml
@@ -33,24 +33,24 @@ jobs:
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
             echo "Pull request check: $BASE_SHA..$HEAD_SHA"
-            COMMITS=$(git rev-list "$BASE_SHA..$HEAD_SHA")
+            COMMITS=$(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
           elif [ "${{ github.event_name }}" = "push" ]; then
             BEFORE="${{ github.event.before }}"
             if [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && git rev-parse --verify "$BEFORE" >/dev/null 2>&1; then
               echo "Push check: $BEFORE..HEAD"
-              COMMITS=$(git rev-list "$BEFORE..HEAD")
+              COMMITS=$(git rev-list --no-merges "$BEFORE..HEAD")
             elif git rev-parse --verify origin/main >/dev/null 2>&1 && [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
               echo "Push check against origin/main: origin/main..HEAD"
-              COMMITS=$(git rev-list origin/main..HEAD)
+              COMMITS=$(git rev-list --no-merges origin/main..HEAD)
             else
               echo "Push check single commit: HEAD"
-              COMMITS=$(git rev-list -n 1 HEAD)
+              COMMITS=$(git rev-list --no-merges -n 1 HEAD)
             fi
           else
             if git rev-parse --verify origin/main >/dev/null 2>&1 && [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
-              COMMITS=$(git rev-list origin/main..HEAD)
+              COMMITS=$(git rev-list --no-merges origin/main..HEAD)
             else
-              COMMITS=$(git rev-list -n 1 HEAD)
+              COMMITS=$(git rev-list --no-merges -n 1 HEAD)
             fi
           fi
 


### PR DESCRIPTION
## Defect

`ci/cpu-only` rejected pushes to `main` because GitHub-generated merge commits do not carry a DCO trailer, even when every authored commit in the merge is signed off.

## Fix

- Enumerate DCO ranges with `git rev-list --no-merges` on pull-request, push, and fallback paths.
- Continue checking every non-merge authored commit for `Signed-off-by:`.
- Leave specs, roadmap, decisions, and orchestration documents unchanged.

## Verification

- Historical `94c5ae8..3b2c296`: now checks signed authored commit `c9d1671` and ignores unsigned GitHub merge commit `3b2c296`.
- Synthetic unsigned merge over signed authored commits: passes.
- Synthetic unsigned non-merge authored commit: fails.
- YAML and extracted-shell syntax: pass.
- Workspace tests, strict clippy, docs, cargo-deny, codegen diff, assembly/unsafe scans, and card-checker tests: pass.

## DCO

The implementation commit is signed and includes a `Signed-off-by` trailer.
