### PR TITLE
A1.8: harden sampling and typed T0 failures

### DIFF
--- a/crates/r9v-t0/src/act_mul.rs
+++ b/crates/r9v-t0/src/act_mul.rs
@@ -5,7 +5,7 @@ use r9v_ir::{ActMulOp, DType};
 
 use crate::activation::{eval_activation_f32, eval_activation_f64};
 use crate::buffer::{TensorView, TensorViewMut};
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 gated activation product: `y = act(gate) * up` (Spec 1 §4.B, Spec 1 §6.4, Spec 4 §2).
 pub fn act_mul(
@@ -21,67 +21,67 @@ pub fn act_mul(
     let mut problems = Vec::new();
 
     if gate.rank() != 2 {
-        problems.push(format!(
-            "operand gate: expected rank 2 [T, Dff], got rank {} with shape {:?}",
-            gate.rank(),
-            gate.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "gate",
+            expected: 2,
+            got: gate.rank(),
+            shape: gate.shape().to_vec(),
+        });
     }
     if up.rank() != 2 {
-        problems.push(format!(
-            "operand up: expected rank 2 [T, Dff], got rank {} with shape {:?}",
-            up.rank(),
-            up.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "up",
+            expected: 2,
+            got: up.rank(),
+            shape: up.shape().to_vec(),
+        });
     }
     if y.rank() != 2 {
-        problems.push(format!(
-            "output y: expected rank 2 [T, Dff], got rank {} with shape {:?}",
-            y.rank(),
-            y.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
     }
     if !matches!(gate.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "operand gate: expected f16, bf16, or f32, got {:?}",
-            gate.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "gate",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: gate.dtype(),
+        });
     }
     if up.dtype() != gate.dtype() {
-        problems.push(format!(
-            "operand up dtype {:?} does not match gate dtype {:?}",
-            up.dtype(),
-            gate.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "up",
+            expected: vec![gate.dtype()],
+            got: up.dtype(),
+        });
     }
     if y.dtype() != gate.dtype() {
-        problems.push(format!(
-            "output y dtype {:?} does not match gate dtype {:?}",
-            y.dtype(),
-            gate.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![gate.dtype()],
+            got: y.dtype(),
+        });
     }
     if gate.rank() == 2 && up.rank() == 2 && gate.shape() != up.shape() {
-        problems.push(format!(
-            "operand up shape {:?} does not match gate shape {:?}",
-            up.shape(),
-            gate.shape()
-        ));
+        push_shape_agreement(&mut problems, "up", "gate", up.shape(), gate.shape());
     }
     if gate.rank() == 2 && y.rank() == 2 && gate.shape() != y.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match gate shape {:?}",
-            y.shape(),
-            gate.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "gate", y.shape(), gate.shape());
     }
     if let Some(c) = op.clamp {
         if !c.is_finite() || c <= 0.0 {
-            problems.push(format!("clamp must be finite and > 0, got {c}"));
+            problems.push(T0Error::InvalidAttribute {
+                op: "act_mul",
+                attribute: "clamp",
+                reason: format!("must be finite and > 0, got {c}"),
+            });
         }
     }
 
-    T0Error::from_problems("act_mul", problems)?;
+    T0Error::from_problems(problems)?;
 
     let num_elem = gate.num_elements();
     for i in 0..num_elem {

--- a/crates/r9v-t0/src/activation.rs
+++ b/crates/r9v-t0/src/activation.rs
@@ -4,7 +4,7 @@
 use r9v_ir::{ActivationKind, ActivationOp, DType};
 
 use crate::buffer::{TensorView, TensorViewMut};
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 use std::f64::consts::{FRAC_1_SQRT_2 as INV_SQRT_2_F64, FRAC_2_SQRT_PI as TWO_DIV_SQRT_PI_F64};
 
@@ -186,46 +186,49 @@ pub fn activation(
     let mut problems = Vec::new();
 
     if x.rank() != 2 {
-        problems.push(format!(
-            "input x: expected rank 2 [T, Dff], got rank {} with shape {:?}",
-            x.rank(),
-            x.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 2,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
     }
     if y.rank() != 2 {
-        problems.push(format!(
-            "output y: expected rank 2 [T, Dff], got rank {} with shape {:?}",
-            y.rank(),
-            y.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
     }
     if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "input x: expected f16, bf16, or f32, got {:?}",
-            x.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: x.dtype(),
+        });
     }
     if y.dtype() != x.dtype() {
-        problems.push(format!(
-            "output y dtype {:?} does not match input x dtype {:?}",
-            y.dtype(),
-            x.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![x.dtype()],
+            got: y.dtype(),
+        });
     }
     if x.rank() == 2 && y.rank() == 2 && x.shape() != y.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match input x shape {:?}",
-            y.shape(),
-            x.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "x", y.shape(), x.shape());
     }
     if let Some(c) = op.clamp {
         if !c.is_finite() || c <= 0.0 {
-            problems.push(format!("clamp must be finite and > 0, got {c}"));
+            problems.push(T0Error::InvalidAttribute {
+                op: "activation",
+                attribute: "clamp",
+                reason: format!("must be finite and > 0, got {c}"),
+            });
         }
     }
 
-    T0Error::from_problems("activation", problems)?;
+    T0Error::from_problems(problems)?;
 
     let num_elem = x.num_elements();
     for i in 0..num_elem {

--- a/crates/r9v-t0/src/cast.rs
+++ b/crates/r9v-t0/src/cast.rs
@@ -5,7 +5,7 @@ use r9v_ir::{CastOp, DType};
 
 use crate::buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut};
 use crate::dtype::dtype_element_size;
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 precision cast: `x -> y` with `y.dtype == op.dtype` (Spec 1 §4.A, Spec 1 §6.4, Spec 4 §2).
 pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
@@ -15,21 +15,17 @@ pub fn cast(op: &CastOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resul
     let mut problems = Vec::new();
 
     if x.shape() != y.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match input x shape {:?}",
-            y.shape(),
-            x.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "x", y.shape(), x.shape());
     }
     if y.dtype() != op.dtype {
-        problems.push(format!(
-            "output y dtype {:?} does not match op target dtype {:?}",
-            y.dtype(),
-            op.dtype
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.dtype],
+            got: y.dtype(),
+        });
     }
 
-    T0Error::from_problems("cast", problems)?;
+    T0Error::from_problems(problems)?;
 
     // Identity casts copy raw storage bit-exactly instead of round-tripping through `f32`,
     // which cannot represent U32/I32 magnitudes beyond 2^24 and would normalize FP8 NaN

--- a/crates/r9v-t0/src/concat.rs
+++ b/crates/r9v-t0/src/concat.rs
@@ -23,72 +23,105 @@ pub fn concat(
 
     for (name, view) in [("a", a), ("b", b)] {
         if view.rank() != 3 {
-            problems.push(format!(
-                "input {name}: expected rank 3 [T, H, D], got rank {} with shape {:?}",
-                view.rank(),
-                view.shape()
-            ));
+            problems.push(T0Error::RankMismatch {
+                tensor: name,
+                expected: 3,
+                got: view.rank(),
+                shape: view.shape().to_vec(),
+            });
         }
         if !matches!(view.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-            problems.push(format!(
-                "input {name}: expected f16, bf16, or f32, got {:?}",
-                view.dtype()
-            ));
+            problems.push(T0Error::DTypeMismatch {
+                tensor: name,
+                expected: vec![DType::F16, DType::Bf16, DType::F32],
+                got: view.dtype(),
+            });
         }
     }
     if y.rank() != 3 {
-        problems.push(format!(
-            "output y: expected rank 3 [T, H, Da + Db], got rank {} with shape {:?}",
-            y.rank(),
-            y.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 3,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
     }
     if !matches!(y.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "output y: expected f16, bf16, or f32, got {:?}",
-            y.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: y.dtype(),
+        });
     }
     if b.dtype() != a.dtype() {
-        problems.push(format!(
-            "input b: expected input a dtype {:?}, got {:?}",
-            a.dtype(),
-            b.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "b",
+            expected: vec![a.dtype()],
+            got: b.dtype(),
+        });
     }
     if y.dtype() != a.dtype() {
-        problems.push(format!(
-            "output y: expected input a dtype {:?}, got {:?}",
-            a.dtype(),
-            y.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![a.dtype()],
+            got: y.dtype(),
+        });
     }
     if a.rank() == 3 && b.rank() == 3 && y.rank() == 3 {
         let (t, h, da) = (a.shape()[0], a.shape()[1], a.shape()[2]);
-        if b.shape()[0] != t || b.shape()[1] != h {
-            problems.push(format!(
-                "input b shape {:?} does not share input a [T, H] = [{t}, {h}]",
-                b.shape()
-            ));
+        if b.shape()[0] != t {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "a",
+                expected: t,
+                tensor: "b",
+                got: b.shape()[0],
+            });
         }
-        if y.shape()[0] != t || y.shape()[1] != h {
-            problems.push(format!(
-                "output y shape {:?} does not share input a [T, H] = [{t}, {h}]",
-                y.shape()
-            ));
+        if b.shape()[1] != h {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "H",
+                expected_from: "a",
+                expected: h,
+                tensor: "b",
+                got: b.shape()[1],
+            });
+        }
+        if y.shape()[0] != t {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "a",
+                expected: t,
+                tensor: "y",
+                got: y.shape()[0],
+            });
+        }
+        if y.shape()[1] != h {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "H",
+                expected_from: "a",
+                expected: h,
+                tensor: "y",
+                got: y.shape()[1],
+            });
         }
         match da.checked_add(b.shape()[2]) {
             Some(sum) if sum == y.shape()[2] => {}
-            Some(sum) => problems.push(format!(
-                "input widths {da} + {} = {sum} do not match output dim {}",
-                b.shape()[2],
-                y.shape()[2]
-            )),
-            None => problems.push("input widths overflow usize".to_string()),
+            Some(sum) => problems.push(T0Error::DimensionMismatch {
+                dim_name: "D",
+                expected_from: "a+b",
+                expected: y.shape()[2],
+                tensor: "y",
+                got: sum,
+            }),
+            None => problems.push(T0Error::ArithmeticOverflow {
+                op: "concat",
+                detail: "input widths overflow usize".to_string(),
+            }),
         }
     }
 
-    T0Error::from_problems("concat", problems)?;
+    T0Error::from_problems(problems)?;
 
     let (t, h, da) = (a.shape()[0], a.shape()[1], a.shape()[2]);
     let db = b.shape()[2];

--- a/crates/r9v-t0/src/copy.rs
+++ b/crates/r9v-t0/src/copy.rs
@@ -5,7 +5,7 @@ use r9v_ir::{CopyOp, DType};
 
 use crate::buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut};
 use crate::dtype::dtype_element_size;
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 tensor copy / contiguization (Spec 1 §4.A, Spec 4 §2).
 ///
@@ -17,21 +17,17 @@ pub fn copy(_op: &CopyOp, x: &TensorView<'_>, y: &mut TensorViewMut<'_>) -> Resu
     let mut problems = Vec::new();
 
     if x.shape() != y.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match input x shape {:?}",
-            y.shape(),
-            x.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "x", y.shape(), x.shape());
     }
     if y.dtype() != x.dtype() {
-        problems.push(format!(
-            "output y dtype {:?} does not match input x dtype {:?}",
-            y.dtype(),
-            x.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![x.dtype()],
+            got: y.dtype(),
+        });
     }
 
-    T0Error::from_problems("copy", problems)?;
+    T0Error::from_problems(problems)?;
 
     let num_elem = x.num_elements();
     match (&x.data, &mut y.data) {

--- a/crates/r9v-t0/src/embed_gather.rs
+++ b/crates/r9v-t0/src/embed_gather.rs
@@ -279,7 +279,7 @@ pub fn embed_gather_with_scales(
         }
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     let t_len = token_ids.shape()[0];
     let v_vocab = table.shape()[0];
@@ -369,7 +369,7 @@ pub fn embed_gather_with_scales(
         }
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     let superblock_k = match scheme_res {
         Some(SchemeId::I4K) => 256,

--- a/crates/r9v-t0/src/error.rs
+++ b/crates/r9v-t0/src/error.rs
@@ -155,22 +155,7 @@ pub enum T0Error {
         dtype: DType,
     },
 
-    /// Multiple validation errors collected together (CONVENTIONS.md §1.4).
-    #[error("{count} validation error(s) in op `{op}`: {problems:?}")]
-    Multiple {
-        /// Name of the failing op.
-        op: &'static str,
-        /// Count of collected problems.
-        count: usize,
-        /// Vector of formatted problem descriptions.
-        problems: Vec<String>,
-    },
-
     /// Flat-slice length mismatch for sampling ops (Spec 1 §4.F).
-    ///
-    /// Renamed from the A1.8 `DimensionMismatch` so it cannot collide with the
-    /// A1.5 symbolic-dimension `DimensionMismatch` above, which carries
-    /// `(dim_name, expected_from, ...)` instead of `(op, detail)`.
     #[error("shape length mismatch in {op}: tensor {tensor} expected length {expected}, got {got}; detail: {detail}")]
     ShapeLengthMismatch {
         /// Op name.
@@ -194,7 +179,7 @@ pub enum T0Error {
         tensor: &'static str,
     },
 
-    /// All tokens masked out by grammar mask.
+    /// All tokens masked out by grammar mask or invalid logits.
     #[error("all tokens masked out by grammar mask in sequence {seq}, query {query}; vocabulary size was {vocab_size}")]
     AllTokensMasked {
         /// Sequence index.
@@ -252,6 +237,55 @@ pub enum T0Error {
         value: f32,
     },
 
+    /// A logit value is NaN or +Inf (Spec 1 §4.F).
+    ///
+    /// `-Inf` is never reported through this variant: it is the intentional
+    /// encoding of masked or impossible tokens (grammar mask, `logit_bias`
+    /// to `-Inf`). NaN and `+Inf` can never be intentional and are rejected
+    /// with their exact `(seq, query, token)` location, both on the raw input
+    /// and after bias/penalty/temperature transforms (overflow).
+    #[error("invalid logit {value} at sequence {seq}, query {query}, token {token} in op `{op}`")]
+    InvalidLogit {
+        /// Op name.
+        op: &'static str,
+        /// Sequence index.
+        seq: usize,
+        /// Query index.
+        query: usize,
+        /// Token index within the vocabulary.
+        token: usize,
+        /// Invalid logit value.
+        value: f32,
+    },
+
+    /// An RNG sequence id exceeds the canonical u32 Philox counter word (Spec 1 §4.F).
+    ///
+    /// The 128-bit Philox counter carries the sequence id in one 32-bit word,
+    /// so ids above `u32::MAX` cannot be represented without truncation
+    /// collision. RNG construction rejects it before a usable state exists.
+    #[error("rng seq_id {seq_id} exceeds the canonical u32 Philox counter word (max {max}) in op `{op}`")]
+    SeqIdOutOfRange {
+        /// Op name.
+        op: &'static str,
+        /// Offending 64-bit sequence id.
+        seq_id: u64,
+        /// Maximum representable sequence id.
+        max: u64,
+    },
+
+    /// Advancing an RNG state would wrap its per-step draw counter (Spec 1 §4.F).
+    #[error(
+        "rng draw index {draw_index} cannot advance by {advance} without overflow in op `{op}`"
+    )]
+    DrawIndexOverflow {
+        /// Operation that requested the advance.
+        op: &'static str,
+        /// Current draw index.
+        draw_index: u32,
+        /// Requested advance.
+        advance: u32,
+    },
+
     /// Invalid tree structure.
     #[error("invalid tree draft structure for sequence {seq}: {detail}")]
     InvalidTree {
@@ -261,46 +295,68 @@ pub enum T0Error {
         detail: String,
     },
 
-    /// Multiple coexisting typed validation problems (Spec 1 §4.F).
-    ///
-    /// Renamed from the A1.8 `Multiple` so it cannot collide with the A1.5
-    /// `Multiple` above, which carries `(op, count, problems: Vec<String>)`.
-    #[error("multiple T0 validation problems ({} failures): {problems:?}", problems.len())]
-    MultipleErrors {
-        /// Accumulated problems.
+    /// Multiple coexisting typed validation problems (Spec 1 §4.F, CONVENTIONS.md §1.4).
+    #[error("multiple validation error(s) ({} failures): {problems:?}", problems.len())]
+    Multiple {
+        /// Accumulated typed problems.
         problems: Box<[T0Error]>,
     },
 }
 
 impl T0Error {
-    /// Helper to produce a `Multiple` error if problems were collected (Spec 4 §2, CONVENTIONS.md §1.4).
-    pub fn from_problems(op: &'static str, problems: Vec<String>) -> Result<(), Self> {
-        if problems.is_empty() {
-            Ok(())
-        } else {
-            Err(Self::Multiple {
-                op,
-                count: problems.len(),
-                problems,
-            })
+    /// Aggregates typed problems: `Ok(())` if empty, the single error if one,
+    /// or `Multiple` otherwise (CONVENTIONS.md §1.4).
+    pub fn from_problems(mut problems: Vec<T0Error>) -> Result<(), Self> {
+        match problems.len() {
+            0 => Ok(()),
+            1 => {
+                if let Some(problem) = problems.pop() {
+                    Err(problem)
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Err(Self::Multiple {
+                problems: problems.into_boxed_slice(),
+            }),
         }
     }
+}
 
-    /// Aggregates typed problems: `Ok(())` if empty, the single error if one,
-    /// or `MultipleErrors` otherwise (Spec 1 §4.F).
-    ///
-    /// Renamed from the A1.8 `from_problems` so it cannot collide with the
-    /// A1.5 `from_problems(op, problems: Vec<String>)` above.
-    pub fn from_typed_problems(mut problems: Vec<T0Error>) -> Result<(), Self> {
-        if problems.is_empty() {
-            Ok(())
-        } else if problems.len() == 1 {
-            // Invariant: length was just checked to be exactly 1, so pop cannot fail.
-            Err(problems.pop().expect("exactly one problem"))
-        } else {
-            Err(Self::MultipleErrors {
-                problems: problems.into_boxed_slice(),
-            })
+/// Positional dimension names for shape-agreement checks on ops whose dimensions
+/// carry no symbolic name (Spec 4 §2).
+const POS_DIM_NAMES: [&str; 8] = ["d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7"];
+
+/// Pushes typed shape-agreement problems between two shapes (Spec 4 §2, CONVENTIONS.md §1.4).
+///
+/// Pushes `RankMismatch` when the ranks differ, otherwise one
+/// `DimensionMismatch` per disagreeing dimension. Used by elementwise ops to
+/// replace stringly formatted shape problems with typed errors.
+pub fn push_shape_agreement(
+    problems: &mut Vec<T0Error>,
+    tensor: &'static str,
+    expected_from: &'static str,
+    actual_shape: &[usize],
+    expected_shape: &[usize],
+) {
+    if actual_shape.len() != expected_shape.len() {
+        problems.push(T0Error::RankMismatch {
+            tensor,
+            expected: expected_shape.len(),
+            got: actual_shape.len(),
+            shape: actual_shape.to_vec(),
+        });
+        return;
+    }
+    for (i, (&got, &expected)) in actual_shape.iter().zip(expected_shape.iter()).enumerate() {
+        if got != expected {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: POS_DIM_NAMES.get(i).copied().unwrap_or("dim"),
+                expected_from,
+                expected,
+                tensor,
+                got,
+            });
         }
     }
 }

--- a/crates/r9v-t0/src/gather_rows.rs
+++ b/crates/r9v-t0/src/gather_rows.rs
@@ -100,7 +100,7 @@ pub fn gather_rows(
         });
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     let n = x.shape()[0];
     let d = x.shape()[1];
@@ -168,7 +168,7 @@ pub fn gather_rows(
         }
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     // Execute bit-exact copy for each row
     for row_out in 0..m {

--- a/crates/r9v-t0/src/lib.rs
+++ b/crates/r9v-t0/src/lib.rs
@@ -51,7 +51,9 @@ pub use philox::{philox4x32_10, u32_to_unit_f32, RngState};
 pub use quant_act::{fp8_e4m3_encode_f64_oracle, quant_act, quant_act_f64_reference};
 pub use residual_add::{residual_add, residual_add_f64_reference};
 pub use rope::{rope, rope_f64_reference};
-pub use sampling::{logits_postprocess, sample, verify, VerifyOutput};
+pub use sampling::{
+    logits_postprocess, logits_postprocess_f64_reference, sample, verify, VerifyOutput,
+};
 pub use scatter_add_rows::{scatter_add_rows, scatter_add_rows_f64_reference};
 pub use split::{split, split_f64_reference};
 pub use tolerance::Tolerance;

--- a/crates/r9v-t0/src/logit_softcap.rs
+++ b/crates/r9v-t0/src/logit_softcap.rs
@@ -4,7 +4,7 @@
 use r9v_ir::{DType, LogitSoftcapOp};
 
 use crate::buffer::{TensorView, TensorViewMut};
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 logit softcap: `y = cap * tanh(x / cap)` in f32 over
 /// `x [T, V] f32` (card A1.14, SI-28, Spec 4 §2).
@@ -19,40 +19,47 @@ pub fn logit_softcap(
     let mut problems = Vec::new();
 
     if !op.cap.is_finite() || op.cap <= 0.0 {
-        problems.push(format!(
-            "attribute cap: must be finite and > 0, got {}",
-            op.cap
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "logit_softcap",
+            attribute: "cap",
+            reason: format!("must be finite and > 0, got {}", op.cap),
+        });
     }
     if x.rank() != 2 {
-        problems.push(format!(
-            "input x: expected rank 2 [T, V], got rank {} with shape {:?}",
-            x.rank(),
-            x.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 2,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
     }
     if y.rank() != 2 {
-        problems.push(format!(
-            "output y: expected rank 2 [T, V], got rank {} with shape {:?}",
-            y.rank(),
-            y.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
     }
     if x.dtype() != DType::F32 {
-        problems.push(format!("input x: expected f32, got {:?}", x.dtype()));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F32],
+            got: x.dtype(),
+        });
     }
     if y.dtype() != DType::F32 {
-        problems.push(format!("output y: expected f32, got {:?}", y.dtype()));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![DType::F32],
+            got: y.dtype(),
+        });
     }
     if x.shape() != y.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match input x shape {:?}",
-            y.shape(),
-            x.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "x", y.shape(), x.shape());
     }
 
-    T0Error::from_problems("logit_softcap", problems)?;
+    T0Error::from_problems(problems)?;
 
     let num_elem = x.num_elements();
     for i in 0..num_elem {

--- a/crates/r9v-t0/src/matmul.rs
+++ b/crates/r9v-t0/src/matmul.rs
@@ -406,7 +406,7 @@ pub fn matmul_with_scales(
         });
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     let m = x.shape()[0];
     let k_x = x.shape()[1];
@@ -700,7 +700,7 @@ pub fn matmul_with_scales(
         }
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     // Validate activation scale values are finite and non-negative
     if let Some(xs) = x_scale {

--- a/crates/r9v-t0/src/norm.rs
+++ b/crates/r9v-t0/src/norm.rs
@@ -4,7 +4,7 @@
 use r9v_ir::{DType, NormAxis, NormKind, NormOp};
 
 use crate::buffer::{TensorView, TensorViewMut};
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 normalization (RMS or LayerNorm) per Spec 1 §4.B, §6.4, Spec 4 §2.
 ///
@@ -26,115 +26,146 @@ pub fn norm(
     let mut problems = Vec::new();
 
     if !op.eps.is_finite() || op.eps <= 0.0 {
-        problems.push(format!("eps must be finite and > 0, got {}", op.eps));
+        problems.push(T0Error::InvalidAttribute {
+            op: "norm",
+            attribute: "eps",
+            reason: format!("must be finite and > 0, got {}", op.eps),
+        });
     }
     if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "out_dtype must be f16, bf16, or f32, got {:?}",
-            op.out_dtype
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "norm",
+            attribute: "out_dtype",
+            reason: format!("must be f16, bf16, or f32, got {:?}", op.out_dtype),
+        });
     }
     if !op.weight_offset.is_finite() {
-        problems.push(format!(
-            "weight_offset must be finite, got {}",
-            op.weight_offset
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "norm",
+            attribute: "weight_offset",
+            reason: format!("must be finite, got {}", op.weight_offset),
+        });
     }
     if let NormAxis::Head(d) = op.axis {
         if d == 0 {
-            problems.push("NormAxis::Head(d): d must be > 0".to_string());
+            problems.push(T0Error::InvalidAttribute {
+                op: "norm",
+                attribute: "axis",
+                reason: "NormAxis::Head(d): d must be > 0".to_string(),
+            });
         }
     }
 
     if x.rank() != 2 {
-        problems.push(format!(
-            "input x: expected rank 2 [T, N], got rank {} with shape {:?}",
-            x.rank(),
-            x.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 2,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
     }
     if weight.rank() != 1 {
-        problems.push(format!(
-            "weight: expected rank 1 [N], got rank {} with shape {:?}",
-            weight.rank(),
-            weight.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "weight",
+            expected: 1,
+            got: weight.rank(),
+            shape: weight.shape().to_vec(),
+        });
     }
     if y.rank() != 2 {
-        problems.push(format!(
-            "output y: expected rank 2 [T, N], got rank {} with shape {:?}",
-            y.rank(),
-            y.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
     }
     if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "input x: expected f16, bf16, or f32, got {:?}",
-            x.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: x.dtype(),
+        });
     }
     if weight.dtype() != DType::F32 {
-        problems.push(format!("weight: expected f32, got {:?}", weight.dtype()));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "weight",
+            expected: vec![DType::F32],
+            got: weight.dtype(),
+        });
     }
     if y.dtype() != op.out_dtype {
-        problems.push(format!(
-            "output y: expected out_dtype {:?}, got {:?}",
-            op.out_dtype,
-            y.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.out_dtype],
+            got: y.dtype(),
+        });
     }
 
     if let Some(b) = bias {
         if b.rank() != 1 {
-            problems.push(format!(
-                "bias: expected rank 1 [N], got rank {} with shape {:?}",
-                b.rank(),
-                b.shape()
-            ));
+            problems.push(T0Error::RankMismatch {
+                tensor: "bias",
+                expected: 1,
+                got: b.rank(),
+                shape: b.shape().to_vec(),
+            });
         }
         if b.dtype() != DType::F32 {
-            problems.push(format!("bias: expected f32, got {:?}", b.dtype()));
+            problems.push(T0Error::DTypeMismatch {
+                tensor: "bias",
+                expected: vec![DType::F32],
+                got: b.dtype(),
+            });
         }
     }
 
     if x.rank() == 2 && weight.rank() == 1 {
         let n = x.shape()[1];
         if weight.shape()[0] != n {
-            problems.push(format!(
-                "weight dimension {} does not match x feature dimension N={}",
-                weight.shape()[0],
-                n
-            ));
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "N",
+                expected_from: "x",
+                expected: n,
+                tensor: "weight",
+                got: weight.shape()[0],
+            });
         }
         if let Some(b) = bias {
             if b.rank() == 1 && b.shape()[0] != n {
-                problems.push(format!(
-                    "bias dimension {} does not match x feature dimension N={}",
-                    b.shape()[0],
-                    n
-                ));
+                problems.push(T0Error::DimensionMismatch {
+                    dim_name: "N",
+                    expected_from: "x",
+                    expected: n,
+                    tensor: "bias",
+                    got: b.shape()[0],
+                });
             }
         }
         if let NormAxis::Head(d) = op.axis {
             if d == 0 {
-                problems.push("NormAxis::Head(d): d must be > 0".to_string());
+                problems.push(T0Error::InvalidAttribute {
+                    op: "norm",
+                    attribute: "axis",
+                    reason: "NormAxis::Head(d): d must be > 0".to_string(),
+                });
             } else if !n.is_multiple_of(d as usize) {
-                problems.push(format!(
-                    "feature dimension N={n} is not divisible by head dimension d={d}"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "norm",
+                    attribute: "axis",
+                    reason: format!(
+                        "feature dimension N={n} is not divisible by head dimension d={d}"
+                    ),
+                });
             }
         }
     }
 
     if x.rank() == 2 && y.rank() == 2 && y.shape() != x.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match input x shape {:?}",
-            y.shape(),
-            x.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "x", y.shape(), x.shape());
     }
 
-    T0Error::from_problems("norm", problems)?;
+    T0Error::from_problems(problems)?;
 
     let t = x.shape()[0];
     let n = x.shape()[1];

--- a/crates/r9v-t0/src/philox.rs
+++ b/crates/r9v-t0/src/philox.rs
@@ -39,7 +39,12 @@ pub fn philox4x32_10(ctr: [u32; 4], mut key: [u32; 2]) -> [u32; 4] {
     c
 }
 
-// DECISION(A1.8): Philox4x32 maps key [seed as u32, (seed >> 32) as u32] and counter [draw_index, step as u32, seq_id as u32, (seq_id >> 32) as u32]; uniform f32 draws map word >> 9 centered by +0.5 in (0, 1) to avoid boundary saturation in inverse-CDF; rejected uncentered float conversion because boundary 0.0/1.0 corrupts rejection and CDF thresholds. Spec 1 §4.F, Spec 7 §4.
+use r9v_common::{SeqId, StepId};
+
+use crate::error::T0Error;
+
+// DECISION(A1.8): Philox4x32 maps 64-bit key [seed as u32, (seed >> 32) as u32] and 128-bit counter [draw_index, step_lo, step_hi, seq_id_u32]; step is encoded losslessly as 64-bit (step_lo, step_hi) to prevent collision across steps > 2^32, and seq_id is bound to canonical BatchMeta u32 global sequence ids, rejecting seq_id > u32::MAX before mutation; uniform f32 draws map word >> 9 centered by +0.5 in (0, 1) to avoid boundary saturation in inverse-CDF; rejected uncentered float conversion because boundary 0.0/1.0 corrupts rejection and CDF thresholds. Spec 1 §4.F, Spec 4 §5.8, Spec 7 §4.
+// DECISION(A1.8): draw_index arithmetic is checked, never wrapping: advance and draw_uniform_f32 fail loudly on u32 overflow instead of silently reusing draws; rejected wrapping_add because a wrapped draw counter replays earlier uniforms and breaks the (seq, step, draw) uniqueness the Philox counter mapping promises. Spec 1 §4.F.
 /// Maps a 32-bit random word to an `f32` uniform on the open interval `(0, 1)` (Spec 1 §4.F).
 ///
 /// Uses the upper 23 bits (`word >> 9`) centered by `+0.5` scaled by `2^-23`.
@@ -59,30 +64,44 @@ pub fn u32_to_unit_f32(word: u32) -> f32 {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RngState {
     seed: u64,
-    seq_id: u64,
-    step: u64,
+    seq_id: SeqId,
+    seq_word: u32,
+    step: StepId,
     draw_index: u32,
 }
 
 impl RngState {
     /// Creates a new RNG state with `draw_index = 0` (Spec 1 §4.F).
-    pub const fn new(seed: u64, seq_id: u64, step: u64) -> Self {
-        Self {
+    pub fn new(seed: u64, seq_id: SeqId, step: StepId) -> Result<Self, T0Error> {
+        let seq_word = u32::try_from(seq_id.as_u64()).map_err(|_| T0Error::SeqIdOutOfRange {
+            op: "RngState::new",
+            seq_id: seq_id.as_u64(),
+            max: u32::MAX as u64,
+        })?;
+        Ok(Self {
             seed,
             seq_id,
+            seq_word,
             step,
             draw_index: 0,
-        }
+        })
     }
 
     /// Creates an RNG state with an explicit initial `draw_index` (Spec 1 §4.F).
-    pub const fn with_draw(seed: u64, seq_id: u64, step: u64, draw_index: u32) -> Self {
-        Self {
-            seed,
-            seq_id,
-            step,
-            draw_index,
-        }
+    pub fn with_draw(
+        seed: u64,
+        seq_id: SeqId,
+        step: StepId,
+        draw_index: u32,
+    ) -> Result<Self, T0Error> {
+        let mut state = Self::new(seed, seq_id, step)?;
+        state.draw_index = draw_index;
+        Ok(state)
+    }
+
+    /// Creates an RNG state from raw 64-bit integer values (Spec 1 §4.F).
+    pub fn from_u64(seed: u64, seq_id: u64, step: u64) -> Result<Self, T0Error> {
+        Self::new(seed, SeqId::new(seq_id), StepId::new(step))
     }
 
     /// Returns the RNG seed (Spec 1 §4.F, Spec 10 §4).
@@ -91,12 +110,22 @@ impl RngState {
     }
 
     /// Returns the sequence identifier (Spec 1 §4.F, Spec 3 §2).
-    pub const fn seq_id(&self) -> u64 {
+    pub const fn seq_id(&self) -> SeqId {
         self.seq_id
     }
 
+    /// Returns the sequence id as the canonical u32 Philox counter word (Spec 1 §4.F).
+    ///
+    /// The 128-bit Philox counter carries the sequence id in one 32-bit word,
+    /// so ids above `u32::MAX` cannot be represented without truncation
+    /// collision. Sampling ops call this for every state at the op boundary,
+    /// before any RNG or output mutation, so rejection leaves state untouched.
+    pub const fn seq_id_u32(&self) -> u32 {
+        self.seq_word
+    }
+
     /// Returns the step identifier/counter (Spec 1 §4.F, Spec 6 §9).
-    pub const fn step(&self) -> u64 {
+    pub const fn step(&self) -> StepId {
         self.step
     }
 
@@ -106,35 +135,62 @@ impl RngState {
     }
 
     /// Updates the execution step and resets the draw counter to 0 (Spec 1 §4.F).
-    pub fn set_step(&mut self, step: u64) {
+    pub fn set_step(&mut self, step: StepId) {
         self.step = step;
         self.draw_index = 0;
     }
 
     /// Advances the draw index by `count` (Spec 1 §4.F).
-    pub fn advance(&mut self, count: u32) {
-        self.draw_index = self.draw_index.wrapping_add(count);
+    ///
+    /// Fails loudly on `u32` overflow: a wrapped counter would replay earlier
+    /// uniforms for the same `(seq, step)`.
+    pub fn advance(&mut self, count: u32) -> Result<(), T0Error> {
+        let next = self.checked_advance(count, "RngState::advance")?;
+        self.draw_index = next;
+        Ok(())
+    }
+
+    /// Checks an advance without mutating this state.
+    pub(crate) fn ensure_can_advance(&self, count: u32, op: &'static str) -> Result<(), T0Error> {
+        self.checked_advance(count, op).map(|_| ())
+    }
+
+    fn checked_advance(&self, count: u32, op: &'static str) -> Result<u32, T0Error> {
+        self.draw_index
+            .checked_add(count)
+            .ok_or(T0Error::DrawIndexOverflow {
+                op,
+                draw_index: self.draw_index,
+                advance: count,
+            })
     }
 
     /// Draws a uniform `f32` in `(0, 1)` at a specified draw index without mutating the state (Spec 1 §4.F, Spec 7 §4).
+    ///
+    /// Construction establishes `seq_id <= u32::MAX`, so the counter word is
+    /// always lossless and this pure accessor cannot fail.
     #[must_use]
     pub fn draw_at(&self, draw: u32) -> f32 {
+        let step_val = self.step.as_u64();
         let key = [self.seed as u32, (self.seed >> 32) as u32];
         let ctr = [
             draw,
-            self.step as u32,
-            self.seq_id as u32,
-            (self.seq_id >> 32) as u32,
+            step_val as u32,
+            (step_val >> 32) as u32,
+            self.seq_word,
         ];
         let words = philox4x32_10(ctr, key);
         u32_to_unit_f32(words[0])
     }
 
     /// Draws the next uniform `f32` in `(0, 1)` and increments `draw_index` by 1 (Spec 1 §4.F).
-    pub fn draw_uniform_f32(&mut self) -> f32 {
+    ///
+    /// Fails loudly on `u32` overflow rather than wrapping onto reused draws.
+    pub fn draw_uniform_f32(&mut self) -> Result<f32, T0Error> {
+        let next = self.checked_advance(1, "RngState::draw_uniform_f32")?;
         let val = self.draw_at(self.draw_index);
-        self.draw_index = self.draw_index.wrapping_add(1);
-        val
+        self.draw_index = next;
+        Ok(val)
     }
 }
 
@@ -172,10 +228,88 @@ mod tests {
 
     #[test]
     fn test_rng_state_draw_reproducibility() {
-        let mut rng1 = RngState::new(42, 1, 0);
-        let mut rng2 = RngState::new(42, 1, 0);
+        let mut rng1 = RngState::new(42, SeqId::new(1), StepId::new(0)).unwrap();
+        let mut rng2 = RngState::new(42, SeqId::new(1), StepId::new(0)).unwrap();
         for _ in 0..100 {
-            assert_eq!(rng1.draw_uniform_f32(), rng2.draw_uniform_f32());
+            assert_eq!(
+                rng1.draw_uniform_f32().unwrap(),
+                rng2.draw_uniform_f32().unwrap()
+            );
         }
+    }
+
+    #[test]
+    fn test_rng_state_step_upper_bits_no_collision() {
+        // Prove that steps differing only in upper 32 bits produce distinct draws (no truncation)
+        let rng_low = RngState::new(42, SeqId::new(1), StepId::new(1)).unwrap();
+        let rng_high = RngState::new(42, SeqId::new(1), StepId::new(1 | (1u64 << 32))).unwrap();
+        assert_ne!(rng_low.draw_at(0), rng_high.draw_at(0));
+
+        let rng_zero = RngState::new(42, SeqId::new(1), StepId::new(0)).unwrap();
+        let rng_step_rollover = RngState::new(42, SeqId::new(1), StepId::new(1u64 << 32)).unwrap();
+        assert_ne!(rng_zero.draw_at(0), rng_step_rollover.draw_at(0));
+    }
+
+    #[test]
+    fn test_rng_state_boundary_values() {
+        let rng_max =
+            RngState::new(u64::MAX, SeqId::new(u32::MAX as u64), StepId::new(u64::MAX)).unwrap();
+        let val = rng_max.draw_at(u32::MAX);
+        assert!(val > 0.0 && val < 1.0);
+    }
+
+    #[test]
+    fn test_rng_state_seq_id_u32_checked() {
+        let ok = RngState::new(7, SeqId::new(u32::MAX as u64), StepId::new(0)).unwrap();
+        assert_eq!(ok.seq_id_u32(), u32::MAX);
+        let err = RngState::new(7, SeqId::new(u32::MAX as u64 + 1), StepId::new(0)).unwrap_err();
+        assert!(
+            matches!(err, crate::error::T0Error::SeqIdOutOfRange { seq_id, max, .. }
+                if seq_id == u32::MAX as u64 + 1 && max == u32::MAX as u64)
+        );
+    }
+
+    #[test]
+    fn test_rng_state_draw_at_is_pure_over_advance() {
+        // draw_at(i) is a pure function of (seed, seq, step, i): advancing the
+        // mutable cursor never changes what draw_at reports for any index.
+        let mut rng = RngState::new(99, SeqId::new(3), StepId::new(4)).unwrap();
+        let before: Vec<f32> = (0..8).map(|i| rng.draw_at(i)).collect();
+        for _ in 0..8 {
+            rng.draw_uniform_f32().unwrap();
+        }
+        let after: Vec<f32> = (0..8).map(|i| rng.draw_at(i)).collect();
+        assert_eq!(before, after);
+        // Sequential draws consume draw_at(0), draw_at(1), ... in order.
+        let mut fresh = RngState::new(99, SeqId::new(3), StepId::new(4)).unwrap();
+        for (i, &expected) in before.iter().enumerate() {
+            assert_eq!(fresh.draw_uniform_f32().unwrap(), expected, "draw {i}");
+        }
+    }
+
+    #[test]
+    fn test_rng_state_advance_overflow_is_typed_and_non_mutating() {
+        let mut rng = RngState::with_draw(1, SeqId::new(0), StepId::new(0), u32::MAX).unwrap();
+        let err = rng.advance(1).unwrap_err();
+        assert!(matches!(
+            err,
+            T0Error::DrawIndexOverflow {
+                op: "RngState::advance",
+                draw_index: u32::MAX,
+                advance: 1
+            }
+        ));
+        assert_eq!(rng.draw_index(), u32::MAX);
+
+        let err = rng.draw_uniform_f32().unwrap_err();
+        assert!(matches!(
+            err,
+            T0Error::DrawIndexOverflow {
+                op: "RngState::draw_uniform_f32",
+                draw_index: u32::MAX,
+                advance: 1
+            }
+        ));
+        assert_eq!(rng.draw_index(), u32::MAX);
     }
 }

--- a/crates/r9v-t0/src/quant_act.rs
+++ b/crates/r9v-t0/src/quant_act.rs
@@ -5,7 +5,7 @@ use r9v_ir::{DType, QuantActOp, QuantScheme};
 
 use crate::buffer::{TensorView, TensorViewMut};
 use crate::dtype::fp8_e4m3_encode;
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 activation quantization (Spec 1 §4.A, Spec 2 §3.4, Spec 4 §2).
 pub fn quant_act(
@@ -21,52 +21,53 @@ pub fn quant_act(
     let mut problems = Vec::new();
 
     if op.target != DType::I8 && op.target != DType::E4m3 {
-        problems.push(format!(
-            "quant_act target must be i8 or e4m3, got {:?}",
-            op.target
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "quant_act",
+            attribute: "target",
+            reason: format!("must be i8 or e4m3, got {:?}", op.target),
+        });
     }
 
     if x.rank() != 2 {
-        problems.push(format!(
-            "input x: expected rank 2 [T, N], got rank {} with shape {:?}",
-            x.rank(),
-            x.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 2,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
     }
     if xq.rank() != 2 {
-        problems.push(format!(
-            "output xq: expected rank 2 [T, N], got rank {} with shape {:?}",
-            xq.rank(),
-            xq.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "xq",
+            expected: 2,
+            got: xq.rank(),
+            shape: xq.shape().to_vec(),
+        });
     }
     if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "input x: expected f16, bf16, or f32, got {:?}",
-            x.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: x.dtype(),
+        });
     }
     if xq.dtype() != op.target {
-        problems.push(format!(
-            "output xq dtype {:?} does not match op target {:?}",
-            xq.dtype(),
-            op.target
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "xq",
+            expected: vec![op.target],
+            got: xq.dtype(),
+        });
     }
     if scale.dtype() != DType::F32 {
-        problems.push(format!(
-            "output scale: expected f32, got {:?}",
-            scale.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "scale",
+            expected: vec![DType::F32],
+            got: scale.dtype(),
+        });
     }
 
     if x.rank() == 2 && xq.rank() == 2 && x.shape() != xq.shape() {
-        problems.push(format!(
-            "output xq shape {:?} does not match input x shape {:?}",
-            xq.shape(),
-            x.shape()
-        ));
+        push_shape_agreement(&mut problems, "xq", "x", xq.shape(), x.shape());
     }
 
     if x.rank() == 2 {
@@ -76,48 +77,77 @@ pub fn quant_act(
         match op.scheme {
             QuantScheme::PerToken => {
                 if op.target != DType::I8 && op.target != DType::E4m3 {
-                    problems.push(format!(
-                        "PerToken only supports i8 or e4m3 target, got {:?}",
-                        op.target
-                    ));
+                    problems.push(T0Error::InvalidAttribute {
+                        op: "quant_act",
+                        attribute: "scheme",
+                        reason: format!(
+                            "PerToken only supports i8 or e4m3 target, got {:?}",
+                            op.target
+                        ),
+                    });
                 }
-                if scale.rank() != 1 || scale.shape()[0] != t {
-                    problems.push(format!(
-                        "PerToken scale: expected rank 1 [{t}], got rank {} with shape {:?}",
-                        scale.rank(),
-                        scale.shape()
-                    ));
+                if scale.rank() != 1 {
+                    problems.push(T0Error::RankMismatch {
+                        tensor: "scale",
+                        expected: 1,
+                        got: scale.rank(),
+                        shape: scale.shape().to_vec(),
+                    });
+                } else if scale.shape()[0] != t {
+                    problems.push(T0Error::DimensionMismatch {
+                        dim_name: "T",
+                        expected_from: "x",
+                        expected: t,
+                        tensor: "scale",
+                        got: scale.shape()[0],
+                    });
                 }
             }
             QuantScheme::PerBlock32 => {
                 if op.target != DType::I8 {
-                    problems.push(format!(
-                        "PerBlock32 only supports i8 target, got {:?}",
-                        op.target
-                    ));
+                    problems.push(T0Error::InvalidAttribute {
+                        op: "quant_act",
+                        attribute: "scheme",
+                        reason: format!("PerBlock32 only supports i8 target, got {:?}", op.target),
+                    });
                 }
                 if !n.is_multiple_of(32) {
-                    problems.push(format!("PerBlock32 requires N={n} divisible by 32"));
+                    problems.push(T0Error::InvalidAttribute {
+                        op: "quant_act",
+                        attribute: "scheme",
+                        reason: format!("PerBlock32 requires N={n} divisible by 32"),
+                    });
                 } else {
                     let expected_blocks = n / 32;
-                    if scale.rank() != 2 || scale.shape() != [t, expected_blocks] {
-                        problems.push(format!(
-                            "PerBlock32 scale: expected shape [{t}, {expected_blocks}], got shape {:?}",
-                            scale.shape()
-                        ));
+                    if scale.rank() != 2 {
+                        problems.push(T0Error::RankMismatch {
+                            tensor: "scale",
+                            expected: 2,
+                            got: scale.rank(),
+                            shape: scale.shape().to_vec(),
+                        });
+                    } else if scale.shape() != [t, expected_blocks] {
+                        push_shape_agreement(
+                            &mut problems,
+                            "scale",
+                            "x",
+                            scale.shape(),
+                            &[t, expected_blocks],
+                        );
                     }
                 }
             }
             _ => {
-                problems.push(format!(
-                    "quant_act only supports PerToken or PerBlock32, got {:?}",
-                    op.scheme
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "quant_act",
+                    attribute: "scheme",
+                    reason: format!("only supports PerToken or PerBlock32, got {:?}", op.scheme),
+                });
             }
         }
     }
 
-    T0Error::from_problems("quant_act", problems)?;
+    T0Error::from_problems(problems)?;
 
     let t = x.shape()[0];
     let n = x.shape()[1];

--- a/crates/r9v-t0/src/residual_add.rs
+++ b/crates/r9v-t0/src/residual_add.rs
@@ -4,7 +4,7 @@
 use r9v_ir::{DType, ResidualAddOp};
 
 use crate::buffer::{TensorView, TensorViewMut};
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Executes scalar T0 residual addition: `a + scale * b` in f32, cast to `out_dtype` (Spec 1 §4.B, Spec 1 §6.1, Spec 1 §6.4, Spec 4 §2; card A1.14, SI-27).
 pub fn residual_add(
@@ -20,46 +20,41 @@ pub fn residual_add(
     let mut problems = Vec::new();
 
     if !op.scale.is_finite() || op.scale == 0.0 {
-        problems.push(format!(
-            "attribute scale: must be finite and non-zero, got {}",
-            op.scale
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "residual_add",
+            attribute: "scale",
+            reason: format!("must be finite and non-zero, got {}", op.scale),
+        });
     }
     if a.shape() != b.shape() {
-        problems.push(format!(
-            "operand b shape {:?} does not match operand a shape {:?}",
-            b.shape(),
-            a.shape()
-        ));
+        push_shape_agreement(&mut problems, "b", "a", b.shape(), a.shape());
     }
     if a.shape() != y.shape() {
-        problems.push(format!(
-            "output y shape {:?} does not match operand a shape {:?}",
-            y.shape(),
-            a.shape()
-        ));
+        push_shape_agreement(&mut problems, "y", "a", y.shape(), a.shape());
     }
     if !matches!(a.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "operand a: expected f16, bf16, or f32, got {:?}",
-            a.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "a",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: a.dtype(),
+        });
     }
     if !matches!(b.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "operand b: expected f16, bf16, or f32, got {:?}",
-            b.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "b",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: b.dtype(),
+        });
     }
     if y.dtype() != op.out_dtype {
-        problems.push(format!(
-            "output y: expected out_dtype {:?}, got {:?}",
-            op.out_dtype,
-            y.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.out_dtype],
+            got: y.dtype(),
+        });
     }
 
-    T0Error::from_problems("residual_add", problems)?;
+    T0Error::from_problems(problems)?;
 
     let num_elem = a.num_elements();
     for i in 0..num_elem {

--- a/crates/r9v-t0/src/rope.rs
+++ b/crates/r9v-t0/src/rope.rs
@@ -4,7 +4,7 @@
 use r9v_ir::{DType, RopeOp, RopeScaling, RopeStyle};
 
 use crate::buffer::{TensorView, TensorViewMut};
-use crate::error::T0Error;
+use crate::error::{push_shape_agreement, T0Error};
 
 /// Precomputes RoPE frequencies for a given token position and rotary dimension.
 #[allow(clippy::needless_range_loop)]
@@ -126,36 +126,58 @@ pub fn rope(
     let mut problems = Vec::new();
 
     if op.rot_dim == 0 || !op.rot_dim.is_multiple_of(2) {
-        problems.push(format!(
-            "rot_dim must be positive and even, got {}",
-            op.rot_dim
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "rope",
+            attribute: "rot_dim",
+            reason: format!("must be positive and even, got {}", op.rot_dim),
+        });
     }
     if !op.theta.is_finite() || op.theta <= 0.0 {
-        problems.push(format!("theta must be finite and > 0, got {}", op.theta));
+        problems.push(T0Error::InvalidAttribute {
+            op: "rope",
+            attribute: "theta",
+            reason: format!("must be finite and > 0, got {}", op.theta),
+        });
     }
     if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "out_dtype must be f16, bf16, or f32, got {:?}",
-            op.out_dtype
-        ));
+        problems.push(T0Error::InvalidAttribute {
+            op: "rope",
+            attribute: "out_dtype",
+            reason: format!("must be f16, bf16, or f32, got {:?}", op.out_dtype),
+        });
     }
     if let Some(sections) = op.mrope_sections {
         if sections.contains(&0) {
-            problems.push("mrope sections must be positive".to_string());
+            problems.push(T0Error::InvalidAttribute {
+                op: "rope",
+                attribute: "mrope_sections",
+                reason: "sections must be positive".to_string(),
+            });
         }
         if sections.iter().any(|&s| s % 2 != 0) {
-            problems.push("mrope section dimensions must be even".to_string());
+            problems.push(T0Error::InvalidAttribute {
+                op: "rope",
+                attribute: "mrope_sections",
+                reason: "section dimensions must be even".to_string(),
+            });
         }
         match sections.iter().try_fold(0u32, |sum, &s| sum.checked_add(s)) {
             Some(total) if total > op.rot_dim => {
-                problems.push(format!(
-                    "sum of mrope sections {total} exceeds rot_dim {}",
-                    op.rot_dim
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "mrope_sections",
+                    reason: format!(
+                        "sum of mrope sections {total} exceeds rot_dim {}",
+                        op.rot_dim
+                    ),
+                });
             }
             None => {
-                problems.push("sum of mrope sections exceeds u32::MAX".to_string());
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "mrope_sections",
+                    reason: "sum of mrope sections exceeds u32::MAX".to_string(),
+                });
             }
             Some(_) => {}
         }
@@ -164,9 +186,11 @@ pub fn rope(
         RopeScaling::None => {}
         RopeScaling::Linear(factor) => {
             if !factor.is_finite() || factor <= 0.0 {
-                problems.push(format!(
-                    "scaling factor must be finite and > 0, got {factor}"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.factor",
+                    reason: format!("must be finite and > 0, got {factor}"),
+                });
             }
         }
         RopeScaling::Yarn {
@@ -177,119 +201,150 @@ pub fn rope(
             mscale,
         } => {
             if !factor.is_finite() || factor <= 0.0 {
-                problems.push(format!(
-                    "scaling factor must be finite and > 0, got {factor}"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.factor",
+                    reason: format!("must be finite and > 0, got {factor}"),
+                });
             }
             if !beta_fast.is_finite() || beta_fast <= 0.0 {
-                problems.push(format!(
-                    "scaling beta_fast must be finite and > 0, got {beta_fast}"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.beta_fast",
+                    reason: format!("must be finite and > 0, got {beta_fast}"),
+                });
             }
             if !beta_slow.is_finite() || beta_slow <= 0.0 {
-                problems.push(format!(
-                    "scaling beta_slow must be finite and > 0, got {beta_slow}"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.beta_slow",
+                    reason: format!("must be finite and > 0, got {beta_slow}"),
+                });
             }
             if beta_slow > beta_fast {
-                problems.push(format!(
-                    "scaling beta_slow ({beta_slow}) cannot exceed beta_fast ({beta_fast})"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.beta_slow",
+                    reason: format!(
+                        "beta_slow ({beta_slow}) cannot exceed beta_fast ({beta_fast})"
+                    ),
+                });
             }
             if orig_ctx == 0 {
-                problems.push("scaling orig_ctx must be > 0".to_string());
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.orig_ctx",
+                    reason: "must be > 0".to_string(),
+                });
             }
             if !mscale.is_finite() || mscale <= 0.0 {
-                problems.push(format!(
-                    "scaling mscale must be finite and > 0, got {mscale}"
-                ));
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling.mscale",
+                    reason: format!("must be finite and > 0, got {mscale}"),
+                });
             }
         }
         RopeScaling::Dynamic => {
             if op.rot_dim == 2 {
-                problems.push(
-                    "rot_dim 2 is invalid for Dynamic RoPE: exponent rot_dim / (rot_dim - 2) requires rot_dim > 2 to avoid division by zero".to_string(),
-                );
+                problems.push(T0Error::InvalidAttribute {
+                    op: "rope",
+                    attribute: "scaling",
+                    reason: "rot_dim 2 is invalid for Dynamic RoPE: exponent rot_dim / (rot_dim - 2) requires rot_dim > 2 to avoid division by zero".to_string(),
+                });
             }
         }
     }
 
     if x.rank() != 3 {
-        problems.push(format!(
-            "input x: expected rank 3 [T, H, D], got rank {} with shape {:?}",
-            x.rank(),
-            x.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 3,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
     }
     if y.rank() != 3 {
-        problems.push(format!(
-            "output y: expected rank 3 [T, H, D], got rank {} with shape {:?}",
-            y.rank(),
-            y.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 3,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
     }
     if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
-        problems.push(format!(
-            "input x: expected f16, bf16, or f32, got {:?}",
-            x.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: x.dtype(),
+        });
     }
     if y.dtype() != op.out_dtype {
-        problems.push(format!(
-            "output y: expected out_dtype {:?}, got {:?}",
-            op.out_dtype,
-            y.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.out_dtype],
+            got: y.dtype(),
+        });
     }
     if positions.dtype() != DType::U32 {
-        problems.push(format!(
-            "positions: expected u32, got {:?}",
-            positions.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "positions",
+            expected: vec![DType::U32],
+            got: positions.dtype(),
+        });
     }
 
     if op.mrope_sections.is_some() {
-        if positions.rank() != 2 || (positions.rank() == 2 && positions.shape()[1] != 3) {
-            problems.push(format!(
-                "mrope requires positions with rank 2 [T, 3], got rank {} with shape {:?}",
-                positions.rank(),
-                positions.shape()
-            ));
+        if positions.rank() != 2 {
+            problems.push(T0Error::RankMismatch {
+                tensor: "positions",
+                expected: 2,
+                got: positions.rank(),
+                shape: positions.shape().to_vec(),
+            });
+        } else if positions.shape()[1] != 3 {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "d1",
+                expected_from: "mrope",
+                expected: 3,
+                tensor: "positions",
+                got: positions.shape()[1],
+            });
         }
     } else if positions.rank() != 1 {
-        problems.push(format!(
-            "standard rope requires positions with rank 1 [T], got rank {} with shape {:?}",
-            positions.rank(),
-            positions.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "positions",
+            expected: 1,
+            got: positions.rank(),
+            shape: positions.shape().to_vec(),
+        });
     }
 
     if x.rank() == 3 {
         let t = x.shape()[0];
         let d = x.shape()[2];
         if positions.shape()[0] != t {
-            problems.push(format!(
-                "positions token dimension {} does not match input x token dimension T={}",
-                positions.shape()[0],
-                t
-            ));
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "x",
+                expected: t,
+                tensor: "positions",
+                got: positions.shape()[0],
+            });
         }
         if (op.rot_dim as usize) > d {
-            problems.push(format!(
-                "rot_dim {} exceeds head dimension D={}",
-                op.rot_dim, d
-            ));
+            problems.push(T0Error::InvalidAttribute {
+                op: "rope",
+                attribute: "rot_dim",
+                reason: format!("rot_dim {} exceeds head dimension D={d}", op.rot_dim),
+            });
         }
         if y.rank() == 3 && y.shape() != x.shape() {
-            problems.push(format!(
-                "output y shape {:?} does not match input x shape {:?}",
-                y.shape(),
-                x.shape()
-            ));
+            push_shape_agreement(&mut problems, "y", "x", y.shape(), x.shape());
         }
     }
 
-    T0Error::from_problems("rope", problems)?;
+    T0Error::from_problems(problems)?;
 
     let t = x.shape()[0];
     let h = x.shape()[1];

--- a/crates/r9v-t0/src/sampling.rs
+++ b/crates/r9v-t0/src/sampling.rs
@@ -106,7 +106,7 @@ pub fn logits_postprocess(
             }
         }
     }
-    T0Error::from_typed_problems(parameter_problems)?;
+    T0Error::from_problems(parameter_problems)?;
 
     if let Some(history) = history_counts {
         let expected_hist = s * v;
@@ -133,6 +133,26 @@ pub fn logits_postprocess(
         }
     }
 
+    // DECISION(A1.8): raw-logit NaN and +Inf are rejected with their exact (seq, query, token) location before any output is touched, while -Inf is allowed as the intentional encoding of impossible tokens (it is also what the grammar mask writes); rejected treating -Inf as invalid because callers legitimately pre-mask logits, and rejected post-softmax-only detection because a NaN poisons the whole row's max/sum and hides its origin. Spec 1 §4.F.
+    for s_idx in 0..s {
+        for q_idx in 0..q {
+            let offset = (s_idx * q + q_idx) * v;
+            for (tok, &logit) in logits[offset..offset + v].iter().enumerate() {
+                if logit.is_nan() || logit == f32::INFINITY {
+                    return Err(T0Error::InvalidLogit {
+                        op: "logits_postprocess",
+                        seq: s_idx,
+                        query: q_idx,
+                        token: tok,
+                        value: logit,
+                    });
+                }
+            }
+        }
+    }
+
+    // DECISION(A1.8): the whole output is computed into a staging buffer and copied to out_probs only on success, so any mid-loop refusal (masked-out row, post-transform overflow, degenerate renormalization) leaves the caller's buffer bit-identical; rejected in-place writes because an early row would already be overwritten when a later row fails. Spec 1 §4.F.
+    let mut staged_probs = vec![0.0f32; expected_len];
     let mut work_logits = vec![0.0f32; v];
     let mut exp_vals = vec![0.0f32; v];
     let mut cand_mask = vec![false; v];
@@ -144,7 +164,7 @@ pub fn logits_postprocess(
         for q_idx in 0..q {
             let offset = (s_idx * q + q_idx) * v;
             let logit_slice = &logits[offset..offset + v];
-            let out_slice = &mut out_probs[offset..offset + v];
+            let out_slice = &mut staged_probs[offset..offset + v];
             let mask_slice = grammar_mask.map(|m| &m[offset..offset + v]);
 
             work_logits.copy_from_slice(logit_slice);
@@ -194,6 +214,21 @@ pub fn logits_postprocess(
                     if !allowed {
                         work_logits[tok] = f32::NEG_INFINITY;
                     }
+                }
+            }
+
+            // Post-transform overflow check: bias, penalties, and temperature
+            // scaling run in f32 and can overflow finite inputs to +Inf (or NaN
+            // via Inf arithmetic). -Inf stays legal (masked/impossible token).
+            for (tok, &l) in work_logits.iter().enumerate() {
+                if l.is_nan() || l == f32::INFINITY {
+                    return Err(T0Error::InvalidLogit {
+                        op: "logits_postprocess",
+                        seq: s_idx,
+                        query: q_idx,
+                        token: tok,
+                        value: l,
+                    });
                 }
             }
 
@@ -328,7 +363,167 @@ pub fn logits_postprocess(
         }
     }
 
+    out_probs.copy_from_slice(&staged_probs);
     Ok(())
+}
+
+// DECISION(A1.8): the f64 oracle re-implements the logits_postprocess pipeline (bias, penalties, temperature, mask, stable (-logit, index) sort, top-k/top-p/min-p, renormalization, temperature-zero argmax) independently in f64 rather than calling the f32 implementation, so cross-tests compare two formulas instead of one formula against itself; rejected deriving the oracle from the f32 code path because a shared implementation would reproduce shared bugs. Spec 1 §4.F, §6.5.
+/// Independent 64-bit floating point oracle for `logits_postprocess` (Spec 1 §4.F, §6.5).
+///
+/// Re-implements the postprocessing pipeline in `f64` for cross-testing the f32
+/// T0 implementation within [`crate::tolerance::Tolerance`] bounds. Assumes
+/// valid inputs (finite logits or intentional `-Inf`, finite biases, at least
+/// one unmasked token per row); invalid inputs are a test bug, not an error.
+#[allow(clippy::too_many_arguments)]
+pub fn logits_postprocess_f64_reference(
+    logits: &[f64],
+    s: usize,
+    q: usize,
+    v: usize,
+    params: &[SamplingParams],
+    history_counts: Option<&[u32]>,
+    grammar_mask: Option<&[bool]>,
+) -> Vec<f64> {
+    assert_eq!(logits.len(), s * q * v);
+    assert_eq!(params.len(), s);
+    if let Some(history) = history_counts {
+        assert_eq!(history.len(), s * v);
+    }
+    if let Some(mask) = grammar_mask {
+        assert_eq!(mask.len(), s * q * v);
+    }
+
+    let mut probs = vec![0.0f64; s * q * v];
+    let mut work = vec![0.0f64; v];
+
+    for s_idx in 0..s {
+        let p = &params[s_idx];
+        let hist_row = history_counts.map(|h| &h[s_idx * v..(s_idx + 1) * v]);
+        for q_idx in 0..q {
+            let offset = (s_idx * q + q_idx) * v;
+            work.copy_from_slice(&logits[offset..offset + v]);
+            let out_slice = &mut probs[offset..offset + v];
+            let mask_slice = grammar_mask.map(|m| &m[offset..offset + v]);
+
+            for &(token_id, bias) in &p.logit_bias {
+                work[token_id as usize] += bias as f64;
+            }
+            if let Some(hist) = hist_row {
+                for (tok, &count) in hist.iter().enumerate().take(v) {
+                    if count > 0 {
+                        let l = work[tok];
+                        if p.repetition_penalty != 1.0 {
+                            work[tok] = if l > 0.0 {
+                                l / p.repetition_penalty as f64
+                            } else {
+                                l * p.repetition_penalty as f64
+                            };
+                        }
+                        if p.presence_penalty != 0.0 {
+                            work[tok] -= p.presence_penalty as f64;
+                        }
+                        if p.frequency_penalty != 0.0 {
+                            work[tok] -= (count as f64) * p.frequency_penalty as f64;
+                        }
+                    }
+                }
+            }
+            if p.temperature > 0.0 {
+                let inv_temp = 1.0 / p.temperature as f64;
+                for l in &mut work {
+                    *l *= inv_temp;
+                }
+            }
+            if let Some(mask) = mask_slice {
+                for (tok, &allowed) in mask.iter().enumerate().take(v) {
+                    if !allowed {
+                        work[tok] = f64::NEG_INFINITY;
+                    }
+                }
+            }
+
+            if p.temperature == 0.0 {
+                let mut best_idx = 0;
+                let mut best_val = f64::NEG_INFINITY;
+                for (tok, &l) in work.iter().enumerate() {
+                    if l > best_val {
+                        best_val = l;
+                        best_idx = tok;
+                    }
+                }
+                out_slice.fill(0.0);
+                out_slice[best_idx] = 1.0;
+                continue;
+            }
+
+            let max_l = work
+                .iter()
+                .copied()
+                .filter(|&l| l > f64::NEG_INFINITY)
+                .fold(f64::NEG_INFINITY, f64::max);
+            let mut sum_exp = 0.0f64;
+            let mut exp_vals = vec![0.0f64; v];
+            for tok in 0..v {
+                if work[tok] > f64::NEG_INFINITY {
+                    let e = (work[tok] - max_l).exp();
+                    exp_vals[tok] = e;
+                    sum_exp += e;
+                }
+            }
+            assert!(sum_exp > 0.0 && sum_exp.is_finite());
+            for tok in 0..v {
+                out_slice[tok] = exp_vals[tok] / sum_exp;
+            }
+
+            let mut candidates: Vec<usize> =
+                (0..v).filter(|&i| work[i] > f64::NEG_INFINITY).collect();
+            candidates.sort_by(|&a, &b| {
+                (-work[a], a)
+                    .partial_cmp(&(-work[b], b))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            if p.top_k > 0 && (p.top_k as usize) < candidates.len() {
+                candidates.truncate(p.top_k as usize);
+            }
+            if p.top_p < 1.0 {
+                let mut cumsum = 0.0f64;
+                let mut keep = 0;
+                for &idx in &candidates {
+                    cumsum += out_slice[idx];
+                    keep += 1;
+                    if cumsum >= p.top_p as f64 {
+                        break;
+                    }
+                }
+                candidates.truncate(keep.max(1));
+            }
+            if p.min_p > 0.0 && !candidates.is_empty() {
+                let p_max = out_slice[candidates[0]];
+                let thresh = p.min_p as f64 * p_max;
+                let filtered: Vec<usize> = candidates
+                    .iter()
+                    .copied()
+                    .filter(|&idx| out_slice[idx] >= thresh)
+                    .collect();
+                if !filtered.is_empty() {
+                    candidates = filtered;
+                } else {
+                    candidates.truncate(1);
+                }
+            }
+
+            let cand_sum: f64 = candidates.iter().map(|&idx| out_slice[idx]).sum();
+            assert!(cand_sum > 0.0 && cand_sum.is_finite());
+            let inv_cand_sum = 1.0 / cand_sum;
+            for slot in out_slice.iter_mut() {
+                *slot = 0.0;
+            }
+            for &idx in &candidates {
+                out_slice[idx] = exp_vals[idx] / sum_exp * inv_cand_sum;
+            }
+        }
+    }
+    probs
 }
 
 /// Stochastic or greedy inverse-CDF token sampling op (Spec 1 §4.F).
@@ -381,6 +576,9 @@ pub fn sample(
     for s_idx in 0..s {
         validate_distribution(&probs[s_idx * v..(s_idx + 1) * v], "sample", s_idx, 0)?;
     }
+    for rng in rng_states.iter() {
+        rng.ensure_can_advance(1, "sample")?;
+    }
 
     let mut tokens = Vec::with_capacity(s);
 
@@ -388,7 +586,7 @@ pub fn sample(
         let p_row = &probs[s_idx * v..(s_idx + 1) * v];
 
         // Draw uniform random float u in (0, 1) and advance RNG state by 1
-        let u = rng.draw_uniform_f32();
+        let u = rng.draw_uniform_f32()?;
 
         let mut cumsum = 0.0f32;
         let mut chosen = v - 1;
@@ -549,6 +747,24 @@ pub fn verify(
         });
     }
 
+    // DECISION(A1.8): TypicalAcceptance eps/delta are validated publicly at the verify boundary (finite, strictly positive) before any RNG or output mutation, matching the IR contract; rejected deferring validation to the per-position loop because a late refusal would leave earlier sequences' RNG states advanced and outputs committed. Spec 7 §4.
+    if let VerifyMethod::TypicalAcceptance { eps, delta } = *method {
+        if !eps.is_finite() || eps <= 0.0 {
+            return Err(T0Error::InvalidAttribute {
+                op: "verify",
+                attribute: "method.eps",
+                reason: format!("typical acceptance eps must be finite and > 0.0, got {eps}"),
+            });
+        }
+        if !delta.is_finite() || delta <= 0.0 {
+            return Err(T0Error::InvalidAttribute {
+                op: "verify",
+                attribute: "method.delta",
+                reason: format!("typical acceptance delta must be finite and > 0.0, got {delta}"),
+            });
+        }
+    }
+
     if let Some(tree_mask) = tree {
         if tree_mask.t() != k {
             return Err(T0Error::ShapeLengthMismatch {
@@ -574,6 +790,9 @@ pub fn verify(
             let offset = (s_idx * k_plus_one + pos) * v;
             validate_distribution(&target_probs[offset..offset + v], "verify", s_idx, pos)?;
         }
+    }
+    for rng in rng_states.iter() {
+        rng.ensure_can_advance(draw_advance, "verify")?;
     }
 
     // Precompute root-to-leaf paths for tree drafts (Spec 7 §5)
@@ -639,7 +858,7 @@ pub fn verify(
             };
             out_acc_slice[0] = bonus_tok;
             out_accept_len[s_idx] = 0;
-            rng.advance(1);
+            rng.advance(1)?;
             continue;
         }
 
@@ -714,8 +933,11 @@ pub fn verify(
                                     rng.draw_at(terminal_draw),
                                 )?;
                             } else {
-                                // Fallback to target argmax if residual is zeroed
-                                terminal_token = argmax_stable(target_dist) as u32;
+                                // DECISION(A1.8): a degenerate zero residual (norm(max(0, p-q)) undefined, reachable only through float rounding since exact p == q implies acceptance with alpha == 1) falls back to sampling the validated target distribution with the same reserved terminal draw k; rejected the argmax fallback because it is not distribution-exact and would silently change the draw-consumption contract (every rejection consumes exactly draw k). Spec 1 §4.F, Spec 7 §4.
+                                terminal_token = sample_from_distribution(
+                                    target_dist,
+                                    rng.draw_at(terminal_draw),
+                                )?;
                             }
                             false
                         }
@@ -800,7 +1022,7 @@ pub fn verify(
         out_acc_slice[best_path_len] = best_terminal_token;
 
         // Advance RNG state by k + 1 for clean non-overlapping step keying (Spec 1 §4.F, Spec 7 §4)
-        rng.advance(draw_advance);
+        rng.advance(draw_advance)?;
     }
 
     Ok(VerifyOutput {
@@ -932,7 +1154,7 @@ mod tests {
             0.0, 0.0, 0.0, 0.0, 1.0, // pos 2: bonus token is 1
             0.0, 1.0, 0.0, 0.0, 0.0,
         ];
-        let mut rng_states = vec![RngState::new(42, 1, 0)];
+        let mut rng_states = vec![RngState::from_u64(42, 1, 0).unwrap()];
 
         let out = verify(
             &draft_tokens,

--- a/crates/r9v-t0/src/scatter_add_rows.rs
+++ b/crates/r9v-t0/src/scatter_add_rows.rs
@@ -142,7 +142,7 @@ pub fn scatter_add_rows(
         }
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     let m = x.shape()[0];
     let d = x.shape()[1];
@@ -231,7 +231,7 @@ pub fn scatter_add_rows(
         }
     }
 
-    T0Error::from_typed_problems(problems)?;
+    T0Error::from_problems(problems)?;
 
     // Initialize y with dest or zeros
     if let Some(dest_view) = dest {

--- a/crates/r9v-t0/src/split.rs
+++ b/crates/r9v-t0/src/split.rs
@@ -22,83 +22,123 @@ pub fn split(
     let mut problems = Vec::new();
 
     if op.first == 0 {
-        problems.push("attribute first: split width must be > 0".to_string());
+        problems.push(T0Error::InvalidAttribute {
+            op: "split",
+            attribute: "first",
+            reason: "split width must be > 0".to_string(),
+        });
     }
     if x.rank() != 3 {
-        problems.push(format!(
-            "input x: expected rank 3 [T, H, D], got rank {} with shape {:?}",
-            x.rank(),
-            x.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 3,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
     }
     if a.rank() != 3 {
-        problems.push(format!(
-            "output a: expected rank 3 [T, H, first], got rank {} with shape {:?}",
-            a.rank(),
-            a.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "a",
+            expected: 3,
+            got: a.rank(),
+            shape: a.shape().to_vec(),
+        });
     }
     if b.rank() != 3 {
-        problems.push(format!(
-            "output b: expected rank 3 [T, H, D - first], got rank {} with shape {:?}",
-            b.rank(),
-            b.shape()
-        ));
+        problems.push(T0Error::RankMismatch {
+            tensor: "b",
+            expected: 3,
+            got: b.rank(),
+            shape: b.shape().to_vec(),
+        });
     }
     for (name, view) in [("x", x.dtype()), ("a", a.dtype()), ("b", b.dtype())] {
         if !matches!(view, DType::F16 | DType::Bf16 | DType::F32) {
-            problems.push(format!(
-                "tensor {name}: expected f16, bf16, or f32, got {view:?}"
-            ));
+            problems.push(T0Error::DTypeMismatch {
+                tensor: name,
+                expected: vec![DType::F16, DType::Bf16, DType::F32],
+                got: view,
+            });
         }
     }
     if a.dtype() != x.dtype() {
-        problems.push(format!(
-            "output a: expected input x dtype {:?}, got {:?}",
-            x.dtype(),
-            a.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "a",
+            expected: vec![x.dtype()],
+            got: a.dtype(),
+        });
     }
     if b.dtype() != x.dtype() {
-        problems.push(format!(
-            "output b: expected input x dtype {:?}, got {:?}",
-            x.dtype(),
-            b.dtype()
-        ));
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "b",
+            expected: vec![x.dtype()],
+            got: b.dtype(),
+        });
     }
     if x.rank() == 3 && a.rank() == 3 && b.rank() == 3 {
         let (t, h, d) = (x.shape()[0], x.shape()[1], x.shape()[2]);
-        if a.shape()[0] != t || a.shape()[1] != h {
-            problems.push(format!(
-                "output a shape {:?} does not share input [T, H] = [{t}, {h}]",
-                a.shape()
-            ));
+        if a.shape()[0] != t {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "x",
+                expected: t,
+                tensor: "a",
+                got: a.shape()[0],
+            });
         }
-        if b.shape()[0] != t || b.shape()[1] != h {
-            problems.push(format!(
-                "output b shape {:?} does not share input [T, H] = [{t}, {h}]",
-                b.shape()
-            ));
+        if a.shape()[1] != h {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "H",
+                expected_from: "x",
+                expected: h,
+                tensor: "a",
+                got: a.shape()[1],
+            });
+        }
+        if b.shape()[0] != t {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "x",
+                expected: t,
+                tensor: "b",
+                got: b.shape()[0],
+            });
+        }
+        if b.shape()[1] != h {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "H",
+                expected_from: "x",
+                expected: h,
+                tensor: "b",
+                got: b.shape()[1],
+            });
         }
         if a.shape()[2] != op.first as usize {
-            problems.push(format!(
-                "output a width {} does not match split attr first={}",
-                a.shape()[2],
-                op.first
-            ));
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "first",
+                expected_from: "op",
+                expected: op.first as usize,
+                tensor: "a",
+                got: a.shape()[2],
+            });
         }
         match (op.first as usize).checked_add(b.shape()[2]) {
             Some(sum) if sum == d => {}
-            Some(sum) => problems.push(format!(
-                "output widths {} + {} = {sum} do not reconstruct input dim {d}",
-                op.first,
-                b.shape()[2]
-            )),
-            None => problems.push("output widths overflow usize".to_string()),
+            Some(sum) => problems.push(T0Error::DimensionMismatch {
+                dim_name: "D",
+                expected_from: "x",
+                expected: d,
+                tensor: "b",
+                got: sum,
+            }),
+            None => problems.push(T0Error::ArithmeticOverflow {
+                op: "split",
+                detail: "output widths overflow usize".to_string(),
+            }),
         }
     }
 
-    T0Error::from_problems("split", problems)?;
+    T0Error::from_problems(problems)?;
 
     let (t, h, d) = (x.shape()[0], x.shape()[1], x.shape()[2]);
     let first = op.first as usize;

--- a/crates/r9v-t0/tests/act_mul_tests.rs
+++ b/crates/r9v-t0/tests/act_mul_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{ActMulOp, ActivationKind, DType};
-use r9v_t0::{act_mul, act_mul_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{act_mul, act_mul_f64_reference, T0Error, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -258,8 +258,20 @@ fn act_mul_rejects_malformed_operands() {
         &mut y_buf.as_view_mut(),
     )
     .unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("clamp must be finite and > 0"));
-    assert!(msg.contains("does not match"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    assert_eq!(problems.len(), 2);
+    assert!(
+        problems.iter().any(
+            |e| matches!(e, T0Error::InvalidAttribute { attribute, .. } if *attribute == "clamp")
+        ),
+        "missing clamp problem: {problems:?}"
+    );
+    assert!(
+        problems
+            .iter()
+            .any(|e| matches!(e, T0Error::DimensionMismatch { tensor, .. } if *tensor == "up")),
+        "missing shape problem: {problems:?}"
+    );
 }

--- a/crates/r9v-t0/tests/activation_tests.rs
+++ b/crates/r9v-t0/tests/activation_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{ActivationKind, ActivationOp, DType};
-use r9v_t0::{activation, activation_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{activation, activation_f64_reference, T0Error, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -186,10 +186,22 @@ fn activation_rejects_malformed_operands() {
     let mut y_buf = TypedBuffer::zeros(&[2, 128], DType::F32); // shape mismatch
 
     let err = activation(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("clamp must be finite and > 0"));
-    assert!(msg.contains("does not match"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    assert_eq!(problems.len(), 2);
+    assert!(
+        problems.iter().any(
+            |e| matches!(e, T0Error::InvalidAttribute { attribute, .. } if *attribute == "clamp")
+        ),
+        "missing clamp problem: {problems:?}"
+    );
+    assert!(
+        problems
+            .iter()
+            .any(|e| matches!(e, T0Error::DimensionMismatch { tensor, .. } if *tensor == "y")),
+        "missing shape problem: {problems:?}"
+    );
 }
 
 #[test]

--- a/crates/r9v-t0/tests/api_shape.rs
+++ b/crates/r9v-t0/tests/api_shape.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::needless_range_loop)]
 //! API shape verification for r9v-t0 crate (CONVENTIONS.md §3, Cards A1.5 and A1.8).
 
+use r9v_common::{SeqId, StepId};
 use r9v_ir::{DType, SamplingParams, VerifyMethod};
 use r9v_t0::*;
 
@@ -271,13 +272,14 @@ fn test_type_markers_and_traits() {
     assert_sync::<T0Error>();
 
     // Check trait implementations
-    let rng = RngState::new(42, 1, 0);
+    let rng = RngState::from_u64(42, 1, 0).unwrap();
     let rng_clone = rng.clone();
     assert_eq!(rng, rng_clone);
     assert_eq!(rng.seed(), 42);
-    assert_eq!(rng.seq_id(), 1);
-    assert_eq!(rng.step(), 0);
+    assert_eq!(rng.seq_id(), SeqId::new(1));
+    assert_eq!(rng.step(), StepId::new(0));
     assert_eq!(rng.draw_index(), 0);
+    assert_eq!(rng.seq_id_u32(), 1);
 
     let output = VerifyOutput {
         accepted: vec![1, 2, 3],
@@ -313,7 +315,7 @@ fn test_public_function_signatures() {
     assert!(res.is_ok());
 
     // Verify sample signature
-    let mut rng_states = vec![RngState::new(1, 0, 0)];
+    let mut rng_states = vec![RngState::from_u64(1, 0, 0).unwrap()];
     let res_sample = sample(&probs, 1, 2, &mut rng_states);
     assert!(res_sample.is_ok());
 

--- a/crates/r9v-t0/tests/cast_tests.rs
+++ b/crates/r9v-t0/tests/cast_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{CastOp, DType};
-use r9v_t0::{bf16_to_f32, cast, cast_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{bf16_to_f32, cast, cast_f64_reference, T0Error, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -168,9 +168,22 @@ fn cast_rejects_shape_and_dtype_mismatches() {
     let mut y_buf = TypedBuffer::zeros(&[2, 32], DType::F32); // shape and dtype mismatch
 
     let err = cast(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("does not match"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    assert_eq!(problems.len(), 2);
+    assert!(
+        problems
+            .iter()
+            .any(|e| matches!(e, T0Error::DimensionMismatch { tensor, .. } if *tensor == "y")),
+        "missing shape problem: {problems:?}"
+    );
+    assert!(
+        problems
+            .iter()
+            .any(|e| matches!(e, T0Error::DTypeMismatch { tensor, .. } if *tensor == "y")),
+        "missing dtype problem: {problems:?}"
+    );
 }
 
 /// Identity casts preserve `u32` values beyond 2^24 exactly (Spec 1 §2.1, Spec 1 §6.4).
@@ -385,5 +398,16 @@ fn cast_identity_rejects_shape_mismatch() {
     let x_buf = TypedBuffer::zeros(&[2, 64], DType::U32);
     let mut y_buf = TypedBuffer::zeros(&[2, 32], DType::U32);
     let err = cast(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
-    assert!(err.to_string().contains("does not match"));
+    assert!(
+        matches!(
+            err,
+            T0Error::DimensionMismatch {
+                tensor: "y",
+                expected: 64,
+                got: 32,
+                ..
+            }
+        ),
+        "expected y dimension mismatch, got {err:?}"
+    );
 }

--- a/crates/r9v-t0/tests/copy_tests.rs
+++ b/crates/r9v-t0/tests/copy_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{CopyKind, CopyOp, DType};
-use r9v_t0::{copy, copy_f64_reference, TypedBuffer};
+use r9v_t0::{copy, copy_f64_reference, T0Error, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -129,9 +129,18 @@ fn copy_rejects_shape_and_dtype_mismatches() {
     let mut dst = TypedBuffer::zeros(&[2, 32], DType::F32); // shape mismatch
 
     let err = copy(&op, &src.as_view(), &mut dst.as_view_mut()).unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("does not match"));
+    assert!(
+        matches!(
+            err,
+            T0Error::DimensionMismatch {
+                tensor: "y",
+                expected: 64,
+                got: 32,
+                ..
+            }
+        ),
+        "expected y dimension mismatch, got {err:?}"
+    );
 }
 
 #[test]

--- a/crates/r9v-t0/tests/determinism_tests.rs
+++ b/crates/r9v-t0/tests/determinism_tests.rs
@@ -79,9 +79,9 @@ fn determinism_sample_run_to_run_bit_identical() {
     ];
 
     let mut rng1 = vec![
-        RngState::new(100, 1, 5),
-        RngState::new(200, 2, 5),
-        RngState::new(300, 3, 5),
+        RngState::from_u64(100, 1, 5).unwrap(),
+        RngState::from_u64(200, 2, 5).unwrap(),
+        RngState::from_u64(300, 3, 5).unwrap(),
     ];
     let mut rng2 = rng1.clone();
 
@@ -117,7 +117,10 @@ fn determinism_verify_run_to_run_bit_identical() {
             delta: 0.8,
         },
     ] {
-        let mut rng1 = vec![RngState::new(42, 1, 10), RngState::new(43, 2, 10)];
+        let mut rng1 = vec![
+            RngState::from_u64(42, 1, 10).unwrap(),
+            RngState::from_u64(43, 2, 10).unwrap(),
+        ];
         let mut rng2 = rng1.clone();
 
         let out1 = verify(
@@ -178,7 +181,7 @@ fn determinism_batch_invariance_sequence_alone_vs_batched() {
     )
     .unwrap();
 
-    let mut rng_alone = vec![RngState::new(999, 101, 1)];
+    let mut rng_alone = vec![RngState::from_u64(999, 101, 1).unwrap()];
     let token_alone = sample(&out_alone, 1, v, &mut rng_alone).unwrap()[0];
 
     // 2. Run batched with sequence 1 and sequence 2
@@ -201,9 +204,9 @@ fn determinism_batch_invariance_sequence_alone_vs_batched() {
     .unwrap();
 
     let mut rng_batched = vec![
-        RngState::new(999, 101, 1),
-        RngState::new(888, 102, 1),
-        RngState::new(777, 103, 1),
+        RngState::from_u64(999, 101, 1).unwrap(),
+        RngState::from_u64(888, 102, 1).unwrap(),
+        RngState::from_u64(777, 103, 1).unwrap(),
     ];
     let tokens_batched = sample(&out_batched, 3, v, &mut rng_batched).unwrap();
 

--- a/crates/r9v-t0/tests/distribution_tests.rs
+++ b/crates/r9v-t0/tests/distribution_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! 100,000-draw distribution tests for speculative rejection sampling (Spec 1 §4.F, Spec 7 §4, Card A1.8).
 
+use r9v_common::StepId;
 use r9v_ir::VerifyMethod;
 use r9v_t0::{sample, verify, RngState};
 
@@ -27,9 +28,9 @@ fn rejection_sampling_output_frequency_matches_target_sampling_1e5_draws() {
     let mut rejection_counts = vec![0usize; vocab_size];
     let mut direct_counts = vec![0usize; vocab_size];
 
-    let mut rng_rej = RngState::new(123456789, 1, 0);
-    let mut rng_direct = RngState::new(987654321, 2, 0);
-    let mut rng_draft = RngState::new(555555555, 3, 0);
+    let mut rng_rej = RngState::from_u64(123456789, 1, 0).unwrap();
+    let mut rng_direct = RngState::from_u64(987654321, 2, 0).unwrap();
+    let mut rng_draft = RngState::from_u64(555555555, 3, 0).unwrap();
 
     // Target probs array for verify [S=1, k+1=2, V=4]
     let mut target_probs = Vec::with_capacity(vocab_size * 2);
@@ -44,10 +45,10 @@ fn rejection_sampling_output_frequency_matches_target_sampling_1e5_draws() {
     for step in 0..draws {
         // 1. Draw a draft token from draft distribution Q
         let draft_tok = sample(&draft_q, 1, vocab_size, &mut [rng_draft.clone()]).unwrap()[0];
-        rng_draft.advance(1);
+        rng_draft.advance(1).unwrap();
 
         // 2. Perform speculative rejection sampling verification
-        rng_rej.set_step(step as u64);
+        rng_rej.set_step(StepId::new(step as u64));
         let mut rng_slice = [rng_rej.clone()];
         let out = verify(
             &[draft_tok],
@@ -68,7 +69,7 @@ fn rejection_sampling_output_frequency_matches_target_sampling_1e5_draws() {
         rejection_counts[emitted_token] += 1;
 
         // 3. Perform direct sampling from target distribution P
-        rng_direct.set_step(step as u64);
+        rng_direct.set_step(StepId::new(step as u64));
         let mut rng_dir_slice = [rng_direct.clone()];
         let dir_token = sample(&target_p, 1, vocab_size, &mut rng_dir_slice).unwrap()[0] as usize;
         rng_direct = rng_dir_slice[0].clone();
@@ -112,7 +113,7 @@ fn rejection_sampling_matches_target_sampling_within_statistical_tolerance_on_sy
     let draws = 100_000;
 
     let mut rejection_counts = vec![0usize; vocab_size];
-    let mut rng_rej = RngState::new(777, 10, 0);
+    let mut rng_rej = RngState::from_u64(777, 10, 0).unwrap();
 
     let mut target_probs = Vec::with_capacity(vocab_size * 2);
     target_probs.extend_from_slice(&target_p);
@@ -124,7 +125,7 @@ fn rejection_sampling_matches_target_sampling_within_statistical_tolerance_on_sy
     let draft_tok = 2u32;
 
     for step in 0..draws {
-        rng_rej.set_step(step as u64);
+        rng_rej.set_step(StepId::new(step as u64));
         let mut rng_slice = [rng_rej.clone()];
         let out = verify(
             &[draft_tok],

--- a/crates/r9v-t0/tests/greedy_tests.rs
+++ b/crates/r9v-t0/tests/greedy_tests.rs
@@ -41,7 +41,7 @@ fn greedy_equivalence_at_temperature_zero() {
 
     // 2. Sample on temperature 0 distribution must deterministically return argmax
     for seed in [1, 42, 999, 123456] {
-        let mut rng = vec![RngState::new(seed, 1, 0)];
+        let mut rng = vec![RngState::from_u64(seed, 1, 0).unwrap()];
         let token = sample(&probs, 1, v, &mut rng).unwrap()[0];
         assert_eq!(
             token, 1,
@@ -80,8 +80,8 @@ fn greedy_equivalence_temperature_zero_rejection_matches_greedy() {
 
     // Scenario A: all draft tokens match greedy argmax [2, 4, 0]
     let matching_draft = vec![2u32, 4, 0];
-    let mut rng_greedy = vec![RngState::new(42, 1, 0)];
-    let mut rng_rejection = vec![RngState::new(42, 1, 0)];
+    let mut rng_greedy = vec![RngState::from_u64(42, 1, 0).unwrap()];
+    let mut rng_rejection = vec![RngState::from_u64(42, 1, 0).unwrap()];
 
     let out_greedy = verify(
         &matching_draft,
@@ -116,8 +116,8 @@ fn greedy_equivalence_temperature_zero_rejection_matches_greedy() {
 
     // Scenario B: partial match - second draft token mismatches: [2, 1 (instead of 4), 0]
     let partial_draft = vec![2u32, 1, 0];
-    let mut rng_g2 = vec![RngState::new(100, 2, 0)];
-    let mut rng_r2 = vec![RngState::new(100, 2, 0)];
+    let mut rng_g2 = vec![RngState::from_u64(100, 2, 0).unwrap()];
+    let mut rng_r2 = vec![RngState::from_u64(100, 2, 0).unwrap()];
 
     let out_g2 = verify(
         &partial_draft,

--- a/crates/r9v-t0/tests/norm_tests.rs
+++ b/crates/r9v-t0/tests/norm_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{DType, NormAxis, NormKind, NormOp};
-use r9v_t0::{norm, norm_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{norm, norm_f64_reference, T0Error, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -424,10 +424,39 @@ fn norm_rejects_malformed_inputs_with_complete_error() {
         &mut y_buf.as_view_mut(),
     )
     .unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("not divisible"));
-    assert!(msg.contains("does not match"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    assert_eq!(problems.len(), 3);
+    assert!(
+        problems.iter().any(|e| matches!(
+            e,
+            T0Error::DimensionMismatch {
+                tensor: "weight",
+                dim_name: "N",
+                expected: 128,
+                got: 100,
+                ..
+            }
+        )),
+        "missing weight problem: {problems:?}"
+    );
+    assert!(
+        problems
+            .iter()
+            .any(|e| matches!(e, T0Error::DimensionMismatch { tensor: "y", .. })),
+        "missing y shape problem: {problems:?}"
+    );
+    assert!(
+        problems.iter().any(|e| matches!(
+            e,
+            T0Error::InvalidAttribute {
+                attribute: "axis",
+                ..
+            }
+        )),
+        "missing axis problem: {problems:?}"
+    );
 }
 
 #[test]
@@ -453,10 +482,16 @@ fn norm_rejects_invalid_attributes() {
     )
     .unwrap_err();
 
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("eps must be finite and > 0"));
-    assert!(msg.contains("out_dtype must be f16, bf16, or f32"));
-    assert!(msg.contains("weight_offset must be finite"));
-    assert!(msg.contains("NormAxis::Head(d): d must be > 0"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    for attribute in ["eps", "out_dtype", "weight_offset", "axis"] {
+        assert!(
+            problems.iter().any(|e| matches!(
+                e,
+                T0Error::InvalidAttribute { attribute: a, .. } if *a == attribute
+            )),
+            "missing {attribute} problem: {problems:?}"
+        );
+    }
 }

--- a/crates/r9v-t0/tests/quant_act_tests.rs
+++ b/crates/r9v-t0/tests/quant_act_tests.rs
@@ -6,7 +6,7 @@ use r9v_common::rng::SeededRng;
 use r9v_ir::{DType, QuantActOp, QuantScheme, Smoothing};
 use r9v_t0::{
     fp8_e4m3_decode, fp8_e4m3_encode, fp8_e4m3_encode_f64_oracle, quant_act,
-    quant_act_f64_reference, Tolerance, TypedBuffer,
+    quant_act_f64_reference, T0Error, Tolerance, TypedBuffer,
 };
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
@@ -321,9 +321,18 @@ fn quant_act_rejects_non_divisible_block_size_and_mismatches() {
         &mut scale_buf.as_view_mut(),
     )
     .unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("divisible by 32"));
+    assert!(
+        matches!(
+            err,
+            T0Error::InvalidAttribute {
+                op: "quant_act",
+                attribute: "scheme",
+                ..
+            }
+        ),
+        "expected scheme attribute error, got {err:?}"
+    );
+    assert!(err.to_string().contains("divisible by 32"), "{err:?}");
 }
 
 #[test]

--- a/crates/r9v-t0/tests/residual_add_tests.rs
+++ b/crates/r9v-t0/tests/residual_add_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{DType, ResidualAddOp};
-use r9v_t0::{residual_add, residual_add_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{residual_add, residual_add_f64_reference, T0Error, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -319,7 +319,17 @@ fn residual_add_rejects_shape_and_dtype_mismatches() {
         &mut y_buf.as_view_mut(),
     )
     .unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("does not match"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    assert_eq!(problems.len(), 2);
+    for tensor in ["b", "y"] {
+        assert!(
+            problems.iter().any(|e| matches!(
+                e,
+                T0Error::DimensionMismatch { tensor: t, .. } if *t == tensor
+            )),
+            "missing {tensor} shape problem: {problems:?}"
+        );
+    }
 }

--- a/crates/r9v-t0/tests/rope_tests.rs
+++ b/crates/r9v-t0/tests/rope_tests.rs
@@ -4,7 +4,7 @@
 
 use r9v_common::rng::SeededRng;
 use r9v_ir::{DType, RopeOp, RopeScaling, RopeStyle};
-use r9v_t0::{rope, rope_f64_reference, Tolerance, TypedBuffer};
+use r9v_t0::{rope, rope_f64_reference, T0Error, Tolerance, TypedBuffer};
 
 fn generate_f32_data(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
     let mut out = Vec::with_capacity(len);
@@ -375,11 +375,31 @@ fn rope_rejects_odd_rot_dim_and_dimension_mismatch() {
         &mut y_buf.as_view_mut(),
     )
     .unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("validation error(s)"));
-    assert!(msg.contains("rot_dim must be positive and even"));
-    assert!(msg.contains("exceeds head dimension"));
-    assert!(msg.contains("does not match"));
+    let T0Error::Multiple { problems } = err else {
+        panic!("expected aggregated Multiple, got {err:?}");
+    };
+    assert_eq!(problems.len(), 3);
+    assert!(
+        problems.iter().any(|e| matches!(
+            e,
+            T0Error::InvalidAttribute {
+                attribute: "rot_dim",
+                ..
+            }
+        )),
+        "missing rot_dim problem: {problems:?}"
+    );
+    assert!(
+        problems.iter().any(|e| matches!(
+            e,
+            T0Error::DimensionMismatch {
+                tensor: "positions",
+                dim_name: "T",
+                ..
+            }
+        )),
+        "missing positions problem: {problems:?}"
+    );
 }
 
 #[test]

--- a/crates/r9v-t0/tests/sampling_oracle_tests.rs
+++ b/crates/r9v-t0/tests/sampling_oracle_tests.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-tests of f32 `logits_postprocess` against the independent f64 oracle
+//! (Spec 1 §4.F, §6.5, Card A1.8).
+
+use r9v_common::rng::SeededRng;
+use r9v_ir::SamplingParams;
+use r9v_t0::{logits_postprocess, logits_postprocess_f64_reference, Tolerance};
+
+fn base_params() -> SamplingParams {
+    SamplingParams {
+        temperature: 1.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        logit_bias: vec![],
+    }
+}
+
+fn random_logits(rng: &mut SeededRng, len: usize, scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let raw = (rng.next_u64() & 0xFFFF_FFFF) as u32;
+        out.push(((raw as f32 / u32::MAX as f32) * 2.0 - 1.0) * scale);
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_oracle_agreement(
+    logits: &[f32],
+    s: usize,
+    q: usize,
+    v: usize,
+    params: &[SamplingParams],
+    history_counts: Option<&[u32]>,
+    grammar_mask: Option<&[bool]>,
+    context: &str,
+) {
+    let mut probs = vec![0.0f32; s * q * v];
+    logits_postprocess(
+        logits,
+        s,
+        q,
+        v,
+        params,
+        history_counts,
+        grammar_mask,
+        &mut probs,
+    )
+    .unwrap_or_else(|e| panic!("{context}: f32 implementation failed: {e:?}"));
+
+    let logits_f64: Vec<f64> = logits.iter().map(|&x| x as f64).collect();
+    let reference = logits_postprocess_f64_reference(
+        &logits_f64,
+        s,
+        q,
+        v,
+        params,
+        history_counts,
+        grammar_mask,
+    );
+
+    let tol = Tolerance::f32();
+    for (i, (&actual, &expected)) in probs.iter().zip(reference.iter()).enumerate() {
+        tol.assert_within(
+            actual as f64,
+            expected,
+            &format!("{context} at flat index {i}"),
+        );
+    }
+
+    // Both pipelines must emit normalized rows.
+    for row in 0..s * q {
+        let sum: f32 = probs[row * v..(row + 1) * v].iter().sum();
+        assert!(
+            (sum - 1.0).abs() < 1e-5,
+            "{context}: f32 row {row} sums to {sum}"
+        );
+        let ref_sum: f64 = reference[row * v..(row + 1) * v].iter().sum();
+        assert!(
+            (ref_sum - 1.0).abs() < 1e-12,
+            "{context}: oracle row {row} sums to {ref_sum}"
+        );
+    }
+}
+
+#[test]
+fn logits_postprocess_matches_f64_oracle_plain_softmax() {
+    let mut rng = SeededRng::new(0xA1_8001);
+    let (s, q, v) = (2, 3, 32);
+    let logits = random_logits(&mut rng, s * q * v, 3.0);
+    let params = vec![base_params(), base_params()];
+    check_oracle_agreement(&logits, s, q, v, &params, None, None, "plain softmax");
+}
+
+#[test]
+fn logits_postprocess_matches_f64_oracle_temperature_sweep() {
+    let mut rng = SeededRng::new(0xA1_8002);
+    let (s, q, v) = (1, 2, 24);
+    let logits = random_logits(&mut rng, s * q * v, 2.5);
+    for &temp in &[0.2f32, 0.7, 1.0, 2.0] {
+        let mut p = base_params();
+        p.temperature = temp;
+        let context = format!("temperature {temp}");
+        check_oracle_agreement(
+            &logits,
+            s,
+            q,
+            v,
+            std::slice::from_ref(&p),
+            None,
+            None,
+            &context,
+        );
+    }
+}
+
+#[test]
+fn logits_postprocess_temperature_zero_is_exact_argmax() {
+    let mut rng = SeededRng::new(0xA1_8003);
+    let (s, q, v) = (2, 2, 16);
+    let logits = random_logits(&mut rng, s * q * v, 4.0);
+    let mut p = base_params();
+    p.temperature = 0.0;
+    let params = vec![p.clone(), p];
+    let mut probs = vec![0.0f32; s * q * v];
+    logits_postprocess(&logits, s, q, v, &params, None, None, &mut probs).unwrap();
+
+    let logits_f64: Vec<f64> = logits.iter().map(|&x| x as f64).collect();
+    let reference = logits_postprocess_f64_reference(&logits_f64, s, q, v, &params, None, None);
+    for (i, (&actual, &expected)) in probs.iter().zip(reference.iter()).enumerate() {
+        assert_eq!(actual, expected as f32, "temperature-0 mismatch at {i}");
+    }
+}
+
+#[test]
+fn logits_postprocess_matches_f64_oracle_penalties_bias_history() {
+    let mut rng = SeededRng::new(0xA1_8004);
+    let (s, q, v) = (2, 2, 20);
+    let logits = random_logits(&mut rng, s * q * v, 2.0);
+    let history: Vec<u32> = (0..s * v).map(|_| (rng.next_u64() % 4) as u32).collect();
+
+    let mut p0 = base_params();
+    p0.repetition_penalty = 1.3;
+    p0.presence_penalty = 0.2;
+    p0.frequency_penalty = 0.1;
+    p0.logit_bias = vec![(3, 1.5), (17, -2.0)];
+    let mut p1 = base_params();
+    p1.temperature = 0.7;
+    p1.repetition_penalty = 0.8;
+    p1.logit_bias = vec![(0, 0.5)];
+    let params = vec![p0, p1];
+    check_oracle_agreement(
+        &logits,
+        s,
+        q,
+        v,
+        &params,
+        Some(&history),
+        None,
+        "penalties+bias+history",
+    );
+}
+
+#[test]
+fn logits_postprocess_matches_f64_oracle_filters_and_mask() {
+    let mut rng = SeededRng::new(0xA1_8005);
+    let (s, q, v) = (1, 3, 28);
+    let logits = random_logits(&mut rng, s * q * v, 2.0);
+    // Random mask with token 0 forced allowed so no row is fully masked.
+    let mut mask = vec![false; s * q * v];
+    for (i, m) in mask.iter_mut().enumerate() {
+        *m = i % v == 0 || (rng.next_u64() & 1) == 1;
+    }
+
+    for &(top_k, top_p, min_p) in &[
+        (3u32, 1.0f32, 0.0f32),
+        (0, 0.9, 0.0),
+        (0, 1.0, 0.15),
+        (5, 0.95, 0.05),
+    ] {
+        let mut p = base_params();
+        p.top_k = top_k;
+        p.top_p = top_p;
+        p.min_p = min_p;
+        let context = format!("top_k={top_k} top_p={top_p} min_p={min_p}");
+        check_oracle_agreement(
+            &logits,
+            s,
+            q,
+            v,
+            std::slice::from_ref(&p),
+            None,
+            Some(&mask),
+            &context,
+        );
+    }
+}
+
+#[test]
+fn logits_postprocess_matches_f64_oracle_intentional_neg_inf() {
+    let mut rng = SeededRng::new(0xA1_8006);
+    let (s, q, v) = (1, 2, 12);
+    let mut logits = random_logits(&mut rng, s * q * v, 2.0);
+    logits[2] = f32::NEG_INFINITY;
+    logits[v + 7] = f32::NEG_INFINITY;
+    let params = vec![base_params()];
+    check_oracle_agreement(
+        &logits,
+        s,
+        q,
+        v,
+        &params,
+        None,
+        None,
+        "intentional -Inf logits",
+    );
+}

--- a/crates/r9v-t0/tests/sampling_validation_tests.rs
+++ b/crates/r9v-t0/tests/sampling_validation_tests.rs
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Adversarial validation tests for sampling ops: exact-location logit
+//! rejection, overflow, shape/arithmetic/distribution/token/tree/mask refusal,
+//! and no output/RNG mutation on failure (Spec 1 §4.F, §6.5, Spec 7 §4,
+//! Card A1.8).
+
+use r9v_common::{SeqId, StepId};
+use r9v_ir::{IrError, SamplingParams, TreeMask, VerifyMethod};
+use r9v_t0::{logits_postprocess, sample, verify, RngState, T0Error};
+
+fn base_params() -> SamplingParams {
+    SamplingParams {
+        temperature: 1.0,
+        top_k: 0,
+        top_p: 1.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        logit_bias: vec![],
+    }
+}
+
+#[test]
+fn logits_postprocess_rejects_nan_with_exact_location() {
+    // Second sequence, second query, token 2 carries the NaN.
+    let (s, q, v) = (2, 2, 4);
+    let mut logits = vec![0.5f32; s * q * v];
+    logits[(q + 1) * v + 2] = f32::NAN;
+    let params = vec![base_params(), base_params()];
+    let mut probs = vec![0.0f32; s * q * v];
+    let err = logits_postprocess(&logits, s, q, v, &params, None, None, &mut probs)
+        .expect_err("NaN logit must be rejected");
+    assert!(
+        matches!(
+            err,
+            T0Error::InvalidLogit {
+                seq: 1,
+                query: 1,
+                token: 2,
+                ..
+            }
+        ),
+        "wrong error or location: {err:?}"
+    );
+}
+
+#[test]
+fn logits_postprocess_rejects_pos_inf_allows_neg_inf() {
+    let params = vec![base_params()];
+    let mut probs = vec![0.0f32; 3];
+
+    let err = logits_postprocess(
+        &[0.0, f32::INFINITY, 1.0],
+        1,
+        1,
+        3,
+        &params,
+        None,
+        None,
+        &mut probs,
+    )
+    .expect_err("+Inf logit must be rejected");
+    assert!(
+        matches!(err, T0Error::InvalidLogit { token: 1, value, .. } if value == f32::INFINITY),
+        "wrong error: {err:?}"
+    );
+
+    // Intentional -Inf (impossible token) is legal and gets zero probability.
+    logits_postprocess(
+        &[f32::NEG_INFINITY, 0.0, 1.0],
+        1,
+        1,
+        3,
+        &params,
+        None,
+        None,
+        &mut probs,
+    )
+    .expect("-Inf logit must be accepted");
+    assert_eq!(probs[0], 0.0);
+    assert!((probs[1] + probs[2] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn logits_postprocess_rejects_post_transform_overflow_with_location() {
+    // Finite inputs that overflow f32 under temperature scaling.
+    let params = vec![SamplingParams {
+        temperature: 1e-30,
+        ..base_params()
+    }];
+    let mut probs = vec![0.0f32; 2];
+    let err = logits_postprocess(&[1e10, 0.0], 1, 1, 2, &params, None, None, &mut probs)
+        .expect_err("temperature overflow must be rejected");
+    assert!(
+        matches!(err, T0Error::InvalidLogit { token: 0, .. }),
+        "wrong error or location: {err:?}"
+    );
+
+    // Finite logit plus finite bias overflowing to +Inf.
+    let mut biased = base_params();
+    biased.logit_bias = vec![(0, 3.0e38)];
+    let params = vec![biased];
+    let err = logits_postprocess(&[3.0e38, 0.0], 1, 1, 2, &params, None, None, &mut probs)
+        .expect_err("bias overflow must be rejected");
+    assert!(
+        matches!(err, T0Error::InvalidLogit { token: 0, .. }),
+        "wrong error or location: {err:?}"
+    );
+}
+
+#[test]
+fn logits_postprocess_rejects_non_finite_bias_at_parameter() {
+    // Non-finite biases are refused by SamplingParams validation (r9v-ir) with
+    // the token and value, surfaced through the typed aggregation path.
+    let mut p = base_params();
+    p.logit_bias = vec![(1, f32::NAN)];
+    let params = vec![p];
+    let mut probs = vec![0.0f32; 3];
+    let err = logits_postprocess(&[0.0, 0.0, 0.0], 1, 1, 3, &params, None, None, &mut probs)
+        .expect_err("NaN bias must be rejected");
+    assert!(
+        matches!(err, T0Error::Ir(IrError::OpAttributeInvalid { .. })),
+        "wrong error: {err:?}"
+    );
+}
+
+#[test]
+fn logits_postprocess_failure_leaves_output_untouched() {
+    let params = vec![base_params(), base_params()];
+    // Row 0 is valid; row 1 carries a NaN. Staging must not leak row 0.
+    let (s, q, v) = (2, 1, 3);
+    let logits = vec![1.0f32, 2.0, 3.0, 0.0, f32::NAN, 0.0];
+    let mut probs = vec![7.0f32; s * q * v];
+    logits_postprocess(&logits, s, q, v, &params, None, None, &mut probs)
+        .expect_err("NaN must fail");
+    assert_eq!(probs, vec![7.0f32; s * q * v]);
+
+    // Row 0 valid; row 1 fully masked out.
+    let logits = vec![1.0f32, 2.0, 3.0, 0.0, 0.0, 0.0];
+    let mask = vec![true, true, true, false, false, false];
+    let mut probs = vec![7.0f32; s * q * v];
+    let err = logits_postprocess(&logits, s, q, v, &params, None, Some(&mask), &mut probs)
+        .expect_err("all-masked row must fail");
+    assert!(
+        matches!(err, T0Error::AllTokensMasked { seq: 1, .. }),
+        "{err:?}"
+    );
+    assert_eq!(probs, vec![7.0f32; s * q * v]);
+}
+
+#[test]
+fn logits_postprocess_rejects_bad_shapes_masks_and_bias_tokens() {
+    let params = vec![base_params()];
+    let mut probs = vec![0.0f32; 3];
+
+    // Logits length mismatch.
+    let err = logits_postprocess(&[1.0, 2.0], 1, 1, 3, &params, None, None, &mut probs)
+        .expect_err("short logits must fail");
+    assert!(
+        matches!(err, T0Error::ShapeLengthMismatch { tensor, .. } if tensor == "logits"),
+        "{err:?}"
+    );
+
+    // Grammar mask length mismatch.
+    let err = logits_postprocess(
+        &[1.0, 2.0, 3.0],
+        1,
+        1,
+        3,
+        &params,
+        None,
+        Some(&[true, true]),
+        &mut probs,
+    )
+    .expect_err("short mask must fail");
+    assert!(
+        matches!(err, T0Error::ShapeLengthMismatch { tensor, .. } if tensor == "grammar_mask"),
+        "{err:?}"
+    );
+
+    // Logit bias tokens outside the vocabulary aggregate into one typed
+    // Multiple instead of failing on the first token.
+    let mut p = base_params();
+    p.logit_bias = vec![(9, 1.0), (10, 2.0)];
+    let err = logits_postprocess(
+        &[1.0, 2.0, 3.0],
+        1,
+        1,
+        3,
+        std::slice::from_ref(&p),
+        None,
+        None,
+        &mut probs,
+    )
+    .expect_err("out-of-range bias tokens must fail");
+    assert!(
+        matches!(&err, T0Error::Multiple { problems } if problems.len() == 2),
+        "expected 2-problem aggregation, got {err:?}"
+    );
+}
+
+#[test]
+fn rng_construction_rejects_bad_seq_id() {
+    let probs = vec![0.25f32; 4];
+    let err = RngState::from_u64(42, u64::MAX, 0)
+        .expect_err("oversized seq_id must fail at construction");
+    assert!(
+        matches!(err, T0Error::SeqIdOutOfRange { seq_id, .. } if seq_id == u64::MAX),
+        "{err:?}"
+    );
+
+    // Boundary: u32::MAX is representable and draws fine.
+    let mut rng = vec![RngState::from_u64(42, u32::MAX as u64, 0).unwrap()];
+    let tokens = sample(&probs, 1, 4, &mut rng).expect("u32::MAX seq_id must pass");
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(rng[0].draw_index(), 1);
+}
+
+#[test]
+fn sample_rejects_bad_distribution_without_rng_mutation() {
+    let mut rng = vec![RngState::from_u64(7, 1, 0).unwrap()];
+    // Negative entry.
+    let err =
+        sample(&[0.5, -0.25, 0.5, 0.25], 1, 4, &mut rng).expect_err("negative prob must fail");
+    assert!(
+        matches!(err, T0Error::InvalidProbability { token: 1, .. }),
+        "{err:?}"
+    );
+    // Wrong sum.
+    let err = sample(&[0.5, 0.5, 0.5, 0.5], 1, 4, &mut rng).expect_err("unnormalized must fail");
+    assert!(
+        matches!(err, T0Error::InvalidDistribution { .. }),
+        "{err:?}"
+    );
+    assert_eq!(rng[0].draw_index(), 0);
+}
+
+#[test]
+fn sample_preflights_draw_overflow_for_the_entire_batch() {
+    let probs = vec![0.5f32, 0.5, 0.5, 0.5];
+    let mut rng = vec![
+        RngState::from_u64(1, 1, 0).unwrap(),
+        RngState::with_draw(2, SeqId::new(2), StepId::new(0), u32::MAX).unwrap(),
+    ];
+    let err = sample(&probs, 2, 2, &mut rng).expect_err("batch draw overflow must fail");
+    assert!(matches!(
+        err,
+        T0Error::DrawIndexOverflow {
+            op: "sample",
+            draw_index: u32::MAX,
+            advance: 1
+        }
+    ));
+    assert_eq!(rng[0].draw_index(), 0);
+    assert_eq!(rng[1].draw_index(), u32::MAX);
+}
+
+#[test]
+fn verify_validates_typical_params_before_mutation() {
+    let draft = vec![1u32];
+    let target = vec![0.5f32, 0.5, 0.5, 0.5];
+    for (eps, delta) in [
+        (f32::NAN, 0.5),
+        (0.5, f32::INFINITY),
+        (-0.1, 0.5),
+        (0.5, -2.0),
+        (0.0, 0.5),
+        (0.5, 0.0),
+    ] {
+        let method = VerifyMethod::TypicalAcceptance { eps, delta };
+        let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
+        let err = verify(&draft, None, &target, 1, 1, 2, &method, &mut rng, None)
+            .expect_err("bad typical params must fail");
+        assert!(
+            matches!(err, T0Error::InvalidAttribute { op, .. } if op == "verify"),
+            "eps={eps} delta={delta}: {err:?}"
+        );
+        assert_eq!(rng[0].draw_index(), 0);
+    }
+
+    // Valid typical params run and advance k + 1 draws.
+    let method = VerifyMethod::TypicalAcceptance {
+        eps: 0.1,
+        delta: 0.9,
+    };
+    let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
+    let out = verify(&draft, None, &target, 1, 1, 2, &method, &mut rng, None)
+        .expect("valid typical params must pass");
+    assert_eq!(out.accepted.len(), 2);
+    assert_eq!(rng[0].draw_index(), 2);
+}
+
+#[test]
+fn verify_preflights_draw_overflow_for_the_entire_batch() {
+    let draft = vec![0u32, 0];
+    let target = vec![0.5f32; 8];
+    let mut rng = vec![
+        RngState::from_u64(1, 1, 0).unwrap(),
+        RngState::with_draw(2, SeqId::new(2), StepId::new(0), u32::MAX - 1).unwrap(),
+    ];
+    let err = verify(
+        &draft,
+        None,
+        &target,
+        2,
+        1,
+        2,
+        &VerifyMethod::Rejection,
+        &mut rng,
+        None,
+    )
+    .expect_err("batch draw overflow must fail");
+    assert!(matches!(
+        err,
+        T0Error::DrawIndexOverflow {
+            op: "verify",
+            draw_index,
+            advance: 2
+        } if draw_index == u32::MAX - 1
+    ));
+    assert_eq!(rng[0].draw_index(), 0);
+    assert_eq!(rng[1].draw_index(), u32::MAX - 1);
+}
+
+#[test]
+fn verify_rejects_bad_shapes_without_mutation() {
+    let draft = vec![1u32];
+    let target = vec![0.5f32, 0.5, 0.5, 0.5];
+    let method = VerifyMethod::Greedy;
+
+    let err = RngState::from_u64(1, u64::from(u32::MAX) + 1, 0)
+        .expect_err("oversized seq_id must fail at construction");
+    assert!(matches!(err, T0Error::SeqIdOutOfRange { .. }), "{err:?}");
+
+    // Draft token outside the vocabulary.
+    let mut rng = vec![RngState::from_u64(1, 1, 0).unwrap()];
+    let err = verify(&[7u32], None, &target, 1, 1, 2, &method, &mut rng, None)
+        .expect_err("out-of-range draft token must fail");
+    assert!(
+        matches!(err, T0Error::TokenOutOfRange { token: 7, .. }),
+        "{err:?}"
+    );
+    assert_eq!(rng[0].draw_index(), 0);
+
+    // Target length mismatch.
+    let mut rng = vec![RngState::from_u64(1, 1, 0).unwrap()];
+    let err = verify(&draft, None, &target[..2], 1, 1, 2, &method, &mut rng, None)
+        .expect_err("short target must fail");
+    assert!(
+        matches!(err, T0Error::ShapeLengthMismatch { tensor, .. } if tensor == "target_probs"),
+        "{err:?}"
+    );
+
+    // Unrepresentable draw index: k = u32::MAX has no terminal draw k.
+    let mut rng = vec![RngState::from_u64(1, 1, 0).unwrap()];
+    let err = verify(
+        &[],
+        None,
+        &[],
+        1,
+        u32::MAX as usize,
+        2,
+        &method,
+        &mut rng,
+        None,
+    )
+    .expect_err("u32::MAX k must fail");
+    assert!(
+        matches!(err, T0Error::ShapeLengthMismatch { tensor, .. } if tensor == "k"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn verify_rejects_mismatched_tree_size() {
+    // Tree with T = 2 presented for k = 1: structural refusal, no mutation.
+    let tree = TreeMask::new(vec![-1, 0], 2, vec![false; 4]).expect("valid tree");
+    let mut rng = vec![RngState::from_u64(1, 1, 0).unwrap()];
+    let err = verify(
+        &[0u32],
+        None,
+        &[0.5f32, 0.5, 0.5, 0.5],
+        1,
+        1,
+        2,
+        &VerifyMethod::Greedy,
+        &mut rng,
+        Some(&tree),
+    )
+    .expect_err("tree/k mismatch must fail");
+    assert!(
+        matches!(err, T0Error::ShapeLengthMismatch { tensor, .. } if tensor == "tree"),
+        "{err:?}"
+    );
+    assert_eq!(rng[0].draw_index(), 0);
+}
+
+#[test]
+fn verify_advances_draws_and_reproduces() {
+    // k = 2 rejection verify consumes draws {0, 1} for candidates and draw 2
+    // for the terminal token, advancing the cursor by k + 1 = 3.
+    let draft = vec![0u32, 1];
+    let target = vec![
+        0.2f32, 0.8, // pos 0
+        0.7, 0.3, // pos 1
+        0.5, 0.5, // bonus
+    ];
+    let method = VerifyMethod::Rejection;
+    let run = || {
+        let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
+        let out = verify(&draft, None, &target, 1, 2, 2, &method, &mut rng, None).unwrap();
+        (out, rng[0].draw_index())
+    };
+    let (out_a, adv_a) = run();
+    let (out_b, adv_b) = run();
+    assert_eq!(out_a, out_b);
+    assert_eq!((adv_a, adv_b), (3, 3));
+
+    // Degenerate k = 0 advances exactly one draw.
+    let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
+    let out = verify(&[], None, &[0.3f32, 0.7], 1, 0, 2, &method, &mut rng, None).unwrap();
+    assert_eq!(out.accept_len, vec![0]);
+    assert_eq!(rng[0].draw_index(), 1);
+}
+
+#[test]
+fn typed_seq_and_step_ids_reach_the_philox_counter() {
+    // Same (seed, step, draw) with different SeqIds must diverge; the u32
+    // word carries the id losslessly below the canonical ceiling.
+    let a = RngState::new(11, SeqId::new(1), StepId::new(0)).unwrap();
+    let b = RngState::new(11, SeqId::new(2), StepId::new(0)).unwrap();
+    assert_ne!(a.draw_at(0), b.draw_at(0));
+    // Step and draw words are likewise separated.
+    let c = RngState::new(11, SeqId::new(1), StepId::new(1)).unwrap();
+    assert_ne!(a.draw_at(0), c.draw_at(0));
+    assert_ne!(a.draw_at(0), a.draw_at(1));
+}

--- a/crates/r9v-t0/tests/verify_tests.rs
+++ b/crates/r9v-t0/tests/verify_tests.rs
@@ -15,7 +15,7 @@ fn test_verify_rejection_all_accepted_samples_bonus() {
         0.0, 0.0, 0.0, 1.0, // pos 1 -> token 3 prob 1.0
         0.5, 0.5, 0.0, 0.0, // pos 2 (bonus) -> uniform over 0 and 1
     ];
-    let mut rng = vec![RngState::new(42, 1, 0)];
+    let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
 
     let out = verify(
         &draft_tokens,
@@ -48,7 +48,7 @@ fn test_verify_rejection_first_rejected_samples_replacement() {
         0.0, 0.0, 1.0, 0.0, // pos 1
         1.0, 0.0, 0.0, 0.0, // pos 2
     ];
-    let mut rng = vec![RngState::new(123, 1, 0)];
+    let mut rng = vec![RngState::from_u64(123, 1, 0).unwrap()];
 
     let out = verify(
         &draft_tokens,
@@ -76,7 +76,7 @@ fn test_verify_typical_acceptance_threshold() {
     let target_probs = vec![
         0.05, 0.80, 0.10, 0.05, 1.0, 0.0, 0.0, 0.0, // bonus
     ];
-    let mut rng = vec![RngState::new(42, 1, 0)];
+    let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
 
     // 1. With eps = 0.5, p[1] = 0.80 > min(0.5, ...) -> should accept!
     let method_accept = VerifyMethod::TypicalAcceptance {
@@ -159,7 +159,7 @@ fn test_verify_tree_walk_longest_path_and_tie_breaking() {
     // Node 3 output: valid bonus distribution for Path B
     target_probs[4 * v] = 1.0;
 
-    let mut rng = vec![RngState::new(42, 1, 0)];
+    let mut rng = vec![RngState::from_u64(42, 1, 0).unwrap()];
     let out = verify(
         &draft_tokens,
         None,
@@ -190,7 +190,7 @@ fn test_verify_tree_walk_longest_path_and_tie_breaking() {
     target_probs[2 * v + 4] = 1.0; // Now node 1 output also matches node 3!
     let tie_draft_tokens = vec![1, 1, 3, 4];
 
-    let mut rng_tie = vec![RngState::new(42, 1, 0)];
+    let mut rng_tie = vec![RngState::from_u64(42, 1, 0).unwrap()];
     let out_tie = verify(
         &tie_draft_tokens,
         None,
@@ -214,7 +214,7 @@ fn test_verify_tree_walk_longest_path_and_tie_breaking() {
 #[test]
 fn test_verify_degenerate_k_zero() {
     let target_probs = vec![0.2, 0.6, 0.2];
-    let mut rng = vec![RngState::new(1, 1, 0)];
+    let mut rng = vec![RngState::from_u64(1, 1, 0).unwrap()];
     let out = verify(
         &[],
         None,
@@ -234,7 +234,7 @@ fn test_verify_degenerate_k_zero() {
 
 #[test]
 fn verify_rejects_out_of_range_tokens_and_dimension_overflow_without_panicking() {
-    let mut rng = vec![RngState::new(1, 1, 0)];
+    let mut rng = vec![RngState::from_u64(1, 1, 0).unwrap()];
     let err = verify(
         &[3],
         None,


### PR DESCRIPTION
## Card
A1.8 — t0 sampling group, sampling audit repair   (kind: implementation; GPU: no; size: M)

## Spec sections implemented
- spec 1 §4.F: logits postprocessing input validation, Philox-keyed sampling draws, verify acceptance and draw contract.
- spec 1 §6.5: f32 sampling numerics cross-checked against an independent f64 oracle within Tolerance::f32.
- spec 7 §4: public TypicalAcceptance parameter validation; distribution-exact residual fallback on rejection.
- spec 7 §5: longest-path tree verification draw accounting (draw i per candidate, draw k terminal).
- spec 4 §5.8: counter-based Philox draws keyed by (seq_id, step, draw_index) with full-u64 step mapping.
- spec 4 §2, CONVENTIONS.md §1.4: single recursively typed boxed T0Error aggregation path for all T0 validation.

## Deliverables
- [x] Independent f64 `logits_postprocess` oracle (`logits_postprocess_f64_reference`) plus tolerance cross-tests against the f32 implementation.
- [x] Typed exact-location rejection of NaN/+Inf logits (raw input and post-transform overflow) while allowing intentional -Inf.
- [x] Semantically typed `RngState` `SeqId`/`StepId` API with construction-time canonical-u32 `seq_id` validation, collision-free full-u64 step counter `[draw, step_lo, step_hi, seq_u32]`, and typed no-wrap draw-counter errors preflighted across the full batch before mutation.
- [x] Public `verify` TypicalAcceptance eps/delta validation before any RNG or output mutation.
- [x] Distribution-exact Philox fallback for residual cancellation with explicit draw semantics (reserved terminal draw k).
- [x] One recursively typed boxed `T0Error::Multiple` aggregation path; all stringly and duplicate variants/helpers removed across every T0 module and test.
- [x] Adversarial shape/arithmetic/distribution/token/tree/mask validation with no output/RNG mutation on failure.
- [x] All callers and tests updated to the unified APIs.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| 100,000-draw rejection distribution against target sampling | crates/r9v-t0/tests/distribution_tests.rs | cpu-only | green |
| deterministic run-to-run and batch-invariant sampling/verification | crates/r9v-t0/tests/determinism_tests.rs | cpu-only | green |
| temperature-zero greedy equivalence and stable tie breaking | crates/r9v-t0/tests/greedy_tests.rs | cpu-only | green |
| every logits-postprocess parameter and filtering order | crates/r9v-t0/tests/sampling_params_tests.rs | cpu-only | green |
| rejection, typical, degenerate, malformed, and tree verification | crates/r9v-t0/tests/verify_tests.rs | cpu-only | green |
| public types, signatures, and Send/Sync bounds | crates/r9v-t0/tests/api_shape.rs | cpu-only | green |
| f32 logits_postprocess vs independent f64 oracle within Tolerance::f32 | crates/r9v-t0/tests/sampling_oracle_tests.rs | cpu-only | green |
| adversarial logit/shape/distribution/token/tree/mask refusal and no-mutation | crates/r9v-t0/tests/sampling_validation_tests.rs | cpu-only | green |
| Philox counter mapping, checked seq u32, draw purity, no-wrap overflow | crates/r9v-t0/src/philox.rs (unit) | cpu-only | green |

## Decisions
- crates/r9v-t0/src/philox.rs:46 — map the seed and sequence/step/draw tuple to Philox key/counter words and use open-interval centered f32 draws.
- crates/r9v-t0/src/philox.rs:47 — draw_index arithmetic is checked, never wrapping; rejected wrapping_add because a wrapped counter replays earlier uniforms.
- crates/r9v-t0/src/sampling.rs:19 — filter candidates in stable `(-logit, token)` order, renormalize survivors, and use lowest-token tie breaking at temperature zero.
- crates/r9v-t0/src/sampling.rs:136 — reject raw-logit NaN/+Inf at exact (seq, query, token) before any output is touched while allowing intentional -Inf; rejected treating -Inf as invalid and post-softmax-only detection.
- crates/r9v-t0/src/sampling.rs:154 — compute the whole output into a staging buffer and copy to out_probs only on success; rejected in-place writes because an early row would already be overwritten when a later row fails.
- crates/r9v-t0/src/sampling.rs:370 — the f64 oracle re-implements the pipeline independently in f64; rejected deriving it from the f32 code path because a shared implementation reproduces shared bugs.
- crates/r9v-t0/src/sampling.rs:609 — reserve draw `i` for candidate `i` and draw `k` for the terminal bonus or replacement.
- crates/r9v-t0/src/sampling.rs:610 — index tree target distributions by root/parent output using the shared `[k+1,V]` contract.
- crates/r9v-t0/src/sampling.rs:611 — implement the specified typical-acceptance threshold and sample a verified continuation on rejection.
- crates/r9v-t0/src/sampling.rs:751 — validate TypicalAcceptance eps/delta as finite and strictly positive at the verify boundary before mutation, matching the IR contract.
- crates/r9v-t0/src/sampling.rs:942 — degenerate zero residual falls back to sampling the validated target distribution with the reserved terminal draw k; rejected the argmax fallback as not distribution-exact.

## SPEC-ISSUES filed
- none

## New dependencies
- none

## Hardware
Tests run here: hosted cpu-only plus existing stub-device workspace tests
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command `cargo test --workspace --locked`, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- Shared op-harness migration: no; A1.10 owns the later generic harness after A1.5–A1.9 exist, while this card includes the required golden, batch-invariance, determinism, malformed-input, and distribution coverage directly.
- Performance receipt: no; this is the scalar correctness tier and has no GPU performance gate.

## Size check
Diff size vs card size class: 1286 added / 595 deleted across 32 tracked files plus 2 new test files (608 lines) vs M — consistent with an audit repair spanning the shared T0 error surface (11 modules converted to the typed path), the sampling validation hardening, the f64 oracle, and the RNG API migration with caller updates.
