### PR TITLE
A1.9: implement deferred T0 operators

### DIFF
--- a/SPEC-ISSUES.md
+++ b/SPEC-ISSUES.md
@@ -226,3 +226,57 @@ What: `MlaAttentionSpec` admits `qk_nope_dim != kv_lora_rank` and `v_dim != kv_l
 Why it blocks or misleads: Any T0 lowering of a non-absorbed graph (truncate the latent, pad the query, invent a projection) invents numerics that the kernel cards would then have to match without a contract; a test that passes by such invention proves nothing about the real model path.
 Option taken: Implemented the absorbed MLA form (`qk_nope_dim == kv_lora_rank`, `qk_rope_dim == rope_dim`, `v_dim == kv_lora_rank`) and failed all other combinations closed with typed errors naming SI-46; see `validate_mla_dims` in `crates/r9v-t0/src/attention.rs`.
 Proposed resolution: State in Spec 1 §4.D whether the attention op consumes absorbed projections (and which graph ops produce the absorbed query) or add the missing projection operands to the op signature so non-absorbed dims have a defined lowering.
+
+## SI-47 — A1.9 — spec 1 §4.E (scan kind-specific equations absent)
+What: Spec 1 §4.E fixes the common `q/k/v/alpha/beta` signature and the `S_t` state for `linear_attn_scan` but states no per-kind equations for `GatedDeltaNet`, `GLA`, or `Mamba2` (gate application, normalization, decay placement, output projection order); `w_gate_up` normalization `NRMS` and the `LinearAttnKind` effects are unstated.
+Why it blocks or misleads: Without kind-specific equations, any per-kind T0 behavior would be invented; two implementations can both satisfy the signature while computing different recurrences.
+Option taken: Implemented one shared `alpha/beta/k/v` gated outer-product recurrence (`S = alpha*S + beta*(k⊗v)`, `o = q·S`, all `f32` ascending) for all three kinds — the narrowest contract consistent with the signature — in `crates/r9v-t0/src/linear_attn_scan.rs`; chunked and recurrent forms share it bit-exactly. No architecture-specific claim beyond that contract. Documented under DECISION(A1.9).
+Proposed resolution: State the kind-specific update equations in Spec 1 §4.E or confirm the three kinds share one recurrence.
+
+## SI-48 — A1.9 — spec 1 §4.E (sequence-boundary inputs missing from state/scan signatures)
+What: `causal_conv1d`/`linear_attn_scan` carry `[T, ...]` token-major tensors with no sequence-boundary input, yet require per-sequence state threading and reset; rows are not self-delimiting, `DType` is closed (SI-12), and IR arity cannot grow without touching every producer.
+Why it blocks or misleads: Without a boundary channel, multi-sequence batches cannot reset recurrences or address per-sequence slots; threading boundaries through fake tensor edges would corrupt the dtype system.
+Option taken: Added an explicit execution-only `SeqLayout` descriptor plus leading-`S` state slots (`[S, Wk-1, C]` conv, `[S, H, D, Dv]` scan) in `crates/r9v-t0/src/segments.rs`, consistent across conv/scan without changing IR arity. Documented under DECISION(A1.9).
+Proposed resolution: Confirm boundaries travel out-of-band and bless the `[S, ...]` state convention in Spec 1 §4.E / Spec 3 §4.
+
+## SI-49 — A1.9 — spec 1 §4.C (MoE top-K selection and routing-weight semantics)
+What: Spec 1 §4.C fixes MoE shapes (`[T, K]`) but not the selection contract: is `top_k = 0` legal, may one expert occupy several of a token's K slots, are routing `weights` probabilities or opaque multipliers, is `expert_ids` order significant, and which location scheme reports a bad routing value (`InvalidLogit` names sampling positions only)?
+Why it blocks or misleads: An empty routing (zero output) vs a refusal, duplicate-slot double counting vs dedup, and renormalized vs raw weights all change numerics silently.
+Option taken: In `crates/r9v-t0/src/moe_route.rs` / `moe_ffn.rs`: reject `top_k = 0`; allow duplicate expert slots (each slot combines independently from one shared expert row); treat `weights` as opaque multipliers combined in ascending `(expert, token, slot)` order with `y` zero-initialized first; report non-finite logits per `(t, e)` as `InvalidAttribute`. Documented under DECISION(A1.9).
+Proposed resolution: Fix the top-K selection contract, weight semantics, and routing error locations in Spec 1 §4.C.
+
+## SI-50 — A1.9 — spec 1 §4.C + spec 4 §5.6 (MoE gate/up row order unstated)
+What: Spec 1 §4.C fixes the `[E, 2·Dff, Dm]` gate/up shape but not the row order; Spec 4 §5.6 says "gate/up interleaved" about kernel access without fixing storage, and names a plain (fused) epilogue.
+Why it blocks or misleads: Gate-major halves vs interleaved rows select different weight rows for the same token — a silent numerics fork across implementations.
+Option taken: In `crates/r9v-t0/src/moe_ffn.rs`, read gate rows `[0, Dff)` and up rows `[Dff, 2·Dff)` (gate-major halves, contiguous per projection); L1 expert tiles are interpreted over the flattened `[E·R, K]` row space (no tiled rank-3 expert layout is specified). Documented under DECISION(A1.9).
+Proposed resolution: State the gate/up row order in Spec 1 §4.C.
+
+## SI-51 — A1.9 — spec 1 §4.C (router scoring, renormalization, scale, grouping gaps)
+What: Spec 1 §4.C names the router knobs but not their composition: softmax/sigmoid placement vs bias, what `renormalize` divides by, where `scale` multiplies, the grouped-selection algorithm for `group`, and whether output row order is observable.
+Why it blocks or misleads: Post-renorm scaling silently un-normalizes; full-row denominators contradict selected-weight renormalization; an unstated group algorithm cannot be implemented without invention.
+Option taken: In `crates/r9v-t0/src/moe_route.rs`: scores from `logits + bias`, stable softmax / sigmoid in `f32`, top-K by `(-score, index)` with lowest-index tie-break, `weights = score * scale` with renormalization dividing by the selected-K sum, rows in descending-score order (presentation only — the combine is order-insensitive); `group.is_some()` fails closed. Documented under DECISION(A1.9).
+Proposed resolution: Fix scoring/renormalize/scale composition and the grouped-selection algorithm (or remove `group`) in Spec 1 §4.C.
+
+## SI-52 — A1.9 — spec 1 §4.C/§4.E (MoE/scan scale carriers and the `x` Livness rule)
+What: Spec 1 §4.C/§4.E require scales without fixing their carrier: explicit parameters vs attached views, L0 inline-scale geometry for expert weights, and the meaning of the `x` Livness rule for A1.9 executors.
+Why it blocks or misleads: Divergent carriers across cards would fork every quantized A1.9 graph between A1.6 scale tooling and new code.
+Option taken: In `crates/r9v-t0/src/moe_ffn.rs` / `linear_attn_scan.rs`, mirrored the `matmul`/`matmul_with_scales` carrier contract exactly: explicit scale parameter else attached view (SI-18 pattern), L0 inline strides (`K+2`, `K+K_blocks·2`, `K/2+K_superblocks·16`) permitted for expert weights, and the `x` Livness rule (`Livness::L0` ⇒ inline scales mandatory, `L1` ⇒ explicit scales). Documented under DECISION(A1.9).
+Proposed resolution: Bless the shared out-of-band scale convention for A1.9 executors in Spec 1 §4.C/§4.E.
+
+## SI-53 — A1.9 — spec 1 §4.A (n-gram hash families, orders > 1, staged/device carriers)
+What: Spec 1 §4.A fixes n-gram shapes but (a) publishes no `HashId` enumeration, (b) leaves device-mode `orders > 1` undefined (order-n context rows are not in the signature — what feeds the hash?), and (c) fixes no staged/device scale carriers.
+Why it blocks or misleads: Any hard-coded hash family would be invented; order-n device gather without named hash inputs would fabricate addressing; a scalar cannot name a superblock record, so multi-block staged rows under one scalar have no specified scale application.
+Option taken: In `crates/r9v-t0/src/ngram_gather.rs`: never map a hash family — device mode takes `&dyn NgramHash` (scheduler/models scope supplies `NgramSpec.hash`), bounds-checks every hashed row, and rejects `orders != 1` in device mode; staged `I8R` rows take a scalar `row_scales` per `(t, h)`, staged `I8B128` requires `Dn == 128`, staged `I4K` and multi-block staged rows fail closed; quantized device tables require separate carriers (`[entries]`/`[entries, Dn/128]` F16 bytes, `[entries, Dn/256, 4]` U32 bytes); row-major tables only. Documented under DECISION(A1.9).
+Proposed resolution: Publish the `HashId` enumeration, define order-n device behavior, and bless the staged/device carriers in Spec 1 §4.A.
+
+## SI-54 — A1.9 — spec 1 §4.G (rank-1 collective semantics and the `recv` refusal)
+What: Spec 1 §4.G fixes collective arities but not the accumulation precision or the rank-1 data path: is `all_reduce` an identity at `ranks = 1`, does `all_to_all`'s single `counts[0]` cover all rows, are `send(0)`/`barrier` no-ops, and what sources `recv` data?
+Why it blocks or misleads: An `f32` round-trip identity would silently corrupt integer transfers; a `recv` that returns zeros would fabricate data.
+Option taken: In `crates/r9v-t0/src/collectives.rs`: `all_reduce(Sum)`/`all_gather`/`reduce_scatter`/`all_to_all` are bit-exact identity transfers through the `copy` core (proven with `u32` values above 2²⁴); `reduce_in` must still be `f32` per spec (accepted, unused at rank 1 — multi-rank ascending-rank `f32` reduction is executor scope); `send(peer = 0)` and `barrier` are no-ops; `recv` validates its descriptor then fails closed (no T0 transport). Documented under DECISION(A1.9).
+Proposed resolution: Confirm the rank-1 executor contract in Spec 1 §4.G.
+
+## SI-55 — A1.9 — spec 1 §4.E (causal-conv quantized weights, activations, bias, state dtype)
+What: Spec 1 §4.E permits `i8/i4` conv weights but provides no scale input in the signature; `ConvActivation` lists `Silu|Identity` without saying the set is exhaustive; `bias`/`state` width rules are implicit.
+Why it blocks or misleads: Scale-less quantized weights cannot be dequantized without invention; a third activation or a wider state type would silently change numerics.
+Option taken: In `crates/r9v-t0/src/causal_conv1d.rs`: reject quantized weights with `QuantMismatch`; match `ConvActivation` exhaustively; `bias [C]` optional; state slots `f16` exactly (`[S, Wk-1, C]`, zero rows at `Wk = 1`); every element decoded at use; `y`/state staged before commit. The `f16` carry rounding is the only split-vs-oneshot divergence and is pinned by test, not hidden in tolerance. Documented under DECISION(A1.9).
+Proposed resolution: State the conv weight-scale rule (or remove `i8/i4` from the dtype set) and close the activation/bias/state rules in Spec 1 §4.E.

--- a/crates/r9v-t0/src/causal_conv1d.rs
+++ b/crates/r9v-t0/src/causal_conv1d.rs
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Scalar T0 implementation of `causal_conv1d` op (Spec 1 §4.E, Card A1.9).
+//!
+//! Depthwise causal 1D convolution with explicit sequence segmentation and
+//! fail-before-mutation state continuity: every arithmetic input is the
+//! decoded `f16` bit pattern. Split-vs-one-shot is bit-exact only when the
+//! carried boundary history is already `f16`-representable; for general
+//! `f32`/`bf16` inputs the boundary rows round through the specified `f16`
+//! state quantization, so continuity there is approximate within tolerance.
+
+use r9v_ir::{CausalConv1dOp, ConvActivation, DType, LayoutId};
+
+use crate::activation::eval_activation_f32;
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+use crate::segments::SeqLayout;
+use r9v_ir::ActivationKind;
+
+/// Executes scalar T0 causal depthwise 1D convolution (Spec 1 §4.E, Card A1.9).
+///
+/// Signature:
+/// - `x`: `[T, C]` (`f16|bf16|f32`)
+/// - `w`: `[C, Wk]` (`f16|bf16|f32`; `Wk == op.kernel`)
+/// - `bias`: optional `[C]`
+/// - `state_in`/`state_out`: `[S, Wk-1, C]` (`f16`, `Wk == 1` gives zero rows)
+/// - `y`: `[T, C]` (dtype matches `x`)
+/// - `seq`: explicit per-sequence token counts summing to `T` (SI-48)
+///
+/// Recurrence per channel `c`, ascending `t` within each segment, all MAC in
+/// `f32`: `acc = bias[c] + Σ_{i<Wk} w[c,i]·hist[t−Wk+1+i][c]` with
+/// `hist = [state rows; segment x rows]`, every element decoded to `f32` at
+/// use; `y[t,c] = Silu(acc)` or `acc`. `state_out[s]` holds the last `Wk−1`
+/// rows of segment `s`'s history, encoded `f16`.
+///
+/// Continuity guarantee by construction: chunked runs with carried state
+/// consume the same decoded `f16` bit patterns in the same order as a
+/// one-shot run, so split-vs-oneshot agrees bit-exactly (L0) whenever the
+/// carried boundary history is already `f16`-representable. For general
+/// `f32`/`bf16` inputs the boundary rows pass through the specified `f16`
+/// state quantization and continuity holds only within tolerance.
+///
+/// State inputs are never mutated; `y` and `state_out` are staged in owned
+/// buffers and committed only after all validation and compute succeed.
+///
+/// Fail-closed (SI-55): quantized weights (`i8`/`i4`, IR-permitted but with no
+/// scale input in the signature) are rejected with [`T0Error::QuantMismatch`].
+///
+/// DECISION(A1.9): state slots are `f16` exactly with staged `y`/state commit;
+/// rejected wider state and in-place updates because the spec fixes `f16`
+/// windows and A/B slots must never alias. Per SI-55.
+#[allow(clippy::too_many_arguments)]
+pub fn causal_conv1d(
+    op: &CausalConv1dOp,
+    x: &TensorView<'_>,
+    w: &TensorView<'_>,
+    bias: Option<&TensorView<'_>>,
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    y: &mut TensorViewMut<'_>,
+    state_out: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    w.validate_backing("w")?;
+    if let Some(b) = bias {
+        b.validate_backing("bias")?;
+    }
+    state_in.validate_backing("state_in")?;
+    y.validate_backing("y")?;
+    state_out.validate_backing("state_out")?;
+
+    let mut problems = Vec::new();
+
+    if x.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 2,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
+    }
+    if w.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "w",
+            expected: 2,
+            got: w.rank(),
+            shape: w.shape().to_vec(),
+        });
+    }
+    if y.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
+    }
+    if state_in.rank() != 3 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "state_in",
+            expected: 3,
+            got: state_in.rank(),
+            shape: state_in.shape().to_vec(),
+        });
+    }
+    if state_out.rank() != 3 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "state_out",
+            expected: 3,
+            got: state_out.rank(),
+            shape: state_out.shape().to_vec(),
+        });
+    }
+
+    for (name, v) in [("x", x), ("w", w), ("state_in", state_in)] {
+        let vv: &TensorView<'_> = v;
+        if vv.layout() != LayoutId::CONTIGUOUS && vv.layout() != LayoutId::L0 {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: name,
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+                got: vv.layout(),
+            });
+        }
+    }
+    if let Some(b) = bias {
+        if b.layout() != LayoutId::CONTIGUOUS && b.layout() != LayoutId::L0 {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: "bias",
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+                got: b.layout(),
+            });
+        }
+    }
+    if y.layout() != LayoutId::CONTIGUOUS && y.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "y",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: y.layout(),
+        });
+    }
+    if state_out.layout() != LayoutId::CONTIGUOUS && state_out.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "state_out",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: state_out.layout(),
+        });
+    }
+
+    if !matches!(x.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: x.dtype(),
+        });
+    }
+    match w.dtype() {
+        DType::F16 | DType::Bf16 | DType::F32 => {}
+        DType::I8 | DType::I4 => problems.push(T0Error::QuantMismatch {
+            tensor: "w",
+            expected: vec![r9v_ir::QuantScheme::None],
+            got: w.quant(),
+        }),
+        other => problems.push(T0Error::DTypeMismatch {
+            tensor: "w",
+            expected: vec![DType::F16, DType::Bf16, DType::F32],
+            got: other,
+        }),
+    }
+    if state_in.dtype() != DType::F16 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "state_in",
+            expected: vec![DType::F16],
+            got: state_in.dtype(),
+        });
+    }
+    if state_out.dtype() != DType::F16 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "state_out",
+            expected: vec![DType::F16],
+            got: state_out.dtype(),
+        });
+    }
+    if y.dtype() != x.dtype() {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![x.dtype()],
+            got: y.dtype(),
+        });
+    }
+    if op.kernel == 0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "causal_conv1d",
+            attribute: "kernel",
+            reason: "kernel must be > 0".to_string(),
+        });
+    }
+    match op.act {
+        ConvActivation::Silu | ConvActivation::Identity => {}
+    }
+    match op.handle.kind() {
+        r9v_ir::StateKind::ConvWindow => {}
+        other => problems.push(T0Error::InvalidAttribute {
+            op: "causal_conv1d",
+            attribute: "handle",
+            reason: format!("state handle must be ConvWindow, got {other:?}"),
+        }),
+    }
+
+    T0Error::from_problems(problems)?;
+
+    let t = x.shape()[0];
+    let c = x.shape()[1];
+    let wk = op.kernel as usize;
+    let s = seq.seq_count();
+
+    if t == 0 || c == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "causal_conv1d",
+            tensor: "x",
+        });
+    }
+    for v in [t, c, wk, s] {
+        u32::try_from(v).map_err(|_| T0Error::ArithmeticOverflow {
+            op: "causal_conv1d",
+            detail: format!("dimension exceeds u32: {v}"),
+        })?;
+    }
+    seq.check_total("state_in", t)?;
+
+    let mut problems = Vec::new();
+    if w.shape()[0] != c {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "C",
+            expected_from: "x",
+            expected: c,
+            tensor: "w",
+            got: w.shape()[0],
+        });
+    }
+    if w.shape()[1] != wk {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Wk",
+            expected_from: "kernel",
+            expected: wk,
+            tensor: "w",
+            got: w.shape()[1],
+        });
+    }
+    if let Some(b) = bias {
+        if b.rank() != 1 {
+            problems.push(T0Error::RankMismatch {
+                tensor: "bias",
+                expected: 1,
+                got: b.rank(),
+                shape: b.shape().to_vec(),
+            });
+        } else if b.shape()[0] != c {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "C",
+                expected_from: "x",
+                expected: c,
+                tensor: "bias",
+                got: b.shape()[0],
+            });
+        }
+        if !matches!(b.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(T0Error::DTypeMismatch {
+                tensor: "bias",
+                expected: vec![DType::F16, DType::Bf16, DType::F32],
+                got: b.dtype(),
+            });
+        }
+    }
+    if y.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "x",
+            expected: t,
+            tensor: "y",
+            got: y.shape()[0],
+        });
+    }
+    if y.shape()[1] != c {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "C",
+            expected_from: "x",
+            expected: c,
+            tensor: "y",
+            got: y.shape()[1],
+        });
+    }
+    let hist_rows = wk.saturating_sub(1);
+    if state_in.shape()[0] != s {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "S",
+            expected_from: "seq",
+            expected: s,
+            tensor: "state_in",
+            got: state_in.shape()[0],
+        });
+    }
+    if state_in.shape()[1] != hist_rows {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Wk-1",
+            expected_from: "kernel",
+            expected: hist_rows,
+            tensor: "state_in",
+            got: state_in.shape()[1],
+        });
+    }
+    if state_in.shape()[2] != c {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "C",
+            expected_from: "x",
+            expected: c,
+            tensor: "state_in",
+            got: state_in.shape()[2],
+        });
+    }
+    if state_out.shape()[0] != s {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "S",
+            expected_from: "seq",
+            expected: s,
+            tensor: "state_out",
+            got: state_out.shape()[0],
+        });
+    }
+    if state_out.shape()[1] != hist_rows {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Wk-1",
+            expected_from: "kernel",
+            expected: hist_rows,
+            tensor: "state_out",
+            got: state_out.shape()[1],
+        });
+    }
+    if state_out.shape()[2] != c {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "C",
+            expected_from: "x",
+            expected: c,
+            tensor: "state_out",
+            got: state_out.shape()[2],
+        });
+    }
+    T0Error::from_problems(problems)?;
+
+    // Validated: compute into staged buffers, then commit.
+    let y_len = t
+        .checked_mul(c)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "causal_conv1d",
+            detail: format!("T * C overflows usize for T={t}, C={c}"),
+        })?;
+    let mut y_tmp = vec![0.0f32; y_len];
+    let s_len = s
+        .checked_mul(hist_rows)
+        .and_then(|v| v.checked_mul(c))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "causal_conv1d",
+            detail: "state buffer size overflows usize".to_string(),
+        })?;
+    let mut s_tmp = vec![0u16; s_len];
+
+    let act_kind = match op.act {
+        ConvActivation::Silu => ActivationKind::Silu,
+        ConvActivation::Identity => ActivationKind::Identity,
+    };
+    // Absolute history rows [0, hist) are the segment's input state rows;
+    // rows [hist, hist + len) are the segment's x rows. Since wk == hist + 1,
+    // tap i of output row sits at absolute history row (row + i).
+    let mut base = 0usize;
+    for (slot, &len_u32) in seq.seq_lens().iter().enumerate() {
+        let len = len_u32 as usize;
+        for row in 0..len {
+            let gt = base + row;
+            for ch in 0..c {
+                let mut acc = match bias {
+                    Some(b) => b.read_f32(ch),
+                    None => 0.0f32,
+                };
+                for i in 0..wk {
+                    let abs = row + i;
+                    let h_val = if abs < hist_rows {
+                        state_in.read_f32(slot * hist_rows * c + abs * c + ch)
+                    } else {
+                        x.read_f32((base + abs - hist_rows) * c + ch)
+                    };
+                    acc += w.read_f32(ch * wk + i) * h_val;
+                }
+                y_tmp[gt * c + ch] = eval_activation_f32(acc, act_kind);
+            }
+        }
+        // New tail: the last `hist` history rows, at absolute rows [len, len + hist).
+        for h_row in 0..hist_rows {
+            let abs = len + h_row;
+            for ch in 0..c {
+                let v = if abs < hist_rows {
+                    state_in.read_f32(slot * hist_rows * c + abs * c + ch)
+                } else {
+                    x.read_f32((base + abs - hist_rows) * c + ch)
+                };
+                s_tmp[slot * hist_rows * c + h_row * c + ch] = crate::dtype::f32_to_f16(v);
+            }
+        }
+        base += len;
+    }
+
+    for (idx, &v) in y_tmp.iter().enumerate() {
+        y.write_f32(idx, v);
+    }
+    // Commit staged f16 state bits.
+    for (idx, &bits) in s_tmp.iter().enumerate() {
+        write_f16_bits(state_out, idx, bits)?;
+    }
+    Ok(())
+}
+
+/// 64-bit reference causal convolution for testing (Spec 1 §4.E).
+///
+/// Independent `f64` path: plain nested loops over `&[f64]` slices, never
+/// calling [`causal_conv1d`]. `state_in` arrives as decoded `f64` rows
+/// (the test decodes the `f16` bits); the recurrence mirrors the T0
+/// algorithm in `f64`. Returns `(y [T, C], state_out [S, hist, C])` with the
+/// state tail kept in full precision (the test compares against T0 through
+/// the `f32` tolerance, which absorbs the `f16` tail rounding). Slice
+/// lengths and every extent product are validated with typed errors; there
+/// is no silent empty fallback.
+#[allow(clippy::too_many_arguments)]
+pub fn causal_conv1d_f64_reference(
+    x: &[f64],
+    t: usize,
+    c: usize,
+    w: &[f64],
+    wk: usize,
+    bias: Option<&[f64]>,
+    act: ConvActivation,
+    state_in: &[f64],
+    s: usize,
+    seq_lens: &[u32],
+) -> Result<(Vec<f64>, Vec<f64>), T0Error> {
+    const OP: &str = "causal_conv1d";
+    let hist = wk.saturating_sub(1);
+    let tc = t
+        .checked_mul(c)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * C overflows usize for T={t}, C={c}"),
+        })?;
+    let cwk = c
+        .checked_mul(wk)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("C * Wk overflows usize for C={c}, Wk={wk}"),
+        })?;
+    let shc = s
+        .checked_mul(hist)
+        .and_then(|v| v.checked_mul(c))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "S * hist * C overflows usize".to_string(),
+        })?;
+    let mut problems = Vec::new();
+    if x.len() != tc {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "x",
+            expected: tc,
+            got: x.len(),
+            detail: "x length must equal T * C".to_string(),
+        });
+    }
+    if w.len() != cwk {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "w",
+            expected: cwk,
+            got: w.len(),
+            detail: "w length must equal C * Wk".to_string(),
+        });
+    }
+    if let Some(b) = bias {
+        if b.len() != c {
+            problems.push(T0Error::ShapeLengthMismatch {
+                op: OP,
+                tensor: "bias",
+                expected: c,
+                got: b.len(),
+                detail: "bias length must equal C".to_string(),
+            });
+        }
+    }
+    if state_in.len() != shc {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "state_in",
+            expected: shc,
+            got: state_in.len(),
+            detail: "state_in length must equal S * hist * C".to_string(),
+        });
+    }
+    if seq_lens.len() != s {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "seq_lens",
+            expected: s,
+            got: seq_lens.len(),
+            detail: "seq_lens length must equal S".to_string(),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    let mut y = vec![0.0f64; tc];
+    let mut s_out = vec![0.0f64; shc];
+    let silu = |a: f64| match act {
+        ConvActivation::Silu => a / (1.0 + (-a).exp()),
+        ConvActivation::Identity => a,
+    };
+    let mut base = 0usize;
+    for (slot, &len_u32) in seq_lens.iter().enumerate() {
+        let len = len_u32 as usize;
+        for row in 0..len {
+            for ch in 0..c {
+                let mut acc = bias.map(|b| b[ch]).unwrap_or(0.0);
+                for i in 0..wk {
+                    let abs = row + i;
+                    let h_val = if abs < hist {
+                        state_in[slot * hist * c + abs * c + ch]
+                    } else {
+                        x[(base + abs - hist) * c + ch]
+                    };
+                    acc += w[ch * wk + i] * h_val;
+                }
+                y[(base + row) * c + ch] = silu(acc);
+            }
+        }
+        for h_row in 0..hist {
+            let abs = len + h_row;
+            for ch in 0..c {
+                let v = if abs < hist {
+                    state_in[slot * hist * c + abs * c + ch]
+                } else {
+                    x[(base + abs - hist) * c + ch]
+                };
+                s_out[slot * hist * c + h_row * c + ch] = v;
+            }
+        }
+        base += len;
+    }
+    Ok((y, s_out))
+}
+
+/// Writes raw `f16` bits to a `f16` output view (Spec 1 §4.E).
+///
+/// Accepts typed `F16` and raw-byte `F16` backings bit-exactly.
+fn write_f16_bits(view: &mut TensorViewMut<'_>, index: usize, bits: u16) -> Result<(), T0Error> {
+    match view.data {
+        crate::buffer::TensorDataMut::F16(ref mut slice) => {
+            if index >= slice.len() {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "state_out",
+                    buffer_len: slice.len(),
+                    expected_len: index + 1,
+                    shape: view.shape().to_vec(),
+                });
+            }
+            slice[index] = bits;
+            Ok(())
+        }
+        crate::buffer::TensorDataMut::Bytes(_, ref mut slice) => {
+            let end = index
+                .checked_mul(2)
+                .and_then(|off| off.checked_add(2))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: "causal_conv1d",
+                    detail: format!("f16 byte range for index {index} overflows usize"),
+                })?;
+            if end > slice.len() {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "state_out",
+                    buffer_len: slice.len(),
+                    expected_len: end,
+                    shape: view.shape().to_vec(),
+                });
+            }
+            slice[index * 2..end].copy_from_slice(&bits.to_le_bytes());
+            Ok(())
+        }
+        _ => Err(T0Error::BackingRepresentationMismatch {
+            op: "causal_conv1d",
+            dtype: view.dtype(),
+        }),
+    }
+}

--- a/crates/r9v-t0/src/collectives.rs
+++ b/crates/r9v-t0/src/collectives.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Scalar T0 rank-1 collective implementations (Spec 1 §4.G, Card A1.9).
+//!
+//! At `ranks = 1` every data-movement collective is a bit-exact identity
+//! transfer (SI-54): `all_reduce(Sum)`, `all_gather`, `reduce_scatter`, and
+//! `all_to_all` copy `x` to `y` with no `f32` round-trip by delegating to the
+//! [`copy()`] core. `send` to peer 0 is a no-op, `barrier` is a
+//! no-op, and `recv` fails closed (no data source exists in T0 at rank 1).
+//!
+//! DECISION(A1.9): rank-1 data collectives are bit-exact identities through
+//! the `copy` core; rejected `f32` round-trip copies and zero-filled `recv`.
+//! Per SI-54.
+
+use r9v_ir::{
+    AllGatherOp, AllReduceOp, AllToAllOp, BarrierOp, CopyKind, CopyOp, DType, LayoutId, RecvOp,
+    ReduceOp, ReduceScatterOp, SendOp,
+};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::copy::copy;
+use crate::error::T0Error;
+
+/// Bit-exact identity transfer shared by the rank-1 data collectives.
+///
+/// Validates that both views share `dtype` and delegates the bytes to the
+/// [`copy()`] core, which transfers storage without floating-point
+/// conversion.
+fn identity_transfer(
+    _op: &'static str,
+    x: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    y.validate_backing("y")?;
+    let mut problems = Vec::new();
+    if y.dtype() != x.dtype() {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![x.dtype()],
+            got: y.dtype(),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    // The `copy` core reports shape/dtype/backing problems with the same
+    // `x`/`y` tensor names, so its typed errors propagate unchanged.
+    copy(
+        &CopyOp {
+            kind: CopyKind::DeviceToDevice,
+        },
+        x,
+        y,
+    )
+}
+
+/// Executes scalar T0 rank-1 `all_reduce` (Spec 1 §4.G, Card A1.9).
+///
+/// `y = x` bit-exact copy; `reduce_in` must still be `f32` per spec (SI-54
+/// records the bit-exact identity choice). Multi-rank ascending-rank `f32`
+/// reduction is executor scope, not T0 scope.
+pub fn all_reduce(
+    op: &AllReduceOp,
+    x: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+    match op.op {
+        ReduceOp::Sum => {}
+    }
+    if op.reduce_in != DType::F32 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "all_reduce",
+            attribute: "reduce_in",
+            reason: format!("must be f32 per Spec 1 §4.G, got {:?}", op.reduce_in),
+        });
+    }
+    if x.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![op.dtype],
+            got: x.dtype(),
+        });
+    }
+    if y.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.dtype],
+            got: y.dtype(),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    identity_transfer("all_reduce", x, y)
+}
+
+/// Executes scalar T0 rank-1 `all_gather` (Spec 1 §4.G, Card A1.9).
+///
+/// `y = x` bit-exact copy; `axis` must address a real axis of `x`. At rank 1
+/// the gathered extent equals the input extent on every axis.
+pub fn all_gather(
+    op: &AllGatherOp,
+    x: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+    if x.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![op.dtype],
+            got: x.dtype(),
+        });
+    }
+    if y.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.dtype],
+            got: y.dtype(),
+        });
+    }
+    if op.axis as usize >= x.rank() {
+        problems.push(T0Error::InvalidAttribute {
+            op: "all_gather",
+            attribute: "axis",
+            reason: format!("axis {} out of bounds for rank {}", op.axis, x.rank()),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    identity_transfer("all_gather", x, y)
+}
+
+/// Executes scalar T0 rank-1 `reduce_scatter` (Spec 1 §4.G, Card A1.9).
+///
+/// `y = x` bit-exact copy; `axis` must address a real axis of `x` and
+/// `reduce_in` must be `f32` per spec.
+pub fn reduce_scatter(
+    op: &ReduceScatterOp,
+    x: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let mut problems = Vec::new();
+    match op.op {
+        ReduceOp::Sum => {}
+    }
+    if op.reduce_in != DType::F32 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "reduce_scatter",
+            attribute: "reduce_in",
+            reason: format!("must be f32 per Spec 1 §4.G, got {:?}", op.reduce_in),
+        });
+    }
+    if x.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![op.dtype],
+            got: x.dtype(),
+        });
+    }
+    if y.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.dtype],
+            got: y.dtype(),
+        });
+    }
+    if op.axis as usize >= x.rank() {
+        problems.push(T0Error::InvalidAttribute {
+            op: "reduce_scatter",
+            attribute: "axis",
+            reason: format!("axis {} out of bounds for rank {}", op.axis, x.rank()),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    identity_transfer("reduce_scatter", x, y)
+}
+
+/// Executes scalar T0 rank-1 `all_to_all` (Spec 1 §4.G, Card A1.9).
+///
+/// Validates `counts [1] u32` with `counts[0] == x.shape[0]`, then `y = x`
+/// bit-exact copy. Variable per-peer counts for EP are resolved in the
+/// pre-step phase (spec 1 §4.G); at rank 1 the single count covers all rows.
+pub fn all_to_all(
+    op: &AllToAllOp,
+    x: &TensorView<'_>,
+    counts: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    counts.validate_backing("counts")?;
+    y.validate_backing("y")?;
+
+    let mut problems = Vec::new();
+    if x.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![op.dtype],
+            got: x.dtype(),
+        });
+    }
+    if y.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.dtype],
+            got: y.dtype(),
+        });
+    }
+    if counts.rank() != 1 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "counts",
+            expected: 1,
+            got: counts.rank(),
+            shape: counts.shape().to_vec(),
+        });
+    }
+    if counts.dtype() != DType::U32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "counts",
+            expected: vec![DType::U32],
+            got: counts.dtype(),
+        });
+    }
+    if x.rank() == 0 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 1,
+            got: 0,
+            shape: x.shape().to_vec(),
+        });
+    }
+    T0Error::from_problems(problems)?;
+
+    if counts.shape()[0] != 1 {
+        return Err(T0Error::DimensionMismatch {
+            dim_name: "P",
+            expected_from: "ranks_1",
+            expected: 1,
+            tensor: "counts",
+            got: counts.shape()[0],
+        });
+    }
+    let first = counts
+        .try_read_u32(0, "counts")
+        .map_err(|_| T0Error::BufferLengthMismatch {
+            tensor: "counts",
+            buffer_len: counts.backing_len(),
+            expected_len: 1,
+            shape: counts.shape().to_vec(),
+        })?;
+    if first as usize != x.shape()[0] {
+        return Err(T0Error::DimensionMismatch {
+            dim_name: "rows",
+            expected_from: "x",
+            expected: x.shape()[0],
+            tensor: "counts",
+            got: first as usize,
+        });
+    }
+    identity_transfer("all_to_all", x, y)
+}
+
+/// Executes scalar T0 rank-1 `send` (Spec 1 §4.G, Card A1.9).
+///
+/// Validates the input backing and dtype; `peer == 0` is a no-op `Ok`, any
+/// other peer fails closed (no transport exists in T0 at rank 1).
+pub fn send(op: &SendOp, x: &TensorView<'_>) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    let mut problems = Vec::new();
+    if x.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![op.dtype],
+            got: x.dtype(),
+        });
+    }
+    if x.layout() != LayoutId::CONTIGUOUS && x.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "x",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: x.layout(),
+        });
+    }
+    if op.peer != 0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "send",
+            attribute: "peer",
+            reason: format!("rank-1 send supports peer 0 only, got peer {}", op.peer),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    Ok(())
+}
+
+/// Fails closed scalar T0 rank-1 `recv` (Spec 1 §4.G, Card A1.9, SI-54).
+///
+/// No data source exists in T0 at rank 1, so `recv` always returns a typed
+/// error after validating the output descriptor. The error carries every
+/// descriptor problem plus the fail-closed refusal.
+pub fn recv(op: &RecvOp, y: &mut TensorViewMut<'_>) -> Result<(), T0Error> {
+    y.validate_backing("y")?;
+    let mut problems = Vec::new();
+    if y.dtype() != op.dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.dtype],
+            got: y.dtype(),
+        });
+    }
+    problems.push(T0Error::InvalidAttribute {
+        op: "recv",
+        attribute: "peer",
+        reason: format!(
+            "rank-1 recv has no data source in T0 (peer {}); SI-54",
+            op.peer
+        ),
+    });
+    T0Error::from_problems(problems)?;
+    Ok(())
+}
+
+/// Executes scalar T0 `barrier` (Spec 1 §4.G, Card A1.9).
+///
+/// No-op `Ok`: a single rank has nothing to synchronize.
+pub fn barrier(_op: &BarrierOp) -> Result<(), T0Error> {
+    Ok(())
+}

--- a/crates/r9v-t0/src/lib.rs
+++ b/crates/r9v-t0/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! R9V CPU reference scalar T0 implementations
-//! (Spec 1 §4.B, §4.D, §4.F, §6.3, §6.4, §6.5, Spec 3 §2, §3, Spec 4 §2,
-//! Spec 7 §4, Cards A1.5, A1.7 and A1.8).
+//! (Spec 1 §4.A–§4.G, §6.1–§6.5, Spec 3 §2–§4, Spec 4 §2, Spec 7 §4,
+//! Cards A1.5–A1.9 and A1.14).
 //!
 //! T0 serves as the primary ground-truth oracle for all engine operations.
 //! Implementations are scalar, strictly deterministic, accumulate in f32 (or i32),
@@ -12,14 +12,20 @@ pub mod activation;
 pub mod attention;
 pub mod buffer;
 pub mod cast;
+pub mod causal_conv1d;
+pub mod collectives;
 pub mod concat;
 pub mod copy;
 pub mod dtype;
 pub mod embed_gather;
 pub mod error;
 pub mod gather_rows;
+pub mod linear_attn_scan;
 pub mod logit_softcap;
 pub mod matmul;
+pub mod moe_ffn;
+pub mod moe_route;
+pub mod ngram_gather;
 pub mod norm;
 pub mod philox;
 pub mod quant_act;
@@ -27,6 +33,7 @@ pub mod residual_add;
 pub mod rope;
 pub mod sampling;
 pub mod scatter_add_rows;
+pub mod segments;
 pub mod split;
 pub mod tolerance;
 
@@ -42,6 +49,8 @@ pub use attention::{
 };
 pub use buffer::{TensorData, TensorDataMut, TensorView, TensorViewMut, TypedBuffer};
 pub use cast::{cast, cast_f64_reference};
+pub use causal_conv1d::{causal_conv1d, causal_conv1d_f64_reference};
+pub use collectives::{all_gather, all_reduce, all_to_all, barrier, recv, reduce_scatter, send};
 pub use concat::{concat, concat_f64_reference};
 pub use copy::{copy, copy_f64_reference};
 pub use dtype::{
@@ -51,8 +60,17 @@ pub use dtype::{
 pub use embed_gather::{embed_gather, embed_gather_f64_reference, embed_gather_with_scales};
 pub use error::T0Error;
 pub use gather_rows::{gather_rows, gather_rows_f64_reference};
+pub use linear_attn_scan::{
+    linear_attn_scan_chunked, linear_attn_scan_f64_reference, linear_attn_scan_recurrent,
+};
 pub use logit_softcap::{logit_softcap, logit_softcap_f64_reference};
 pub use matmul::{matmul, matmul_f64_reference, matmul_with_scales};
+pub use moe_ffn::{moe_ffn, moe_ffn_f64_reference};
+pub use moe_route::{moe_route, moe_route_f64_reference};
+pub use ngram_gather::{
+    ngram_gather, ngram_gather_device, ngram_gather_f64_reference_rows,
+    ngram_gather_f64_reference_staged, NgramHash,
+};
 pub use norm::{norm, norm_f64_reference};
 pub use philox::{philox4x32_10, u32_to_unit_f32, RngState};
 pub use quant_act::{fp8_e4m3_encode_f64_oracle, quant_act, quant_act_f64_reference};
@@ -62,6 +80,7 @@ pub use sampling::{
     logits_postprocess, logits_postprocess_f64_reference, sample, verify, VerifyOutput,
 };
 pub use scatter_add_rows::{scatter_add_rows, scatter_add_rows_f64_reference};
+pub use segments::SeqLayout;
 pub use split::{split, split_f64_reference};
 pub use tolerance::Tolerance;
 
@@ -379,6 +398,322 @@ pub fn execute_lookup_op(
             op: other.op_name(),
             attribute: "op",
             reason: format!("op `{}` is not a lookup/scatter op", other.op_name()),
+        }),
+    }
+}
+
+/// Dispatches and executes a MoE op using scalar T0 reference implementations (Spec 1 §4.C, Card A1.9).
+///
+/// `moe_route` takes 1 or 2 inputs `(logits, bias?)` and 2 outputs `(expert_ids, weights)`.
+/// `moe_ffn` takes exactly 5 inputs `(x, expert_ids, weights, w_gate_up, w_down)` and 1 output;
+/// out-of-band scales travel attached to the input views (see [`moe_ffn()`]).
+pub fn execute_moe_op(
+    op: &Op,
+    inputs: &[TensorView<'_>],
+    outputs: &mut [TensorViewMut<'_>],
+) -> Result<(), T0Error> {
+    match op {
+        Op::MoeRoute(route_op) => {
+            if (inputs.len() != 1 && inputs.len() != 2) || outputs.len() != 2 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "moe_route",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "moe_route requires 1 or 2 inputs and 2 outputs, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            let bias = if inputs.len() == 2 {
+                Some(&inputs[1])
+            } else {
+                None
+            };
+            let (ids, rest) = outputs.split_at_mut(1);
+            moe_route(route_op, &inputs[0], bias, &mut ids[0], &mut rest[0])
+        }
+        Op::MoeFfn(ffn_op) => {
+            if inputs.len() != 5 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "moe_ffn",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "moe_ffn requires 5 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            moe_ffn(
+                ffn_op,
+                &inputs[0],
+                &inputs[1],
+                &inputs[2],
+                &inputs[3],
+                None,
+                &inputs[4],
+                None,
+                None,
+                &mut outputs[0],
+            )
+        }
+        other => Err(T0Error::InvalidAttribute {
+            op: other.op_name(),
+            attribute: "op",
+            reason: format!("op `{}` is not in the A1.9 MoE group", other.op_name()),
+        }),
+    }
+}
+
+/// Dispatches and executes a stateful sequence op using scalar T0 reference implementations
+/// (Spec 1 §4.E, Spec 3 §4.2, Card A1.9).
+///
+/// `causal_conv1d` takes 2 or 3 inputs `(x, w, bias?)` and 1 output; `linear_attn_scan`
+/// takes exactly 5 inputs `(q, k, v, alpha, beta)` and 1 output. Both read `state_in`
+/// (slot A) and write `state_out` (slot B) over the explicit `seq` segmentation.
+/// `chunked` selects the scan form for `linear_attn_scan` (ignored for `causal_conv1d`);
+/// form selection is executor scope per spec 4 §5.5.
+#[allow(clippy::too_many_arguments)]
+pub fn execute_state_scan_op(
+    op: &Op,
+    inputs: &[TensorView<'_>],
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    outputs: &mut [TensorViewMut<'_>],
+    state_out: &mut TensorViewMut<'_>,
+    chunked: bool,
+) -> Result<(), T0Error> {
+    match op {
+        Op::CausalConv1d(conv_op) => {
+            if (inputs.len() != 2 && inputs.len() != 3) || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "causal_conv1d",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "causal_conv1d requires 2 or 3 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            let bias = if inputs.len() == 3 {
+                Some(&inputs[2])
+            } else {
+                None
+            };
+            causal_conv1d(
+                conv_op,
+                &inputs[0],
+                &inputs[1],
+                bias,
+                state_in,
+                seq,
+                &mut outputs[0],
+                state_out,
+            )
+        }
+        Op::LinearAttnScan(scan_op) => {
+            if inputs.len() != 5 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "linear_attn_scan",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "linear_attn_scan requires 5 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            if chunked {
+                linear_attn_scan_chunked(
+                    scan_op,
+                    &inputs[0],
+                    &inputs[1],
+                    &inputs[2],
+                    &inputs[3],
+                    &inputs[4],
+                    state_in,
+                    seq,
+                    &mut outputs[0],
+                    state_out,
+                )
+            } else {
+                linear_attn_scan_recurrent(
+                    scan_op,
+                    &inputs[0],
+                    &inputs[1],
+                    &inputs[2],
+                    &inputs[3],
+                    &inputs[4],
+                    state_in,
+                    seq,
+                    &mut outputs[0],
+                    state_out,
+                )
+            }
+        }
+        other => Err(T0Error::InvalidAttribute {
+            op: other.op_name(),
+            attribute: "op",
+            reason: format!(
+                "op `{}` is not in the A1.9 state/scan group",
+                other.op_name()
+            ),
+        }),
+    }
+}
+
+/// Dispatches and executes the staged `ngram_gather` via views (Spec 1 §4.A, Card A1.9).
+///
+/// Takes exactly 2 inputs `(gather_staging, row_scales)` and 1 output; the op must
+/// carry `NgramSource::Staged`. Device-table mode needs a hash and table scale,
+/// so it runs through [`ngram_gather_device`] instead.
+pub fn execute_ngram_op(
+    op: &Op,
+    inputs: &[TensorView<'_>],
+    outputs: &mut [TensorViewMut<'_>],
+) -> Result<(), T0Error> {
+    match op {
+        Op::NgramGather(ngram_op) => {
+            if inputs.len() != 2 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "ngram_gather",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "ngram_gather requires 2 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            ngram_gather(ngram_op, &inputs[0], &inputs[1], &mut outputs[0])
+        }
+        other => Err(T0Error::InvalidAttribute {
+            op: other.op_name(),
+            attribute: "op",
+            reason: format!("op `{}` is not in the A1.9 n-gram group", other.op_name()),
+        }),
+    }
+}
+
+/// Dispatches and executes a rank-1 collective using scalar T0 reference implementations
+/// (Spec 1 §4.G, Card A1.9).
+///
+/// Arity: `all_reduce`/`all_gather`/`reduce_scatter` take 1 input and 1 output;
+/// `all_to_all` takes 2 inputs `(x, counts)` and 1 output; `send` takes 1 input
+/// and no outputs; `recv` takes no inputs and 1 output; `barrier` takes neither.
+pub fn execute_collective_op(
+    op: &Op,
+    inputs: &[TensorView<'_>],
+    outputs: &mut [TensorViewMut<'_>],
+) -> Result<(), T0Error> {
+    match op {
+        Op::AllReduce(reduce_op) => {
+            if inputs.len() != 1 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "all_reduce",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "all_reduce requires 1 input and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            all_reduce(reduce_op, &inputs[0], &mut outputs[0])
+        }
+        Op::AllGather(gather_op) => {
+            if inputs.len() != 1 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "all_gather",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "all_gather requires 1 input and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            all_gather(gather_op, &inputs[0], &mut outputs[0])
+        }
+        Op::ReduceScatter(scatter_op) => {
+            if inputs.len() != 1 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "reduce_scatter",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "reduce_scatter requires 1 input and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            reduce_scatter(scatter_op, &inputs[0], &mut outputs[0])
+        }
+        Op::AllToAll(all_to_all_op) => {
+            if inputs.len() != 2 || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "all_to_all",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "all_to_all requires 2 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            all_to_all(all_to_all_op, &inputs[0], &inputs[1], &mut outputs[0])
+        }
+        Op::Send(send_op) => {
+            if inputs.len() != 1 || !outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "send",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "send requires 1 input and 0 outputs, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            send(send_op, &inputs[0])
+        }
+        Op::Recv(recv_op) => {
+            if !inputs.is_empty() || outputs.len() != 1 {
+                return Err(T0Error::InvalidAttribute {
+                    op: "recv",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "recv requires 0 inputs and 1 output, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            recv(recv_op, &mut outputs[0])
+        }
+        Op::Barrier(barrier_op) => {
+            if !inputs.is_empty() || !outputs.is_empty() {
+                return Err(T0Error::InvalidAttribute {
+                    op: "barrier",
+                    attribute: "inputs/outputs",
+                    reason: format!(
+                        "barrier requires 0 inputs and 0 outputs, got {} inputs and {} outputs",
+                        inputs.len(),
+                        outputs.len()
+                    ),
+                });
+            }
+            barrier(barrier_op)
+        }
+        other => Err(T0Error::InvalidAttribute {
+            op: other.op_name(),
+            attribute: "op",
+            reason: format!(
+                "op `{}` is not in the A1.9 collective group",
+                other.op_name()
+            ),
         }),
     }
 }

--- a/crates/r9v-t0/src/linear_attn_scan.rs
+++ b/crates/r9v-t0/src/linear_attn_scan.rs
@@ -1,0 +1,766 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Scalar T0 implementations of `linear_attn_scan` (Spec 1 §4.E, Card A1.9).
+//!
+//! Chunked and recurrent forms over one shared scalar core with identical
+//! per-token operation order, so the two forms agree bit-exactly (L0).
+//!
+//! DECISION(A1.9): all three scan kinds share the gated outer-product
+//! recurrence and chunking is T0-level loop blocking only; rejected per-kind
+//! branches and device WMMA tiling in T0 scope. Per SI-47.
+
+use r9v_ir::{DType, LayoutId, LinearAttnKind, LinearAttnScanOp};
+
+use crate::buffer::{TensorView, TensorViewMut};
+use crate::error::T0Error;
+use crate::segments::SeqLayout;
+
+/// Validated scan dimensions shared by both forms.
+struct ScanDims {
+    t: usize,
+    h: usize,
+    d: usize,
+    dv: usize,
+    s: usize,
+}
+
+/// Validates a scan invocation without touching outputs or state (Spec 1 §4.E).
+///
+/// Collects every structural, dtype, layout, dimension, and gate-finiteness
+/// problem before any byte is written. Returns the resolved dimensions.
+#[allow(clippy::too_many_arguments)]
+fn validate_scan(
+    op: &LinearAttnScanOp,
+    q: &TensorView<'_>,
+    k: &TensorView<'_>,
+    v: &TensorView<'_>,
+    alpha: &TensorView<'_>,
+    beta: &TensorView<'_>,
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    o: &TensorViewMut<'_>,
+    state_out: &TensorViewMut<'_>,
+) -> Result<ScanDims, T0Error> {
+    q.validate_backing("q")?;
+    k.validate_backing("k")?;
+    v.validate_backing("v")?;
+    alpha.validate_backing("alpha")?;
+    beta.validate_backing("beta")?;
+    state_in.validate_backing("state_in")?;
+    o.validate_backing("o")?;
+    state_out.validate_backing("state_out")?;
+
+    let mut problems = Vec::new();
+
+    for (name, view, rank) in [
+        ("q", q, 3),
+        ("k", k, 3),
+        ("v", v, 3),
+        ("alpha", alpha, 2),
+        ("beta", beta, 2),
+        ("state_in", state_in, 4),
+    ] {
+        if view.rank() != rank {
+            problems.push(T0Error::RankMismatch {
+                tensor: name,
+                expected: rank,
+                got: view.rank(),
+                shape: view.shape().to_vec(),
+            });
+        }
+    }
+    if o.rank() != 3 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "o",
+            expected: 3,
+            got: o.rank(),
+            shape: o.shape().to_vec(),
+        });
+    }
+    if state_out.rank() != 4 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "state_out",
+            expected: 4,
+            got: state_out.rank(),
+            shape: state_out.shape().to_vec(),
+        });
+    }
+
+    for (name, view) in [
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("alpha", alpha),
+        ("beta", beta),
+        ("state_in", state_in),
+    ] {
+        if view.layout() != LayoutId::CONTIGUOUS && view.layout() != LayoutId::L0 {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: name,
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+                got: view.layout(),
+            });
+        }
+    }
+    if o.layout() != LayoutId::CONTIGUOUS && o.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "o",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: o.layout(),
+        });
+    }
+    if state_out.layout() != LayoutId::CONTIGUOUS && state_out.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "state_out",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: state_out.layout(),
+        });
+    }
+
+    for (name, view) in [("q", q), ("k", k), ("v", v)] {
+        if !matches!(view.dtype(), DType::F16 | DType::Bf16 | DType::F32) {
+            problems.push(T0Error::DTypeMismatch {
+                tensor: name,
+                expected: vec![DType::F16, DType::Bf16, DType::F32],
+                got: view.dtype(),
+            });
+        }
+    }
+    if k.dtype() != q.dtype() {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "k",
+            expected: vec![q.dtype()],
+            got: k.dtype(),
+        });
+    }
+    if v.dtype() != q.dtype() {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "v",
+            expected: vec![q.dtype()],
+            got: v.dtype(),
+        });
+    }
+    for (name, view) in [("alpha", alpha), ("beta", beta), ("state_in", state_in)] {
+        if view.dtype() != DType::F32 {
+            problems.push(T0Error::DTypeMismatch {
+                tensor: name,
+                expected: vec![DType::F32],
+                got: view.dtype(),
+            });
+        }
+    }
+    if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(T0Error::InvalidAttribute {
+            op: "linear_attn_scan",
+            attribute: "out_dtype",
+            reason: format!("must be f16, bf16, or f32, got {:?}", op.out_dtype),
+        });
+    }
+    if o.dtype() != op.out_dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "o",
+            expected: vec![op.out_dtype],
+            got: o.dtype(),
+        });
+    }
+    if state_out.dtype() != DType::F32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "state_out",
+            expected: vec![DType::F32],
+            got: state_out.dtype(),
+        });
+    }
+    if op.chunk == 0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "linear_attn_scan",
+            attribute: "chunk",
+            reason: "chunk must be > 0".to_string(),
+        });
+    }
+    // All three kinds share the T0 recurrence (SI-47): accepted, not branched.
+    match op.kind {
+        LinearAttnKind::GatedDeltaNet | LinearAttnKind::GLA | LinearAttnKind::Mamba2 => {}
+    }
+    match op.handle.kind() {
+        r9v_ir::StateKind::Recurrent => {}
+        other => problems.push(T0Error::InvalidAttribute {
+            op: "linear_attn_scan",
+            attribute: "handle",
+            reason: format!("state handle must be Recurrent, got {other:?}"),
+        }),
+    }
+
+    T0Error::from_problems(problems)?;
+
+    let t = q.shape()[0];
+    let h = q.shape()[1];
+    let d = q.shape()[2];
+    let dv = v.shape()[2];
+    let s = seq.seq_count();
+
+    if h == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "linear_attn_scan",
+            tensor: "q",
+        });
+    }
+    if d == 0 || dv == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "linear_attn_scan",
+            tensor: "q",
+        });
+    }
+    if t == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "linear_attn_scan",
+            tensor: "q",
+        });
+    }
+    for dim in [t, h, d, dv, s] {
+        u32::try_from(dim).map_err(|_| T0Error::ArithmeticOverflow {
+            op: "linear_attn_scan",
+            detail: format!("dimension exceeds u32: {dim}"),
+        })?;
+    }
+    seq.check_total("q", t)?;
+
+    let mut problems = Vec::new();
+    // T agreement.
+    for (name, view) in [("k", k), ("v", v)] {
+        if view.shape()[0] != t {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "q",
+                expected: t,
+                tensor: name,
+                got: view.shape()[0],
+            });
+        }
+    }
+    for (name, view) in [("alpha", alpha), ("beta", beta)] {
+        if view.shape()[0] != t {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "q",
+                expected: t,
+                tensor: name,
+                got: view.shape()[0],
+            });
+        }
+    }
+    if o.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "q",
+            expected: t,
+            tensor: "o",
+            got: o.shape()[0],
+        });
+    }
+    // H agreement.
+    if k.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "k",
+            got: k.shape()[1],
+        });
+    }
+    if v.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "v",
+            got: v.shape()[1],
+        });
+    }
+    if alpha.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "alpha",
+            got: alpha.shape()[1],
+        });
+    }
+    if beta.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "beta",
+            got: beta.shape()[1],
+        });
+    }
+    if o.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "o",
+            got: o.shape()[1],
+        });
+    }
+    // D / Dv agreement.
+    if k.shape()[2] != d {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "D",
+            expected_from: "q",
+            expected: d,
+            tensor: "k",
+            got: k.shape()[2],
+        });
+    }
+    if o.shape()[2] != dv {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dv",
+            expected_from: "v",
+            expected: dv,
+            tensor: "o",
+            got: o.shape()[2],
+        });
+    }
+    // State [S, H, D, Dv].
+    if state_in.shape()[0] != s {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "S",
+            expected_from: "seq",
+            expected: s,
+            tensor: "state_in",
+            got: state_in.shape()[0],
+        });
+    }
+    if state_in.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "state_in",
+            got: state_in.shape()[1],
+        });
+    }
+    if state_in.shape()[2] != d {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "D",
+            expected_from: "q",
+            expected: d,
+            tensor: "state_in",
+            got: state_in.shape()[2],
+        });
+    }
+    if state_in.shape()[3] != dv {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dv",
+            expected_from: "v",
+            expected: dv,
+            tensor: "state_in",
+            got: state_in.shape()[3],
+        });
+    }
+    if state_out.shape()[0] != s {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "S",
+            expected_from: "seq",
+            expected: s,
+            tensor: "state_out",
+            got: state_out.shape()[0],
+        });
+    }
+    if state_out.shape()[1] != h {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "H",
+            expected_from: "q",
+            expected: h,
+            tensor: "state_out",
+            got: state_out.shape()[1],
+        });
+    }
+    if state_out.shape()[2] != d {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "D",
+            expected_from: "q",
+            expected: d,
+            tensor: "state_out",
+            got: state_out.shape()[2],
+        });
+    }
+    if state_out.shape()[3] != dv {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dv",
+            expected_from: "v",
+            expected: dv,
+            tensor: "state_out",
+            got: state_out.shape()[3],
+        });
+    }
+    // Gate finiteness: no spec authority to clamp, so non-finite gates are
+    // collected and rejected rather than silently propagated.
+    for row in 0..t {
+        for head in 0..h {
+            let a = alpha.read_f32(row * h + head);
+            if !a.is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "linear_attn_scan",
+                    attribute: "alpha",
+                    reason: format!("non-finite gate at (t={row}, h={head}): {a}"),
+                });
+            }
+            let b = beta.read_f32(row * h + head);
+            if !b.is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "linear_attn_scan",
+                    attribute: "beta",
+                    reason: format!("non-finite gate at (t={row}, h={head}): {b}"),
+                });
+            }
+        }
+    }
+    T0Error::from_problems(problems)?;
+
+    Ok(ScanDims { t, h, d, dv, s })
+}
+
+/// Stages one full scan run: `o_tmp [T·H·Dv]` and `s_tmp [S·H·D·Dv]` in `f32`.
+///
+/// `chunked` selects the loop nest: `false` runs the recurrent token-at-a-time
+/// nest, `true` blocks the token loop over `chunk` with identical per-token
+/// operation order (T0-level loop blocking; device WMMA chunking is T1/T2
+/// scope per spec 4 §5.5). Both nests share the scalar step below.
+#[allow(clippy::too_many_arguments)]
+fn run_scan(
+    q: &TensorView<'_>,
+    k: &TensorView<'_>,
+    v: &TensorView<'_>,
+    alpha: &TensorView<'_>,
+    beta: &TensorView<'_>,
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    dims: &ScanDims,
+    chunk: usize,
+    chunked: bool,
+    o_tmp: &mut [f32],
+    s_tmp: &mut [f32],
+) {
+    let (h, d, dv) = (dims.h, dims.d, dims.dv);
+    let mut base = 0usize;
+    for (slot, &len_u32) in seq.seq_lens().iter().enumerate() {
+        let len = len_u32 as usize;
+        for head in 0..h {
+            let mut s_mat = vec![0.0f32; d * dv];
+            for i in 0..d {
+                for j in 0..dv {
+                    s_mat[i * dv + j] = state_in.read_f32((slot * h + head) * d * dv + i * dv + j);
+                }
+            }
+            if chunked {
+                let mut cs = 0usize;
+                while cs < len {
+                    let ce = (cs + chunk).min(len);
+                    for r in cs..ce {
+                        let gt = base + r;
+                        scan_step_into(q, k, v, alpha, beta, dims, gt, head, &mut s_mat, o_tmp);
+                    }
+                    cs = ce;
+                }
+            } else {
+                for r in 0..len {
+                    let gt = base + r;
+                    scan_step_into(q, k, v, alpha, beta, dims, gt, head, &mut s_mat, o_tmp);
+                }
+            }
+            for i in 0..d {
+                for j in 0..dv {
+                    s_tmp[(slot * h + head) * d * dv + i * dv + j] = s_mat[i * dv + j];
+                }
+            }
+        }
+        base += len;
+    }
+}
+
+/// Executes the chunked scan form (Spec 1 §4.E, spec 4 §5.5, Card A1.9).
+///
+/// Tokens run in per-`(sequence, head)` chunks of `op.chunk`; state reads slot
+/// A (`state_in`) and writes slot B (`state_out`) without mutating the input.
+/// Bit-exact with [`linear_attn_scan_recurrent`] by shared operation order.
+#[allow(clippy::too_many_arguments)]
+pub fn linear_attn_scan_chunked(
+    op: &LinearAttnScanOp,
+    q: &TensorView<'_>,
+    k: &TensorView<'_>,
+    v: &TensorView<'_>,
+    alpha: &TensorView<'_>,
+    beta: &TensorView<'_>,
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    o: &mut TensorViewMut<'_>,
+    state_out: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let dims = validate_scan(op, q, k, v, alpha, beta, state_in, seq, o, state_out)?;
+    run_and_commit(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        state_in,
+        seq,
+        &dims,
+        op.chunk as usize,
+        true,
+        o,
+        state_out,
+    )
+}
+
+/// Executes the recurrent scan form (Spec 1 §4.E, spec 4 §5.5, Card A1.9).
+///
+/// One token step at a time per `(sequence, head)`; used for short queries and
+/// for accepted-prefix recompute from slot A into slot B (spec 3 §4.2).
+/// Bit-exact with [`linear_attn_scan_chunked`] by shared operation order.
+#[allow(clippy::too_many_arguments)]
+pub fn linear_attn_scan_recurrent(
+    op: &LinearAttnScanOp,
+    q: &TensorView<'_>,
+    k: &TensorView<'_>,
+    v: &TensorView<'_>,
+    alpha: &TensorView<'_>,
+    beta: &TensorView<'_>,
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    o: &mut TensorViewMut<'_>,
+    state_out: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let dims = validate_scan(op, q, k, v, alpha, beta, state_in, seq, o, state_out)?;
+    run_and_commit(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        state_in,
+        seq,
+        &dims,
+        op.chunk as usize,
+        false,
+        o,
+        state_out,
+    )
+}
+
+/// Stages a full run and commits outputs and state (Spec 1 §4.E).
+///
+/// `o` (cast once to `out_dtype`) and `state_out` are written only after the
+/// whole run stages successfully, preserving the A/B discipline where slot A
+/// is never mutated.
+#[allow(clippy::too_many_arguments)]
+fn run_and_commit(
+    q: &TensorView<'_>,
+    k: &TensorView<'_>,
+    v: &TensorView<'_>,
+    alpha: &TensorView<'_>,
+    beta: &TensorView<'_>,
+    state_in: &TensorView<'_>,
+    seq: &SeqLayout,
+    dims: &ScanDims,
+    chunk: usize,
+    chunked: bool,
+    o: &mut TensorViewMut<'_>,
+    state_out: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    let o_len = dims
+        .t
+        .checked_mul(dims.h)
+        .and_then(|v| v.checked_mul(dims.dv))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "linear_attn_scan",
+            detail: "output buffer size overflows usize".to_string(),
+        })?;
+    let s_len = dims
+        .s
+        .checked_mul(dims.h)
+        .and_then(|v| v.checked_mul(dims.d))
+        .and_then(|v| v.checked_mul(dims.dv))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "linear_attn_scan",
+            detail: "state buffer size overflows usize".to_string(),
+        })?;
+    let mut o_tmp = vec![0.0f32; o_len];
+    let mut s_tmp = vec![0.0f32; s_len];
+    run_scan(
+        q, k, v, alpha, beta, state_in, seq, dims, chunk, chunked, &mut o_tmp, &mut s_tmp,
+    );
+    for (idx, &val) in o_tmp.iter().enumerate() {
+        o.write_f32(idx, val);
+    }
+    for (idx, &val) in s_tmp.iter().enumerate() {
+        state_out.write_f32(idx, val);
+    }
+    Ok(())
+}
+
+/// 64-bit reference linear-attention scan for testing (Spec 1 §4.E).
+///
+/// Independent `f64` path: plain nested loops over `&[f64]` slices, never
+/// calling either T0 form. Mirrors the shared recurrence in `f64` with
+/// per-segment state slots. Returns `(o [T, H, Dv], state_out [S, H, D, Dv])`.
+/// Slice lengths and every extent product are validated with typed errors;
+/// there is no silent empty fallback.
+#[allow(clippy::too_many_arguments)]
+pub fn linear_attn_scan_f64_reference(
+    q: &[f64],
+    k: &[f64],
+    v: &[f64],
+    alpha: &[f64],
+    beta: &[f64],
+    t: usize,
+    h: usize,
+    d: usize,
+    dv: usize,
+    state_in: &[f64],
+    s: usize,
+    seq_lens: &[u32],
+) -> Result<(Vec<f64>, Vec<f64>), T0Error> {
+    const OP: &str = "linear_attn_scan";
+    let thd = t
+        .checked_mul(h)
+        .and_then(|v| v.checked_mul(d))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "T * H * D overflows usize".to_string(),
+        })?;
+    let thdv = t
+        .checked_mul(h)
+        .and_then(|v| v.checked_mul(dv))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "T * H * Dv overflows usize".to_string(),
+        })?;
+    let th = t
+        .checked_mul(h)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * H overflows usize for T={t}, H={h}"),
+        })?;
+    let shddv = s
+        .checked_mul(h)
+        .and_then(|v| v.checked_mul(d))
+        .and_then(|v| v.checked_mul(dv))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "S * H * D * Dv overflows usize".to_string(),
+        })?;
+    let mut problems = Vec::new();
+    for (name, slice, expected, detail) in [
+        ("q", q, thd, "q length must equal T * H * D"),
+        ("k", k, thd, "k length must equal T * H * D"),
+        ("v", v, thdv, "v length must equal T * H * Dv"),
+        ("alpha", alpha, th, "alpha length must equal T * H"),
+        ("beta", beta, th, "beta length must equal T * H"),
+        (
+            "state_in",
+            state_in,
+            shddv,
+            "state_in length must equal S * H * D * Dv",
+        ),
+    ] {
+        if slice.len() != expected {
+            problems.push(T0Error::ShapeLengthMismatch {
+                op: OP,
+                tensor: name,
+                expected,
+                got: slice.len(),
+                detail: detail.to_string(),
+            });
+        }
+    }
+    if seq_lens.len() != s {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "seq_lens",
+            expected: s,
+            got: seq_lens.len(),
+            detail: "seq_lens length must equal S".to_string(),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    let mut o = vec![0.0f64; thdv];
+    let mut s_out = vec![0.0f64; shddv];
+    let mut base = 0usize;
+    for (slot, &len_u32) in seq_lens.iter().enumerate() {
+        let len = len_u32 as usize;
+        for head in 0..h {
+            let mut s_mat = vec![0.0f64; d * dv];
+            for i in 0..d {
+                for j in 0..dv {
+                    s_mat[i * dv + j] = state_in[(slot * h + head) * d * dv + i * dv + j];
+                }
+            }
+            for r in 0..len {
+                let gt = base + r;
+                let a = alpha[gt * h + head];
+                let b = beta[gt * h + head];
+                for i in 0..d {
+                    let ki = k[(gt * h + head) * d + i];
+                    for j in 0..dv {
+                        let vj = v[(gt * h + head) * dv + j];
+                        s_mat[i * dv + j] = a * s_mat[i * dv + j] + b * ki * vj;
+                    }
+                }
+                for j in 0..dv {
+                    let mut acc = 0.0f64;
+                    for i in 0..d {
+                        acc += q[(gt * h + head) * d + i] * s_mat[i * dv + j];
+                    }
+                    o[(gt * h + head) * dv + j] = acc;
+                }
+            }
+            for i in 0..d {
+                for j in 0..dv {
+                    s_out[(slot * h + head) * d * dv + i * dv + j] = s_mat[i * dv + j];
+                }
+            }
+        }
+        base += len;
+    }
+    Ok((o, s_out))
+}
+
+/// Token step writing directly into the staged output buffer.
+///
+/// `S_t = alpha·S_{t-1} + beta·(k_t ⊗ v_t)` over `[D, Dv]`, then
+/// `o_t[j] = Σ_i q_t[i]·S_t[i,j]`, all ascending in `f32`.
+#[allow(clippy::too_many_arguments)]
+fn scan_step_into(
+    q: &TensorView<'_>,
+    k: &TensorView<'_>,
+    v: &TensorView<'_>,
+    alpha: &TensorView<'_>,
+    beta: &TensorView<'_>,
+    dims: &ScanDims,
+    gt: usize,
+    head: usize,
+    s_mat: &mut [f32],
+    o_tmp: &mut [f32],
+) {
+    let (h, d, dv) = (dims.h, dims.d, dims.dv);
+    let a = alpha.read_f32(gt * h + head);
+    let b = beta.read_f32(gt * h + head);
+    for i in 0..d {
+        let ki = k.read_f32((gt * h + head) * d + i);
+        for j in 0..dv {
+            let vj = v.read_f32((gt * h + head) * dv + j);
+            s_mat[i * dv + j] = a * s_mat[i * dv + j] + b * ki * vj;
+        }
+    }
+    let base = (gt * h + head) * dv;
+    for j in 0..dv {
+        let mut acc = 0.0f32;
+        for i in 0..d {
+            acc += q.read_f32((gt * h + head) * d + i) * s_mat[i * dv + j];
+        }
+        o_tmp[base + j] = acc;
+    }
+}

--- a/crates/r9v-t0/src/moe_ffn.rs
+++ b/crates/r9v-t0/src/moe_ffn.rs
@@ -1,0 +1,1947 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Scalar T0 implementation of `moe_ffn` op (Spec 1 §4.C, §6.2, Card A1.9).
+//!
+//! Sorts `(expert, token)` triples deterministically, runs a grouped GEMM per
+//! expert, applies `act_mul`, projects down, and combines with routing weights
+//! in sorted order (all in `f32`, ascending index order per Spec 1 §6.1).
+
+use r9v_format::records::{E4M3Block128Scale, I4KSuperblock, I8Block128Scale, I8RowScale};
+use r9v_format::scales::E4m3;
+use r9v_format::{
+    l0_region_bytes, l0_row_stride_bytes, l1_forward_index, scale_geometry, FormatError, Layout,
+    PaddedDims, SchemeId,
+};
+use r9v_ir::{
+    ActMulOp, ActivationKind, DType, Epilogue, LayoutId, MatmulOp, MoeFfnOp, QuantScheme,
+};
+
+use crate::act_mul::act_mul;
+use crate::buffer::{TensorData, TensorView, TensorViewMut};
+use crate::dtype::f16_to_f32;
+use crate::error::{u64_to_usize, T0Error};
+use crate::matmul::matmul_with_scales;
+
+/// Executes scalar T0 mixture-of-experts feed-forward (Spec 1 §4.C, §6.2, Card A1.9).
+///
+/// Signature:
+/// - `x`: `[T, Dm]` (matmul activation family: f16|bf16|i8 PerToken|i8 PerBlock32|e4m3 PerToken)
+/// - `expert_ids`: `[T, K]` (`u32`, every id `< E`)
+/// - `weights`: `[T, K]` (`f32` routing weights)
+/// - `w_gate_up`: `[E, 2·Dff, Dm]` (`Weight`, `Device|Tiered`)
+/// - `w_down`: `[E, Dm, Dff]` (`Weight`, `Device|Tiered`)
+/// - `y`: `[T, Dm]` (`out_dtype`)
+///
+/// Scales travel out-of-band per SI-18/SI-52: each explicit scale parameter
+/// falls back to the attached view (`x.scale()` and friends, mirroring
+/// `matmul`) when `None`.
+///
+/// Algorithm:
+/// (a) validate everything and collect every bound failure before touching
+///     `y`; (b) stable sort `(expert, token, k)` triples by expert then token
+///     (mirrors spec 4 §5.6 pre-pass and the `scatter_add_rows` sorted
+///     precedent); (c) per expert with ≥ 1 token, run the gathered rows
+///     through `matmul_with_scales` over the full gate/up matrices (per-row
+///     results are batch-independent, so full-matrix GEMM sliced to the
+///     expert's columns is bit-identical to a per-expert sub-matrix GEMM),
+///     then `act_mul` in `f32`, then the down projection; (d) combine
+///     `y[t] += w[t,k]·out` in `f32` in ascending `(expert, token)` order
+///     with `y` zero-initialized first.
+///
+/// Gate/up row layout: rows `[0, Dff)` are gate, `[Dff, 2·Dff)` are up
+/// (gate-major halves; the spec's `[E, 2·Dff, Dm]` is silent on order —
+/// SI-50; spec 4 §5.6 "gate/up interleaved" describes kernel access, not
+/// storage).
+///
+/// Down-projection numerics mirror matmul Branch D (f32 accumulation over
+/// per-element dequantized weights in ascending-K order); the equivalence is
+/// proven by bit-exact tests against `matmul_with_scales` itself.
+///
+/// `shared_experts` is ignored for compute: the spec assigns the shared path
+/// to a plain graph-level `matmul`, and this attr only sizes internal buffers
+/// (of which T0 has none).
+///
+/// DECISION(A1.9): accept `shared_experts <= E`, ignore it for compute;
+/// rejected wiring a second GEMM path because the graph already owns it.
+/// Per SI-49.
+///
+/// Numerics: same as `matmul` per expert (`moe_ffn_gemm_numerics`); combine in
+/// `f32` in sorted order. Batch invariant by construction.
+///
+/// DECISION(A1.9): gate rows are `[0, Dff)` and up rows `[Dff, 2·Dff)`;
+/// rejected interleaved row alternation because no storage order is stated and
+/// gate-major halves keep each projection a contiguous row range. Per SI-50.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_ffn(
+    op: &MoeFfnOp,
+    x: &TensorView<'_>,
+    expert_ids: &TensorView<'_>,
+    weights: &TensorView<'_>,
+    w_gate_up: &TensorView<'_>,
+    w_gate_up_scale: Option<&TensorView<'_>>,
+    w_down: &TensorView<'_>,
+    w_down_scale: Option<&TensorView<'_>>,
+    x_scale: Option<&TensorView<'_>>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    x.validate_backing("x")?;
+    expert_ids.validate_backing("expert_ids")?;
+    weights.validate_backing("weights")?;
+    w_gate_up.validate_backing("w_gate_up")?;
+    w_down.validate_backing("w_down")?;
+    y.validate_backing("y")?;
+    if let Some(s) = w_gate_up_scale {
+        s.validate_backing("w_gate_up_scale")?;
+    }
+    if let Some(s) = w_down_scale {
+        s.validate_backing("w_down_scale")?;
+    }
+    if let Some(s) = x_scale {
+        s.validate_backing("x_scale")?;
+    }
+
+    // Scales fall back to attached views, mirroring `matmul` (SI-18, SI-52).
+    let x_scale = x_scale.or_else(|| x.scale());
+    let w_gate_up_scale = w_gate_up_scale.or_else(|| w_gate_up.scale());
+    let w_down_scale = w_down_scale.or_else(|| w_down.scale());
+    if let Some(s) = x_scale {
+        s.validate_backing("x_scale")?;
+    }
+    if let Some(s) = w_gate_up_scale {
+        s.validate_backing("w_gate_up_scale")?;
+    }
+    if let Some(s) = w_down_scale {
+        s.validate_backing("w_down_scale")?;
+    }
+
+    let mut problems = Vec::new();
+
+    if x.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "x",
+            expected: 2,
+            got: x.rank(),
+            shape: x.shape().to_vec(),
+        });
+    }
+    if expert_ids.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "expert_ids",
+            expected: 2,
+            got: expert_ids.rank(),
+            shape: expert_ids.shape().to_vec(),
+        });
+    }
+    if weights.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "weights",
+            expected: 2,
+            got: weights.rank(),
+            shape: weights.shape().to_vec(),
+        });
+    }
+    if w_gate_up.rank() != 3 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "w_gate_up",
+            expected: 3,
+            got: w_gate_up.rank(),
+            shape: w_gate_up.shape().to_vec(),
+        });
+    }
+    if w_down.rank() != 3 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "w_down",
+            expected: 3,
+            got: w_down.rank(),
+            shape: w_down.shape().to_vec(),
+        });
+    }
+    if y.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
+    }
+
+    // Layouts mirror matmul: activations CONTIGUOUS|L0, weights L0|L1|CONTIGUOUS.
+    for (name, v) in [("x", x), ("expert_ids", expert_ids), ("weights", weights)] {
+        if v.layout() != LayoutId::CONTIGUOUS && v.layout() != LayoutId::L0 {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: name,
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+                got: v.layout(),
+            });
+        }
+    }
+    for (name, v) in [("w_gate_up", w_gate_up), ("w_down", w_down)] {
+        if v.layout() == LayoutId::L1S
+            || (v.layout() != LayoutId::L0
+                && v.layout() != LayoutId::L1
+                && v.layout() != LayoutId::CONTIGUOUS)
+        {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: name,
+                expected: vec![LayoutId::L0, LayoutId::L1],
+                got: v.layout(),
+            });
+        }
+    }
+    if y.layout() != LayoutId::CONTIGUOUS && y.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "y",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: y.layout(),
+        });
+    }
+    if let Some(xs) = x_scale {
+        if xs.layout() != LayoutId::CONTIGUOUS && xs.layout() != LayoutId::L0 {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: "x_scale",
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+                got: xs.layout(),
+            });
+        }
+    }
+    if let Some(ws) = w_down_scale {
+        if ws.layout() == LayoutId::L1S
+            || (ws.layout() != LayoutId::CONTIGUOUS
+                && ws.layout() != LayoutId::L0
+                && ws.layout() != LayoutId::L1)
+        {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: "w_down_scale",
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0, LayoutId::L1],
+                got: ws.layout(),
+            });
+        }
+    }
+
+    // Activation dtype/quant family mirrors check_gemm_activation_operand.
+    match (x.dtype(), x.quant()) {
+        (DType::F16 | DType::Bf16, QuantScheme::None) => {}
+        (DType::I8, QuantScheme::PerToken | QuantScheme::PerBlock32) => {}
+        (DType::E4m3, QuantScheme::PerToken) => {}
+        (DType::F32, _) => problems.push(T0Error::DTypeMismatch {
+            tensor: "x",
+            expected: vec![DType::F16, DType::Bf16, DType::I8, DType::E4m3],
+            got: x.dtype(),
+        }),
+        _ => problems.push(T0Error::QuantMismatch {
+            tensor: "x",
+            expected: vec![
+                QuantScheme::None,
+                QuantScheme::PerToken,
+                QuantScheme::PerBlock32,
+            ],
+            got: x.quant(),
+        }),
+    }
+    if expert_ids.dtype() != DType::U32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "expert_ids",
+            expected: vec![DType::U32],
+            got: expert_ids.dtype(),
+        });
+    }
+    if weights.dtype() != DType::F32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "weights",
+            expected: vec![DType::F32],
+            got: weights.dtype(),
+        });
+    }
+    if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(T0Error::InvalidAttribute {
+            op: "moe_ffn",
+            attribute: "out_dtype",
+            reason: format!("must be f16, bf16, or f32, got {:?}", op.out_dtype),
+        });
+    }
+    if y.dtype() != op.out_dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.out_dtype],
+            got: y.dtype(),
+        });
+    }
+    match op.act {
+        ActivationKind::Silu
+        | ActivationKind::Gelu
+        | ActivationKind::GeluTanh
+        | ActivationKind::Relu2
+        | ActivationKind::Identity => {}
+    }
+
+    // Reserved schemes fail closed before dtype matching (mirrors matmul).
+    for (name, v) in [("x", x), ("w_gate_up", w_gate_up), ("w_down", w_down)] {
+        if let QuantScheme::Scheme(ir_s) = v.quant() {
+            let sid = SchemeId::from_ir(ir_s)?;
+            if !sid.is_native() {
+                return Err(T0Error::Format(FormatError::ReservedScheme {
+                    scheme: sid.name(),
+                    owner: sid.owner_card(),
+                }));
+            }
+        }
+        let _ = name;
+    }
+
+    // Weight dtype/quant families mirror check_gemm_weight_operand.
+    for (name, v) in [("w_gate_up", w_gate_up), ("w_down", w_down)] {
+        if matches!(v.dtype(), DType::F32 | DType::Bf16) {
+            problems.push(T0Error::DTypeMismatch {
+                tensor: name,
+                expected: vec![DType::F16, DType::I8, DType::I4, DType::E4m3],
+                got: v.dtype(),
+            });
+        }
+    }
+
+    T0Error::from_problems(problems)?;
+
+    // Resolve down-projection weight scheme (mirrors matmul Branch-D gating).
+    let down_scheme = resolve_weight_scheme("w_down", w_down)?;
+
+    let t = x.shape()[0];
+    let dm = x.shape()[1];
+    let k_dim = expert_ids.shape()[1];
+    let e = w_gate_up.shape()[0];
+    let dff = w_down.shape()[2];
+
+    if t == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "moe_ffn",
+            tensor: "x",
+        });
+    }
+    if dm == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "moe_ffn",
+            tensor: "x",
+        });
+    }
+    if e == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "moe_ffn",
+            tensor: "w_gate_up",
+        });
+    }
+    if dff == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "moe_ffn",
+            tensor: "w_down",
+        });
+    }
+    if k_dim == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "moe_ffn",
+            tensor: "expert_ids",
+        });
+    }
+    if op.shared_experts > e as u32 {
+        return Err(T0Error::InvalidAttribute {
+            op: "moe_ffn",
+            attribute: "shared_experts",
+            reason: format!(
+                "shared_experts {} exceeds expert count E={e}",
+                op.shared_experts
+            ),
+        });
+    }
+    for v in [t, dm, e, dff, k_dim] {
+        u32::try_from(v).map_err(|_| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: format!("dimension exceeds u32: {v}"),
+        })?;
+    }
+
+    let mut problems = Vec::new();
+    if weights.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "x",
+            expected: t,
+            tensor: "weights",
+            got: weights.shape()[0],
+        });
+    }
+    if weights.shape()[1] != k_dim {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "K",
+            expected_from: "expert_ids",
+            expected: k_dim,
+            tensor: "weights",
+            got: weights.shape()[1],
+        });
+    }
+    if w_gate_up.shape()[1]
+        != dff
+            .checked_mul(2)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: format!("2 * Dff overflows usize for Dff={dff}"),
+            })?
+    {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "2Dff",
+            expected_from: "w_down",
+            expected: dff * 2,
+            tensor: "w_gate_up",
+            got: w_gate_up.shape()[1],
+        });
+    }
+    if w_gate_up.shape()[2] != dm {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dm",
+            expected_from: "x",
+            expected: dm,
+            tensor: "w_gate_up",
+            got: w_gate_up.shape()[2],
+        });
+    }
+    if w_down.shape()[0] != e {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "E",
+            expected_from: "w_gate_up",
+            expected: e,
+            tensor: "w_down",
+            got: w_down.shape()[0],
+        });
+    }
+    if w_down.shape()[1] != dm {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dm",
+            expected_from: "x",
+            expected: dm,
+            tensor: "w_down",
+            got: w_down.shape()[1],
+        });
+    }
+    if y.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "x",
+            expected: t,
+            tensor: "y",
+            got: y.shape()[0],
+        });
+    }
+    if y.shape()[1] != dm {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dm",
+            expected_from: "x",
+            expected: dm,
+            tensor: "y",
+            got: y.shape()[1],
+        });
+    }
+    // Every expert id is bounds-checked before any output byte is touched.
+    for row in 0..t {
+        for slot in 0..k_dim {
+            let pos = row * k_dim + slot;
+            let id = expert_ids.try_read_u32(pos, "expert_ids").map_err(|_| {
+                T0Error::BufferLengthMismatch {
+                    tensor: "expert_ids",
+                    buffer_len: expert_ids.backing_len(),
+                    expected_len: pos + 1,
+                    shape: expert_ids.shape().to_vec(),
+                }
+            })?;
+            if (id as usize) >= e {
+                problems.push(T0Error::RowIndexOutOfRange {
+                    op: "moe_ffn",
+                    tensor: "expert_ids",
+                    position: pos,
+                    index: id,
+                    upper_bound: e,
+                });
+            }
+        }
+    }
+    validate_moe_x_scale(x, x_scale, t, dm, &mut problems);
+    validate_down_scales(w_down, w_down_scale, down_scheme, e, dff, &mut problems)?;
+    T0Error::from_problems(problems)?;
+
+    // Validated: stage all outputs; `y` is committed once at the end.
+    let y_len = t
+        .checked_mul(dm)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: format!("T * Dm overflows usize for T={t}, Dm={dm}"),
+        })?;
+    let mut y_tmp = vec![0.0f32; y_len];
+
+    // Stable sort of (expert, token, k-slot) triples by expert then token.
+    // `sort_by` is stable, and triples are pushed with ascending k slots, so
+    // duplicate (expert, token) pairs keep ascending slot order.
+    let mut triples: Vec<(u32, usize, usize)> = Vec::new();
+    for row in 0..t {
+        for slot in 0..k_dim {
+            let id = expert_ids
+                .try_read_u32(row * k_dim + slot, "expert_ids")
+                .map_err(|_| T0Error::BufferLengthMismatch {
+                    tensor: "expert_ids",
+                    buffer_len: expert_ids.backing_len(),
+                    expected_len: row * k_dim + slot + 1,
+                    shape: expert_ids.shape().to_vec(),
+                })?;
+            triples.push((id, row, slot));
+        }
+    }
+    triples.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    // Flattened expert-row view [E·2Dff, Dm] over the rank-3 bytes for the
+    // inner matmul (row-major flattening preserves L0/CONTIGUOUS rows;
+    // L1 tiles are interpreted over the flattened row space — DECISION(A1.9)
+    // alongside SI-50, since no tiled rank-3 expert layout is specified).
+    let gu_rows = e
+        .checked_mul(dff)
+        .and_then(|v| v.checked_mul(2))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: format!("E * 2Dff overflows usize for E={e}"),
+        })?;
+    let gu_bytes: &[u8] = match &w_gate_up.data {
+        TensorData::Bytes(_, slice) => slice,
+        _ => {
+            return Err(T0Error::BackingRepresentationMismatch {
+                op: "moe_ffn",
+                dtype: w_gate_up.dtype(),
+            });
+        }
+    };
+    let gu_flat = TensorView::from_bytes(&[gu_rows, dm], w_gate_up.dtype(), gu_bytes)
+        .with_quant(w_gate_up.quant())
+        .with_layout(w_gate_up.layout());
+    let gu_n = gu_rows;
+    let gemm_op = MatmulOp {
+        out_dtype: DType::F32,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    };
+    let act_op = ActMulOp {
+        act: op.act,
+        clamp: None,
+    };
+
+    let mut i = 0;
+    while i < triples.len() {
+        let expert = triples[i].0 as usize;
+        let mut j = i + 1;
+        while j < triples.len() && triples[j].0 == triples[i].0 {
+            j += 1;
+        }
+        let run = &triples[i..j];
+        // Unique tokens in ascending order (duplicate routing slots for one
+        // token share a single gathered row; slots combine separately below).
+        let mut tokens: Vec<usize> = run.iter().map(|&(_, tok, _)| tok).collect();
+        tokens.sort();
+        tokens.dedup();
+        let position = |tok: usize| {
+            tokens
+                .iter()
+                .position(|&v| v == tok)
+                .ok_or(T0Error::RowIndexOutOfRange {
+                    op: "moe_ffn",
+                    tensor: "expert_ids",
+                    position: tok,
+                    index: 0,
+                    upper_bound: t,
+                })
+        };
+        let rows: Vec<(usize, usize)> = tokens.iter().map(|&tok| (tok, 0)).collect();
+        let le = tokens.len();
+
+        // Gather expert token rows (bit-exact, backing-preserving).
+        let gathered = gather_activation_rows(x, &rows, dm, "x")?;
+        let gx_view = gathered.view(&[le, dm], x.quant(), x.layout());
+        let gx_scale_vec = gather_scale_rows(x, x_scale, &rows, t, dm)?;
+        let gx_scale_view = gx_scale_vec.as_ref().map(|v| {
+            let shape: &[usize] = match x.quant() {
+                QuantScheme::PerBlock32 => &[le, dm / 32],
+                _ => &[le],
+            };
+            TensorView::from_f32_slice(shape, v)
+        });
+
+        // Gate/up GEMM over the full matrices (row-independent, bit-identical
+        // to a per-expert sub-matrix GEMM), then slice expert columns.
+        let h_width = gu_n;
+        let h_len = le
+            .checked_mul(h_width)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: format!("Le * 2Dff overflows usize for Le={le}"),
+            })?;
+        let mut h_all = vec![0.0f32; h_len];
+        {
+            let mut h_all_view = TensorViewMut::from_f32_slice(&[le, h_width], &mut h_all);
+            matmul_with_scales(
+                &gemm_op,
+                &gx_view,
+                gx_scale_view.as_ref(),
+                &gu_flat,
+                w_gate_up_scale,
+                None,
+                None,
+                &mut h_all_view,
+            )?;
+        }
+        let base = expert
+            .checked_mul(2)
+            .and_then(|v| v.checked_mul(dff))
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: format!("expert column base overflows usize for expert={expert}"),
+            })?;
+        let hd_len = le
+            .checked_mul(dff)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: format!("Le * Dff overflows usize for Le={le}"),
+            })?;
+        let mut gate = vec![0.0f32; hd_len];
+        let mut up = vec![0.0f32; hd_len];
+        for r in 0..le {
+            for d in 0..dff {
+                gate[r * dff + d] = h_all[r * h_width + base + d];
+                up[r * dff + d] = h_all[r * h_width + base + dff + d];
+            }
+        }
+        let gate_view = TensorView::from_f32_slice(&[le, dff], &gate);
+        let up_view = TensorView::from_f32_slice(&[le, dff], &up);
+        let mut h = vec![0.0f32; hd_len];
+        {
+            let mut h_view = TensorViewMut::from_f32_slice(&[le, dff], &mut h);
+            act_mul(&act_op, &gate_view, &up_view, &mut h_view)?;
+        }
+
+        // Down projection mirrors matmul Branch D over global expert rows.
+        let dm_len = le
+            .checked_mul(dm)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: format!("Le * Dm overflows usize for Le={le}"),
+            })?;
+        let mut down_out = vec![0.0f32; dm_len];
+        down_gemm(
+            &h,
+            le,
+            expert,
+            w_down,
+            w_down_scale,
+            down_scheme,
+            dm,
+            dff,
+            &mut down_out,
+        )?;
+
+        // Weighted combine in ascending (expert, token) order: every routing
+        // slot contributes, sharing one expert output row per token.
+        let mut slots: Vec<(usize, usize)> =
+            run.iter().map(|&(_, tok, slot)| (tok, slot)).collect();
+        slots.sort();
+        for (tok, slot) in slots {
+            let r = position(tok)?;
+            let w = weights.read_f32(tok * k_dim + slot);
+            for d in 0..dm {
+                y_tmp[tok * dm + d] += w * down_out[r * dm + d];
+            }
+        }
+
+        i = j;
+    }
+
+    for (idx, &v) in y_tmp.iter().enumerate() {
+        y.write_f32(idx, v);
+    }
+    Ok(())
+}
+
+/// Resolves the weight quant scheme for a MoE expert matrix (Spec 1 §4.C, §6.2).
+///
+/// Mirrors the matmul `w_scheme` gate: `F16+None` is unquantized, `I8+PerRow`
+/// is `I8R`, and `Scheme(_)` ids must name a supported native scheme.
+/// Anything else is a [`T0Error::QuantMismatch`]; reserved schemes fail closed
+/// through [`FormatError::ReservedScheme`].
+fn resolve_weight_scheme(
+    tensor: &'static str,
+    w: &TensorView<'_>,
+) -> Result<Option<SchemeId>, T0Error> {
+    match (w.dtype(), w.quant()) {
+        (DType::F16, QuantScheme::None) => Ok(None),
+        (DType::I8, QuantScheme::PerRow) => Ok(Some(SchemeId::I8R)),
+        (DType::I8, QuantScheme::Scheme(ir_s)) => {
+            let sid = SchemeId::from_ir(ir_s)?;
+            if sid != SchemeId::I8R && sid != SchemeId::I8B128 {
+                return Err(T0Error::QuantMismatch {
+                    tensor,
+                    expected: vec![
+                        QuantScheme::PerRow,
+                        QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                        QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                    ],
+                    got: w.quant(),
+                });
+            }
+            Ok(Some(sid))
+        }
+        (DType::I4, QuantScheme::Scheme(ir_s)) => {
+            let sid = SchemeId::from_ir(ir_s)?;
+            if sid != SchemeId::I4K {
+                return Err(T0Error::QuantMismatch {
+                    tensor,
+                    expected: vec![QuantScheme::Scheme(SchemeId::I4K.to_ir())],
+                    got: w.quant(),
+                });
+            }
+            Ok(Some(sid))
+        }
+        (DType::E4m3, QuantScheme::Scheme(ir_s)) => {
+            let sid = SchemeId::from_ir(ir_s)?;
+            if sid != SchemeId::E4M3B128 {
+                return Err(T0Error::QuantMismatch {
+                    tensor,
+                    expected: vec![QuantScheme::Scheme(SchemeId::E4M3B128.to_ir())],
+                    got: w.quant(),
+                });
+            }
+            Ok(Some(sid))
+        }
+        _ => Err(T0Error::QuantMismatch {
+            tensor,
+            expected: vec![
+                QuantScheme::None,
+                QuantScheme::PerRow,
+                QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+            ],
+            got: w.quant(),
+        }),
+    }
+}
+
+/// Validates the MoE activation scales (mirrors matmul `x_scale` rules).
+///
+/// `PerToken` requires `[T] f32`; `PerBlock32` requires `Dm % 32 == 0` and
+/// `[T, Dm/32] f32`; unquantized activations reject any scale. Scales must be
+/// finite and non-negative.
+fn validate_moe_x_scale(
+    x: &TensorView<'_>,
+    x_scale: Option<&TensorView<'_>>,
+    t: usize,
+    dm: usize,
+    problems: &mut Vec<T0Error>,
+) {
+    match x.quant() {
+        QuantScheme::PerToken => {
+            if let Some(xs) = x_scale {
+                if xs.rank() != 1 || xs.shape()[0] != t {
+                    problems.push(T0Error::DimensionMismatch {
+                        dim_name: "T",
+                        expected_from: "x",
+                        expected: t,
+                        tensor: "x_scale",
+                        got: xs.shape().first().copied().unwrap_or(0),
+                    });
+                }
+                if xs.dtype() != DType::F32 {
+                    problems.push(T0Error::DTypeMismatch {
+                        tensor: "x_scale",
+                        expected: vec![DType::F32],
+                        got: xs.dtype(),
+                    });
+                }
+                if xs.num_elements() < t || xs.backing_len() < t {
+                    problems.push(T0Error::BufferLengthMismatch {
+                        tensor: "x_scale",
+                        buffer_len: xs.backing_len(),
+                        expected_len: t,
+                        shape: xs.shape().to_vec(),
+                    });
+                }
+            } else {
+                problems.push(T0Error::MissingOperand {
+                    op: "moe_ffn",
+                    operand: "x_scale",
+                    detail: "x_scale required for PerToken activations".to_string(),
+                });
+            }
+        }
+        QuantScheme::PerBlock32 => {
+            if !dm.is_multiple_of(32) {
+                problems.push(T0Error::DimensionMismatch {
+                    dim_name: "Dm",
+                    expected_from: "block_size_32",
+                    expected: 32,
+                    tensor: "x",
+                    got: dm,
+                });
+            }
+            if let Some(xs) = x_scale {
+                let expected_blocks = dm / 32;
+                if xs.rank() != 2 || xs.shape()[0] != t || xs.shape()[1] != expected_blocks {
+                    problems.push(T0Error::DimensionMismatch {
+                        dim_name: "Dm_blocks",
+                        expected_from: "dm_div_32",
+                        expected: expected_blocks,
+                        tensor: "x_scale",
+                        got: if xs.rank() > 1 { xs.shape()[1] } else { 0 },
+                    });
+                }
+                if xs.dtype() != DType::F32 {
+                    problems.push(T0Error::DTypeMismatch {
+                        tensor: "x_scale",
+                        expected: vec![DType::F32],
+                        got: xs.dtype(),
+                    });
+                }
+            } else {
+                problems.push(T0Error::MissingOperand {
+                    op: "moe_ffn",
+                    operand: "x_scale",
+                    detail: "x_scale required for PerBlock32 activations".to_string(),
+                });
+            }
+        }
+        QuantScheme::None if x_scale.is_some() => {
+            problems.push(T0Error::InvalidAttribute {
+                op: "moe_ffn",
+                attribute: "x_scale",
+                reason: "x_scale provided for unquantized activations".to_string(),
+            });
+        }
+        _ => {}
+    }
+    if let Some(xs) = x_scale {
+        for idx in 0..xs.num_elements() {
+            let s = xs.read_f32(idx);
+            if !s.is_finite() || s < 0.0 {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "moe_ffn",
+                    attribute: "x_scale",
+                    reason: format!(
+                        "activation scale at index {idx} must be finite and non-negative, got {s}"
+                    ),
+                });
+            }
+        }
+    }
+}
+
+/// Owned bit-exact row gather of an activation matrix (Spec 1 §4.C).
+///
+/// Preserves the source backing variant so the gathered view carries the same
+/// dtype without any float round-trip.
+enum OwnedRows {
+    F16(Vec<u16>),
+    Bf16(Vec<u16>),
+    I8(Vec<i8>),
+    Bytes(DType, Vec<u8>),
+}
+
+impl OwnedRows {
+    /// Borrows the gathered rows as a view with the given shape and metadata.
+    fn view(&self, shape: &[usize], quant: QuantScheme, layout: LayoutId) -> TensorView<'_> {
+        match self {
+            OwnedRows::F16(v) => TensorView::from_f16_slice(shape, v)
+                .with_quant(quant)
+                .with_layout(layout),
+            OwnedRows::Bf16(v) => TensorView::from_bf16_slice(shape, v)
+                .with_quant(quant)
+                .with_layout(layout),
+            OwnedRows::I8(v) => TensorView::from_i8_slice(shape, v)
+                .with_quant(quant)
+                .with_layout(layout),
+            OwnedRows::Bytes(dtype, v) => TensorView::from_bytes(shape, *dtype, v)
+                .with_quant(quant)
+                .with_layout(layout),
+        }
+    }
+}
+
+/// Gathers `rows` (token indices) of `x` into an owned bit-exact buffer.
+fn gather_activation_rows(
+    x: &TensorView<'_>,
+    rows: &[(usize, usize)],
+    dm: usize,
+    tensor: &'static str,
+) -> Result<OwnedRows, T0Error> {
+    let check_len = |have: usize, need: usize| {
+        if have < need {
+            return Err(T0Error::BufferLengthMismatch {
+                tensor,
+                buffer_len: have,
+                expected_len: need,
+                shape: x.shape().to_vec(),
+            });
+        }
+        Ok(())
+    };
+    let row_elems = rows
+        .len()
+        .checked_mul(dm)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: "gather row count overflows usize".to_string(),
+        })?;
+    match &x.data {
+        TensorData::F16(s) => {
+            check_len(s.len(), row_elems)?;
+            let mut out = vec![0u16; row_elems];
+            for (r, &(tok, _)) in rows.iter().enumerate() {
+                out[r * dm..(r + 1) * dm].copy_from_slice(&s[tok * dm..(tok + 1) * dm]);
+            }
+            Ok(OwnedRows::F16(out))
+        }
+        TensorData::Bf16(s) => {
+            check_len(s.len(), row_elems)?;
+            let mut out = vec![0u16; row_elems];
+            for (r, &(tok, _)) in rows.iter().enumerate() {
+                out[r * dm..(r + 1) * dm].copy_from_slice(&s[tok * dm..(tok + 1) * dm]);
+            }
+            Ok(OwnedRows::Bf16(out))
+        }
+        TensorData::I8(s) => {
+            check_len(s.len(), row_elems)?;
+            let mut out = vec![0i8; row_elems];
+            for (r, &(tok, _)) in rows.iter().enumerate() {
+                out[r * dm..(r + 1) * dm].copy_from_slice(&s[tok * dm..(tok + 1) * dm]);
+            }
+            Ok(OwnedRows::I8(out))
+        }
+        TensorData::Bytes(dtype, s) => {
+            let stride = dm
+                .checked_mul(crate::dtype::dtype_element_size(*dtype))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: "moe_ffn",
+                    detail: format!("gather row stride overflows usize for Dm={dm}"),
+                })?;
+            let row_bytes =
+                rows.len()
+                    .checked_mul(stride)
+                    .ok_or_else(|| T0Error::ArithmeticOverflow {
+                        op: "moe_ffn",
+                        detail: "gather byte count overflows usize".to_string(),
+                    })?;
+            check_len(s.len(), row_bytes)?;
+            let mut out = vec![0u8; row_bytes];
+            for (r, &(tok, _)) in rows.iter().enumerate() {
+                out[r * stride..(r + 1) * stride]
+                    .copy_from_slice(&s[tok * stride..(tok + 1) * stride]);
+            }
+            Ok(OwnedRows::Bytes(*dtype, out))
+        }
+        _ => Err(T0Error::DTypeMismatch {
+            tensor,
+            expected: vec![DType::F16, DType::Bf16, DType::I8, DType::E4m3],
+            got: x.dtype(),
+        }),
+    }
+}
+
+/// Gathers activation scale rows for the expert's tokens (exact `f32` copy).
+///
+/// Returns `None` when no scale view is present (valid only for unquantized
+/// activations, checked by [`validate_moe_x_scale`]).
+fn gather_scale_rows(
+    x: &TensorView<'_>,
+    x_scale: Option<&TensorView<'_>>,
+    rows: &[(usize, usize)],
+    t: usize,
+    dm: usize,
+) -> Result<Option<Vec<f32>>, T0Error> {
+    let Some(xs) = x_scale else {
+        return Ok(None);
+    };
+    match x.quant() {
+        QuantScheme::PerToken => {
+            if xs.shape().first().copied().unwrap_or(0) < t {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "x_scale",
+                    buffer_len: xs.backing_len(),
+                    expected_len: t,
+                    shape: xs.shape().to_vec(),
+                });
+            }
+            let mut out = vec![0.0f32; rows.len()];
+            for (r, &(tok, _)) in rows.iter().enumerate() {
+                out[r] = xs.read_f32(tok);
+            }
+            Ok(Some(out))
+        }
+        QuantScheme::PerBlock32 => {
+            let blocks = dm / 32;
+            if xs.shape().first().copied().unwrap_or(0) < t {
+                let need = t.saturating_mul(blocks);
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "x_scale",
+                    buffer_len: xs.backing_len(),
+                    expected_len: need,
+                    shape: xs.shape().to_vec(),
+                });
+            }
+            let out_len =
+                rows.len()
+                    .checked_mul(blocks)
+                    .ok_or_else(|| T0Error::ArithmeticOverflow {
+                        op: "moe_ffn",
+                        detail: "gathered block-scale count overflows usize".to_string(),
+                    })?;
+            let mut out = vec![0.0f32; out_len];
+            for (r, &(tok, _)) in rows.iter().enumerate() {
+                for b in 0..blocks {
+                    out[r * blocks + b] = xs.read_f32(tok * blocks + b);
+                }
+            }
+            Ok(Some(out))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Validates the down-projection weight buffer geometry and scale carrier.
+///
+/// Mirrors the matmul separate/inline scale contract over the full
+/// `[E·Dm, Dff]` row space (`n = E·Dm`, `k = Dff`): L0 inline strides,
+/// separate-carrier shapes, and L1 region sizes. Tensor names are
+/// `w_down`/`w_down_scale` under op `moe_ffn`.
+fn validate_down_scales(
+    w_down: &TensorView<'_>,
+    w_down_scale: Option<&TensorView<'_>>,
+    scheme: Option<SchemeId>,
+    e: usize,
+    dff: usize,
+    problems: &mut Vec<T0Error>,
+) -> Result<(), T0Error> {
+    // Full row count comes from the validated [E, Dm, Dff] shape.
+    let dm = w_down.shape()[1];
+    let n_rows = e
+        .checked_mul(dm)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: format!("E * Dm overflows usize for E={e}, Dm={dm}"),
+        })?;
+    let k = dff;
+    let n_u32 = u32::try_from(n_rows).map_err(|_| T0Error::ArithmeticOverflow {
+        op: "moe_ffn",
+        detail: format!("down-projection row count exceeds u32: {n_rows}"),
+    })?;
+    let k_u32 = u32::try_from(k).map_err(|_| T0Error::ArithmeticOverflow {
+        op: "moe_ffn",
+        detail: format!("dimension Dff exceeds u32: {k}"),
+    })?;
+
+    match scheme {
+        Some(SchemeId::I4K) if !k.is_multiple_of(256) => {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "Dff",
+                expected_from: "superblock_256",
+                expected: 256,
+                tensor: "w_down",
+                got: k,
+            });
+        }
+        Some(SchemeId::I8B128) | Some(SchemeId::E4M3B128) if !k.is_multiple_of(128) => {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "Dff",
+                expected_from: "block_size_128",
+                expected: 128,
+                tensor: "w_down",
+                got: k,
+            });
+        }
+        _ => {}
+    }
+
+    let is_l1 = w_down.layout() == LayoutId::L1;
+    let w_bytes_len = match &w_down.data {
+        TensorData::Bytes(_, slice) => slice.len(),
+        _ => {
+            problems.push(T0Error::BackingRepresentationMismatch {
+                op: "moe_ffn",
+                dtype: w_down.dtype(),
+            });
+            0
+        }
+    };
+
+    let superblock_k = match scheme {
+        Some(SchemeId::I4K) => 256,
+        Some(SchemeId::I8B128) | Some(SchemeId::E4M3B128) => 128,
+        _ => 16,
+    };
+    let w_dims = PaddedDims::new(n_u32, k_u32, Some(superblock_k))?;
+    let elem_bytes = match w_down.dtype() {
+        DType::F16 => 2,
+        DType::I8 | DType::E4m3 => 1,
+        DType::I4 => 1,
+        _ => 1,
+    };
+    let values_bytes = if w_down.dtype() == DType::I4 {
+        n_rows
+            .checked_mul(k)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: "down-projection I4 values size overflows usize".to_string(),
+            })?
+            / 2
+    } else {
+        n_rows
+            .checked_mul(k)
+            .and_then(|v| v.checked_mul(elem_bytes))
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: "down-projection values size overflows usize".to_string(),
+            })?
+    };
+
+    if let Some(ws) = w_down_scale {
+        if ws.layout() != LayoutId::CONTIGUOUS {
+            return Err(T0Error::LayoutMismatch {
+                tensor: "w_down_scale",
+                expected: vec![LayoutId::CONTIGUOUS],
+                got: ws.layout(),
+            });
+        }
+        let ws_bytes_len = match &ws.data {
+            TensorData::Bytes(_, slice) => slice.len(),
+            _ => {
+                return Err(T0Error::BackingRepresentationMismatch {
+                    op: "moe_ffn",
+                    dtype: ws.dtype(),
+                });
+            }
+        };
+        if w_bytes_len < values_bytes {
+            return Err(T0Error::BufferLengthMismatch {
+                tensor: "w_down",
+                buffer_len: w_bytes_len,
+                expected_len: values_bytes,
+                shape: w_down.shape().to_vec(),
+            });
+        }
+        if let Some(sid) = scheme {
+            if is_l1 {
+                let geom = scale_geometry(sid, Layout::L1, &w_dims)?;
+                let req_bytes = u64_to_usize(geom.region_bytes, "region_bytes")?;
+                match sid {
+                    SchemeId::I8R | SchemeId::I8B128 | SchemeId::E4M3B128 => {
+                        if ws.dtype() != DType::F16 {
+                            return Err(T0Error::DTypeMismatch {
+                                tensor: "w_down_scale",
+                                expected: vec![DType::F16],
+                                got: ws.dtype(),
+                            });
+                        }
+                        let n_blocks = u64_to_usize(geom.n_blocks, "n_blocks")?;
+                        let k_blocks = u64_to_usize(geom.k_blocks, "k_blocks")?;
+                        if ws.shape() != [n_blocks, k_blocks, 16] {
+                            return Err(T0Error::DimensionMismatch {
+                                dim_name: "scale_shape",
+                                expected_from: "scale_geometry",
+                                expected: geom.records as usize,
+                                tensor: "w_down_scale",
+                                got: ws.num_elements(),
+                            });
+                        }
+                    }
+                    SchemeId::I4K => {
+                        if ws.dtype() != DType::U32 {
+                            return Err(T0Error::DTypeMismatch {
+                                tensor: "w_down_scale",
+                                expected: vec![DType::U32],
+                                got: ws.dtype(),
+                            });
+                        }
+                        let n_blocks = u64_to_usize(geom.n_blocks, "n_blocks")?;
+                        let k_blocks = u64_to_usize(geom.k_blocks, "k_blocks")?;
+                        if ws.shape() != [n_blocks, k_blocks, 16, 4] {
+                            return Err(T0Error::DimensionMismatch {
+                                dim_name: "scale_shape",
+                                expected_from: "scale_geometry",
+                                expected: (geom.records * 4) as usize,
+                                tensor: "w_down_scale",
+                                got: ws.num_elements(),
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+                if ws_bytes_len != req_bytes {
+                    return Err(T0Error::BufferLengthMismatch {
+                        tensor: "w_down_scale",
+                        buffer_len: ws_bytes_len,
+                        expected_len: req_bytes,
+                        shape: ws.shape().to_vec(),
+                    });
+                }
+            } else {
+                match sid {
+                    SchemeId::I8R => {
+                        if ws.dtype() != DType::F16 {
+                            return Err(T0Error::DTypeMismatch {
+                                tensor: "w_down_scale",
+                                expected: vec![DType::F16],
+                                got: ws.dtype(),
+                            });
+                        }
+                        if ws.shape() != [n_rows] {
+                            return Err(T0Error::DimensionMismatch {
+                                dim_name: "N",
+                                expected_from: "w_down",
+                                expected: n_rows,
+                                tensor: "w_down_scale",
+                                got: ws.shape().first().copied().unwrap_or(0),
+                            });
+                        }
+                        let req_bytes =
+                            u64_to_usize(l0_region_bytes(n_u32, 2)?, "w_down_scale req_bytes")?;
+                        if ws_bytes_len != req_bytes {
+                            return Err(T0Error::BufferLengthMismatch {
+                                tensor: "w_down_scale",
+                                buffer_len: ws_bytes_len,
+                                expected_len: req_bytes,
+                                shape: ws.shape().to_vec(),
+                            });
+                        }
+                    }
+                    SchemeId::I8B128 | SchemeId::E4M3B128 => {
+                        if ws.dtype() != DType::F16 {
+                            return Err(T0Error::DTypeMismatch {
+                                tensor: "w_down_scale",
+                                expected: vec![DType::F16],
+                                got: ws.dtype(),
+                            });
+                        }
+                        let k_blocks = k / 128;
+                        if ws.shape() != [n_rows, k_blocks] {
+                            return Err(T0Error::DimensionMismatch {
+                                dim_name: "K_blocks",
+                                expected_from: "w_down",
+                                expected: k_blocks,
+                                tensor: "w_down_scale",
+                                got: if ws.rank() > 1 {
+                                    ws.shape()[1]
+                                } else {
+                                    ws.shape().first().copied().unwrap_or(0)
+                                },
+                            });
+                        }
+                        let stride_u64 = (k_u32 / 128 * 2) as u64;
+                        let req_bytes = u64_to_usize(
+                            l0_region_bytes(n_u32, stride_u64)?,
+                            "w_down_scale req_bytes",
+                        )?;
+                        if ws_bytes_len != req_bytes {
+                            return Err(T0Error::BufferLengthMismatch {
+                                tensor: "w_down_scale",
+                                buffer_len: ws_bytes_len,
+                                expected_len: req_bytes,
+                                shape: ws.shape().to_vec(),
+                            });
+                        }
+                    }
+                    SchemeId::I4K => {
+                        if ws.dtype() != DType::U32 {
+                            return Err(T0Error::DTypeMismatch {
+                                tensor: "w_down_scale",
+                                expected: vec![DType::U32],
+                                got: ws.dtype(),
+                            });
+                        }
+                        let k_superblocks = k / 256;
+                        if ws.shape() != [n_rows, k_superblocks, 4] {
+                            return Err(T0Error::DimensionMismatch {
+                                dim_name: "K_superblocks",
+                                expected_from: "w_down",
+                                expected: k_superblocks,
+                                tensor: "w_down_scale",
+                                got: if ws.rank() > 1 {
+                                    ws.shape()[1]
+                                } else {
+                                    ws.shape().first().copied().unwrap_or(0)
+                                },
+                            });
+                        }
+                        let stride_u64 = (k_u32 / 256 * 16) as u64;
+                        let req_bytes = u64_to_usize(
+                            l0_region_bytes(n_u32, stride_u64)?,
+                            "w_down_scale req_bytes",
+                        )?;
+                        if ws_bytes_len != req_bytes {
+                            return Err(T0Error::BufferLengthMismatch {
+                                tensor: "w_down_scale",
+                                buffer_len: ws_bytes_len,
+                                expected_len: req_bytes,
+                                shape: ws.shape().to_vec(),
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        } else {
+            return Err(T0Error::InvalidAttribute {
+                op: "moe_ffn",
+                attribute: "w_down_scale",
+                reason: "w_down_scale provided for unquantized weights".to_string(),
+            });
+        }
+    } else if let Some(sid) = scheme {
+        // Inline scales: length-gate the values region like matmul.
+        let req_bytes = if is_l1 {
+            let geom = scale_geometry(sid, Layout::L1, &w_dims)?;
+            let l1_vals = if w_down.dtype() == DType::I4 {
+                (w_dims.n_padded() as usize)
+                    .checked_mul(w_dims.k_padded() as usize)
+                    .ok_or_else(|| T0Error::ArithmeticOverflow {
+                        op: "moe_ffn",
+                        detail: "L1 down values size overflows usize".to_string(),
+                    })?
+                    / 2
+            } else {
+                (w_dims.n_padded() as usize)
+                    .checked_mul(w_dims.k_padded() as usize)
+                    .and_then(|v| v.checked_mul(elem_bytes))
+                    .ok_or_else(|| T0Error::ArithmeticOverflow {
+                        op: "moe_ffn",
+                        detail: "L1 down values size overflows usize".to_string(),
+                    })?
+            };
+            l1_vals
+                .checked_add(u64_to_usize(geom.region_bytes, "region_bytes")?)
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: "moe_ffn",
+                    detail: "L1 down values + scales overflow".to_string(),
+                })?
+        } else {
+            let stride = match sid {
+                SchemeId::I8R => l0_row_stride_bytes(k_u32, 1, 1, 2)?,
+                SchemeId::I8B128 | SchemeId::E4M3B128 => {
+                    l0_row_stride_bytes(k_u32, 1, k_u32 / 128, 2)?
+                }
+                SchemeId::I4K => l0_row_stride_bytes(k_u32 / 2, 1, k_u32 / 256, 16)?,
+                _ => k_u32 as u64,
+            };
+            u64_to_usize(l0_region_bytes(n_u32, stride)?, "l0_region_bytes")?
+        };
+        if w_bytes_len < req_bytes {
+            problems.push(T0Error::BufferLengthMismatch {
+                tensor: "w_down",
+                buffer_len: w_bytes_len,
+                expected_len: req_bytes,
+                shape: w_down.shape().to_vec(),
+            });
+        }
+    } else if w_bytes_len < values_bytes {
+        problems.push(T0Error::BufferLengthMismatch {
+            tensor: "w_down",
+            buffer_len: w_bytes_len,
+            expected_len: values_bytes,
+            shape: w_down.shape().to_vec(),
+        });
+    }
+    Ok(())
+}
+
+/// Down-projection GEMM over `f32` hidden rows (Spec 1 §4.C, §6.2).
+///
+/// Computes `out[r, d] = Σ_i h[r, i] · dequant(w_down[expert, d, i])` in `f32`
+/// with ascending-`i` accumulation. Weight decoding mirrors matmul Branch D
+/// (the `F16/BF16` general path with dequantization) element-for-element over
+/// global expert rows `grow = expert·Dm + d`; bit-exact agreement with
+/// `matmul_with_scales` on identical inputs is proven by test.
+#[allow(clippy::too_many_arguments)]
+fn down_gemm(
+    h: &[f32],
+    le: usize,
+    expert: usize,
+    w_down: &TensorView<'_>,
+    w_down_scale: Option<&TensorView<'_>>,
+    scheme: Option<SchemeId>,
+    dm: usize,
+    dff: usize,
+    out: &mut [f32],
+) -> Result<(), T0Error> {
+    let w_bytes: &[u8] = match &w_down.data {
+        TensorData::Bytes(_, slice) => slice,
+        _ => {
+            return Err(T0Error::BackingRepresentationMismatch {
+                op: "moe_ffn",
+                dtype: w_down.dtype(),
+            });
+        }
+    };
+    let is_l1 = w_down.layout() == LayoutId::L1;
+    let n_rows = w_down.shape()[0]
+        .checked_mul(w_down.shape()[1])
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: "down-projection row count overflows usize".to_string(),
+        })?;
+    let n_u32 = u32::try_from(n_rows).map_err(|_| T0Error::ArithmeticOverflow {
+        op: "moe_ffn",
+        detail: format!("down-projection row count exceeds u32: {n_rows}"),
+    })?;
+    let k_u32 = u32::try_from(dff).map_err(|_| T0Error::ArithmeticOverflow {
+        op: "moe_ffn",
+        detail: format!("dimension Dff exceeds u32: {dff}"),
+    })?;
+    let superblock_k = match scheme {
+        Some(SchemeId::I4K) => 256,
+        Some(SchemeId::I8B128) | Some(SchemeId::E4M3B128) => 128,
+        _ => 16,
+    };
+    let w_dims = PaddedDims::new(n_u32, k_u32, Some(superblock_k))?;
+    // Separate-scale slice setup mirrors matmul: explicit carrier, else the L1
+    // tail region, else empty (L0 inline scales live in the values bytes).
+    let w_scales_slice: &[u8] = if let Some(ws) = w_down_scale {
+        match &ws.data {
+            TensorData::Bytes(_, slice) => slice,
+            _ => {
+                return Err(T0Error::BackingRepresentationMismatch {
+                    op: "moe_ffn",
+                    dtype: ws.dtype(),
+                });
+            }
+        }
+    } else if is_l1 {
+        let l1_vals = l1_values_len(w_down.dtype(), &w_dims)?;
+        if w_bytes.len() > l1_vals {
+            &w_bytes[l1_vals..]
+        } else {
+            &[]
+        }
+    } else {
+        &[]
+    };
+
+    // Weight rows depend only on (expert, output channel): global row
+    // `expert·Dm + d`. The token position `r` selects the hidden row only.
+    let expert_base = expert
+        .checked_mul(dm)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "moe_ffn",
+            detail: format!("expert down base overflows usize for expert={expert}"),
+        })?;
+    for r in 0..le {
+        for d in 0..dm {
+            let grow_d = expert_base
+                .checked_add(d)
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: "moe_ffn",
+                    detail: "global down row overflows usize".to_string(),
+                })?;
+            let mut acc = 0.0f32;
+            for k_idx in 0..dff {
+                let w_val = down_weight_f32(
+                    w_bytes,
+                    w_scales_slice,
+                    w_down_scale.is_some(),
+                    is_l1,
+                    &w_dims,
+                    scheme,
+                    grow_d,
+                    k_idx,
+                    dff,
+                )?;
+                acc += h[r * dff + k_idx] * w_val;
+            }
+            out[r * dm + d] = acc;
+        }
+    }
+    Ok(())
+}
+
+/// Padded L1 values length in bytes for the down-projection matrix.
+fn l1_values_len(dtype: DType, dims: &PaddedDims) -> Result<usize, T0Error> {
+    let elem_bytes = match dtype {
+        DType::F16 => 2,
+        DType::I8 | DType::E4m3 => 1,
+        DType::I4 => 1,
+        _ => 1,
+    };
+    if dtype == DType::I4 {
+        (dims.n_padded() as usize)
+            .checked_mul(dims.k_padded() as usize)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: "L1 down values size overflows usize".to_string(),
+            })
+            .map(|v| v / 2)
+    } else {
+        (dims.n_padded() as usize)
+            .checked_mul(dims.k_padded() as usize)
+            .and_then(|v| v.checked_mul(elem_bytes))
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "moe_ffn",
+                detail: "L1 down values size overflows usize".to_string(),
+            })
+    }
+}
+
+/// Decodes one down-projection weight element to `f32`.
+///
+/// Element-for-element mirror of the matmul Branch D weight arms over global
+/// row `grow` (the expert's row offset is folded into `grow`), with tensor
+/// names `w_down`/`w_down_scale` under op `moe_ffn`.
+#[allow(clippy::too_many_arguments)]
+fn down_weight_f32(
+    w_bytes: &[u8],
+    w_scales_slice: &[u8],
+    has_separate_scales: bool,
+    is_l1: bool,
+    w_dims: &PaddedDims,
+    scheme: Option<SchemeId>,
+    grow: usize,
+    k_idx: usize,
+    k: usize,
+) -> Result<f32, T0Error> {
+    const OP: &str = "moe_ffn";
+    let grow_u32 = u32::try_from(grow).map_err(|_| T0Error::ArithmeticOverflow {
+        op: OP,
+        detail: format!("global down row exceeds u32: {grow}"),
+    })?;
+    let k_idx_u32 = u32::try_from(k_idx).map_err(|_| T0Error::ArithmeticOverflow {
+        op: OP,
+        detail: format!("k index exceeds u32: {k_idx}"),
+    })?;
+    let byte_at = |offset: usize, tensor: &'static str| {
+        w_bytes
+            .get(offset)
+            .copied()
+            .ok_or_else(|| T0Error::BufferLengthMismatch {
+                tensor,
+                buffer_len: w_bytes.len(),
+                expected_len: offset + 1,
+                shape: vec![grow, k],
+            })
+    };
+    let bytes_at = |offset: usize, len: usize, tensor: &'static str| {
+        w_bytes
+            .get(offset..offset + len)
+            .ok_or_else(|| T0Error::BufferLengthMismatch {
+                tensor,
+                buffer_len: w_bytes.len(),
+                expected_len: offset + len,
+                shape: vec![grow, k],
+            })
+    };
+    let scale_bytes_at = |offset: usize, len: usize| {
+        w_scales_slice
+            .get(offset..offset + len)
+            .ok_or_else(|| T0Error::BufferLengthMismatch {
+                tensor: if has_separate_scales {
+                    "w_down_scale"
+                } else {
+                    "w_down"
+                },
+                buffer_len: w_scales_slice.len(),
+                expected_len: offset + len,
+                shape: vec![grow, k],
+            })
+    };
+    // Checked `row * stride + col` for L0 addressing (debug builds panic on
+    // overflow, so every offset expression goes through here).
+    let row_offset = |row: usize, stride: usize, col: usize| {
+        row.checked_mul(stride)
+            .and_then(|v| v.checked_add(col))
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: OP,
+                detail: format!("down-projection offset overflows usize for row={row}"),
+            })
+    };
+    match scheme {
+        None => {
+            if !is_l1 {
+                let offset = grow
+                    .checked_mul(k)
+                    .and_then(|v| v.checked_add(k_idx))
+                    .and_then(|v| v.checked_mul(2))
+                    .ok_or_else(|| T0Error::ArithmeticOverflow {
+                        op: OP,
+                        detail: "F16 down offset overflows usize".to_string(),
+                    })?;
+                let raw = bytes_at(offset, 2, "w_down")?;
+                let bits = u16::from_le_bytes([raw[0], raw[1]]);
+                Ok(f16_to_f32(bits))
+            } else {
+                let elem_idx = l1_forward_index(grow_u32, k_idx_u32, w_dims)?;
+                let offset = u64_to_usize(
+                    elem_idx
+                        .checked_mul(2)
+                        .ok_or_else(|| T0Error::ArithmeticOverflow {
+                            op: OP,
+                            detail: "L1 F16 down offset overflows".to_string(),
+                        })?,
+                    "l1_f16_offset",
+                )?;
+                let raw = bytes_at(offset, 2, "w_down")?;
+                let bits = u16::from_le_bytes([raw[0], raw[1]]);
+                Ok(f16_to_f32(bits))
+            }
+        }
+        Some(SchemeId::I8R) => {
+            let w_row_stride = if !is_l1 {
+                if has_separate_scales {
+                    k
+                } else {
+                    k + 2
+                }
+            } else {
+                0
+            };
+            let w_s = if !is_l1 {
+                if has_separate_scales {
+                    let raw = scale_bytes_at(row_offset(grow, 2, 0)?, 2)?;
+                    I8RowScale::from_bytes([raw[0], raw[1]]).value(grow as u64)?
+                } else {
+                    let off = row_offset(grow, w_row_stride, k)?;
+                    let raw = bytes_at(off, 2, "w_down")?;
+                    I8RowScale::from_bytes([raw[0], raw[1]]).value(grow as u64)?
+                }
+            } else {
+                let geom = scale_geometry(SchemeId::I8R, Layout::L1, w_dims)?;
+                let scale_offset = u64_to_usize(
+                    geom.record_offset((grow_u32 / 16) as u64, 0, grow_u32 % 16)?,
+                    "record_offset",
+                )?;
+                let raw = scale_bytes_at(scale_offset, 2)?;
+                I8RowScale::from_bytes([raw[0], raw[1]]).value(grow as u64)?
+            };
+            let q = if !is_l1 {
+                byte_at(row_offset(grow, w_row_stride, k_idx)?, "w_down")? as i8
+            } else {
+                let offset = u64_to_usize(
+                    l1_forward_index(grow_u32, k_idx_u32, w_dims)?,
+                    "l1_forward_index",
+                )?;
+                byte_at(offset, "w_down")? as i8
+            };
+            Ok((q as f32) * w_s)
+        }
+        Some(SchemeId::I8B128) => {
+            let b = k_idx / 128;
+            let k_blocks = k / 128;
+            let w_row_stride = if !is_l1 {
+                if has_separate_scales {
+                    k
+                } else {
+                    k + k_blocks * 2
+                }
+            } else {
+                0
+            };
+            let w_s = if !is_l1 {
+                if has_separate_scales {
+                    let base = row_offset(grow, k_blocks, b)?;
+                    let raw = scale_bytes_at(row_offset(base, 2, 0)?, 2)?;
+                    I8Block128Scale::from_bytes([raw[0], raw[1]]).value(b as u64)?
+                } else {
+                    let off = row_offset(grow, w_row_stride, k + b * 2)?;
+                    let raw = bytes_at(off, 2, "w_down")?;
+                    I8Block128Scale::from_bytes([raw[0], raw[1]]).value(b as u64)?
+                }
+            } else {
+                let geom = scale_geometry(SchemeId::I8B128, Layout::L1, w_dims)?;
+                let scale_offset = u64_to_usize(
+                    geom.record_offset((grow_u32 / 16) as u64, b as u64, grow_u32 % 16)?,
+                    "record_offset",
+                )?;
+                let raw = scale_bytes_at(scale_offset, 2)?;
+                I8Block128Scale::from_bytes([raw[0], raw[1]]).value(b as u64)?
+            };
+            let q = if !is_l1 {
+                byte_at(row_offset(grow, w_row_stride, k_idx)?, "w_down")? as i8
+            } else {
+                let offset = u64_to_usize(
+                    l1_forward_index(grow_u32, k_idx_u32, w_dims)?,
+                    "l1_forward_index",
+                )?;
+                byte_at(offset, "w_down")? as i8
+            };
+            Ok((q as f32) * w_s)
+        }
+        Some(SchemeId::I4K) => {
+            let sb = k_idx / 256;
+            let sub = (k_idx % 256) / 32;
+            let k_superblocks = k / 256;
+            let values_bytes_per_row = k / 2;
+            let w_row_stride = if !is_l1 {
+                if has_separate_scales {
+                    values_bytes_per_row
+                } else {
+                    values_bytes_per_row + k_superblocks * 16
+                }
+            } else {
+                0
+            };
+            let header = if !is_l1 {
+                if has_separate_scales {
+                    let base = row_offset(grow, k_superblocks, sb)?;
+                    let raw = scale_bytes_at(row_offset(base, 16, 0)?, 16)?;
+                    let mut arr = [0u8; 16];
+                    arr.copy_from_slice(raw);
+                    I4KSuperblock::from_bytes(&arr)
+                } else {
+                    let off = row_offset(grow, w_row_stride, values_bytes_per_row + sb * 16)?;
+                    let raw = bytes_at(off, 16, "w_down")?;
+                    let mut arr = [0u8; 16];
+                    arr.copy_from_slice(raw);
+                    I4KSuperblock::from_bytes(&arr)
+                }
+            } else {
+                let geom = scale_geometry(SchemeId::I4K, Layout::L1, w_dims)?;
+                let scale_offset = u64_to_usize(
+                    geom.record_offset((grow_u32 / 16) as u64, sb as u64, grow_u32 % 16)?,
+                    "record_offset",
+                )?;
+                let raw = scale_bytes_at(scale_offset, 16)?;
+                let mut arr = [0u8; 16];
+                arr.copy_from_slice(raw);
+                I4KSuperblock::from_bytes(&arr)
+            };
+            let d = header.d_value(sb as u64)?;
+            let dmin = header.dmin_value(sb as u64)?;
+            let sc = header.scales();
+            let mn = header.mins();
+            let s_block = d * (sc[sub] as f32);
+            let m_block = dmin * (mn[sub] as f32);
+            let q = if !is_l1 {
+                let byte = byte_at(row_offset(grow, w_row_stride, k_idx / 2)?, "w_down")?;
+                if k_idx.is_multiple_of(2) {
+                    (byte & 0x0F) as i32
+                } else {
+                    ((byte >> 4) & 0x0F) as i32
+                }
+            } else {
+                let elem_idx = l1_forward_index(grow_u32, k_idx_u32, w_dims)?;
+                let offset = u64_to_usize(elem_idx / 2, "l1_i4_offset")?;
+                let byte = byte_at(offset, "w_down")?;
+                if elem_idx % 2 == 0 {
+                    (byte & 0x0F) as i32
+                } else {
+                    ((byte >> 4) & 0x0F) as i32
+                }
+            };
+            Ok(s_block * (q as f32) - m_block)
+        }
+        Some(SchemeId::E4M3B128) => {
+            let b = k_idx / 128;
+            let k_blocks = k / 128;
+            let w_row_stride = if !is_l1 {
+                if has_separate_scales {
+                    k
+                } else {
+                    k + k_blocks * 2
+                }
+            } else {
+                0
+            };
+            let w_s = if !is_l1 {
+                if has_separate_scales {
+                    let base = row_offset(grow, k_blocks, b)?;
+                    let raw = scale_bytes_at(row_offset(base, 2, 0)?, 2)?;
+                    E4M3Block128Scale::from_bytes([raw[0], raw[1]]).value(b as u64)?
+                } else {
+                    let off = row_offset(grow, w_row_stride, k + b * 2)?;
+                    let raw = bytes_at(off, 2, "w_down")?;
+                    E4M3Block128Scale::from_bytes([raw[0], raw[1]]).value(b as u64)?
+                }
+            } else {
+                let geom = scale_geometry(SchemeId::E4M3B128, Layout::L1, w_dims)?;
+                let scale_offset = u64_to_usize(
+                    geom.record_offset((grow_u32 / 16) as u64, b as u64, grow_u32 % 16)?,
+                    "record_offset",
+                )?;
+                let raw = scale_bytes_at(scale_offset, 2)?;
+                E4M3Block128Scale::from_bytes([raw[0], raw[1]]).value(b as u64)?
+            };
+            let byte = if !is_l1 {
+                byte_at(row_offset(grow, w_row_stride, k_idx)?, "w_down")?
+            } else {
+                let offset = u64_to_usize(
+                    l1_forward_index(grow_u32, k_idx_u32, w_dims)?,
+                    "l1_forward_index",
+                )?;
+                byte_at(offset, "w_down")?
+            };
+            let e = E4m3::new(byte);
+            e.check(k_idx as u64)?;
+            Ok(e.to_f32() * w_s)
+        }
+        Some(scheme) => Err(T0Error::InvalidAttribute {
+            op: OP,
+            attribute: "w_quant",
+            reason: format!("unsupported quant scheme in moe_ffn down path: {scheme:?}"),
+        }),
+    }
+}
+
+/// 64-bit reference MoE feed-forward for testing (Spec 1 §4.C, §6.1, §6.2).
+///
+/// Independent `f64` path: plain nested loops over `&[f64]` slices, never
+/// calling [`moe_ffn`]. Expert weights arrive already dequantized to `f64`
+/// (the test decodes them); the oracle then mirrors the T0 algorithm —
+/// grouped per-expert GEMM, `act`, down projection, sorted weighted combine —
+/// in `f64`. Slice lengths, expert bounds, and every extent product are
+/// validated with typed errors; there is no silent empty fallback.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_ffn_f64_reference(
+    x: &[f64],
+    t: usize,
+    dm: usize,
+    expert_ids: &[u32],
+    weights: &[f64],
+    k_dim: usize,
+    w_gate_up: &[f64],
+    e: usize,
+    dff: usize,
+    w_down: &[f64],
+    act: ActivationKind,
+) -> Result<Vec<f64>, T0Error> {
+    const OP: &str = "moe_ffn";
+    let tdm = t
+        .checked_mul(dm)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * Dm overflows usize for T={t}, Dm={dm}"),
+        })?;
+    let tk = t
+        .checked_mul(k_dim)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * K overflows usize for T={t}, K={k_dim}"),
+        })?;
+    let gu_len = e
+        .checked_mul(2)
+        .and_then(|v| v.checked_mul(dff))
+        .and_then(|v| v.checked_mul(dm))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "E * 2Dff * Dm overflows usize".to_string(),
+        })?;
+    let wd_len = e
+        .checked_mul(dm)
+        .and_then(|v| v.checked_mul(dff))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "E * Dm * Dff overflows usize".to_string(),
+        })?;
+    let mut problems = Vec::new();
+    if x.len() != tdm {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "x",
+            expected: tdm,
+            got: x.len(),
+            detail: "x length must equal T * Dm".to_string(),
+        });
+    }
+    if expert_ids.len() != tk {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "expert_ids",
+            expected: tk,
+            got: expert_ids.len(),
+            detail: "expert_ids length must equal T * K".to_string(),
+        });
+    }
+    if weights.len() != tk {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "weights",
+            expected: tk,
+            got: weights.len(),
+            detail: "weights length must equal T * K".to_string(),
+        });
+    }
+    if w_gate_up.len() != gu_len {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "w_gate_up",
+            expected: gu_len,
+            got: w_gate_up.len(),
+            detail: "w_gate_up length must equal E * 2Dff * Dm".to_string(),
+        });
+    }
+    if w_down.len() != wd_len {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "w_down",
+            expected: wd_len,
+            got: w_down.len(),
+            detail: "w_down length must equal E * Dm * Dff".to_string(),
+        });
+    }
+    for (pos, &id) in expert_ids.iter().enumerate() {
+        if (id as usize) >= e {
+            problems.push(T0Error::RowIndexOutOfRange {
+                op: OP,
+                tensor: "expert_ids",
+                position: pos,
+                index: id,
+                upper_bound: e,
+            });
+        }
+    }
+    T0Error::from_problems(problems)?;
+
+    let mut triples: Vec<(u32, usize, usize)> = Vec::new();
+    for row in 0..t {
+        for slot in 0..k_dim {
+            triples.push((expert_ids[row * k_dim + slot], row, slot));
+        }
+    }
+    triples.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut y = vec![0.0f64; tdm];
+    let mut i = 0;
+    while i < triples.len() {
+        let expert = triples[i].0 as usize;
+        if expert >= e {
+            return Err(T0Error::RowIndexOutOfRange {
+                op: OP,
+                tensor: "expert_ids",
+                position: i,
+                index: triples[i].0,
+                upper_bound: e,
+            });
+        }
+        let mut j = i + 1;
+        while j < triples.len() && triples[j].0 == triples[i].0 {
+            j += 1;
+        }
+        let mut rows: Vec<(usize, usize)> = triples[i..j]
+            .iter()
+            .map(|&(_, tok, slot)| (tok, slot))
+            .collect();
+        rows.sort_by_key(|&(tok, _)| tok);
+        let gu_base = expert * 2 * dff * dm;
+        let d_base = expert * dm * dff;
+        for &(tok, slot) in &rows {
+            let mut hidden = vec![0.0f64; dff];
+            for d in 0..dff {
+                let mut g = 0.0f64;
+                let mut u = 0.0f64;
+                for m in 0..dm {
+                    g += x[tok * dm + m] * w_gate_up[gu_base + d * dm + m];
+                    u += x[tok * dm + m] * w_gate_up[gu_base + (dff + d) * dm + m];
+                }
+                hidden[d] = crate::activation::eval_activation_f64(g, act) * u;
+            }
+            let w = weights[tok * k_dim + slot];
+            for d in 0..dm {
+                let mut acc = 0.0f64;
+                for f in 0..dff {
+                    acc += hidden[f] * w_down[d_base + d * dff + f];
+                }
+                y[tok * dm + d] += w * acc;
+            }
+        }
+        i = j;
+    }
+    Ok(y)
+}

--- a/crates/r9v-t0/src/moe_route.rs
+++ b/crates/r9v-t0/src/moe_route.rs
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Scalar T0 implementation of `moe_route` op (Spec 1 §4.C, §6.1, Card A1.9).
+//!
+//! Routes each token to its top-K experts with deterministic tie-breaking
+//! (lowest expert index wins) and order-stable output rows.
+
+use r9v_ir::{DType, LayoutId, MoeRouteOp, MoeScoring};
+
+use crate::buffer::{TensorDataMut, TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// Writes one expert id bit-exactly to a `u32` output view (Spec 1 §4.C).
+///
+/// Accepts both typed `U32` and raw-byte `U32` backings; anything else is a
+/// backing mismatch (the `u32` dtype check upstream already passed).
+pub(crate) fn write_id(
+    view: &mut TensorViewMut<'_>,
+    index: usize,
+    val: u32,
+) -> Result<(), T0Error> {
+    match view.data {
+        TensorDataMut::U32(ref mut slice) => {
+            if index >= slice.len() {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "expert_ids",
+                    buffer_len: slice.len(),
+                    expected_len: index + 1,
+                    shape: view.shape().to_vec(),
+                });
+            }
+            slice[index] = val;
+            Ok(())
+        }
+        TensorDataMut::Bytes(dtype, ref mut slice) => {
+            let end = index
+                .checked_mul(4)
+                .and_then(|off| off.checked_add(4))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: "moe_route",
+                    detail: format!("u32 byte range for index {index} overflows usize"),
+                })?;
+            if end > slice.len() {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "expert_ids",
+                    buffer_len: slice.len(),
+                    expected_len: end,
+                    shape: view.shape().to_vec(),
+                });
+            }
+            let _ = dtype;
+            slice[index * 4..end].copy_from_slice(&val.to_le_bytes());
+            Ok(())
+        }
+        _ => Err(T0Error::BackingRepresentationMismatch {
+            op: "moe_route",
+            dtype: view.dtype(),
+        }),
+    }
+}
+
+/// Routes tokens to experts: `logits [T, E] f32` (+ optional `bias [E]`)
+/// → `expert_ids [T, K] u32`, `weights [T, K] f32` (Spec 1 §4.C, Card A1.9).
+///
+/// Algorithm in `f32`, ascending-token outer loop for determinism:
+/// 1. `s = logits + bias` (when present);
+/// 2. scores: stable softmax in `f32` (row max, ascending exp-sum) or
+///    `1/(1+exp(-s))` in `f32` for sigmoid;
+/// 3. stable sort of row indices by `(-score, index)` — ties resolve to the
+///    lowest expert index per spec — and take the first K;
+/// 4. `weights = score[selected] * scale`;
+/// 5. when `renormalize`, divide by the `f32` sum over the selected K.
+///
+/// Output rows list experts in descending score order, ties by ascending
+/// expert id. The weighted combine in `moe_ffn` is order-insensitive, so this
+/// order is a presentation choice, not a numerics input.
+///
+/// Numerics: `Numerics::f32(AscendingIndex)`; no IR change.
+///
+/// Fail-closed (SI-51): `group.is_some()` is rejected — the spec states no
+/// grouped-selection algorithm. Non-finite logits are collected per `(t, e)`.
+/// After scoring, non-finite post-bias scores, a zero/non-finite
+/// renormalize divisor, and non-finite staged weights are each rejected per
+/// row before either output mutates, so no NaN/Inf weight is ever committed.
+/// DECISION(A1.9): scale multiplies selected scores before renormalization
+/// and renormalization divides by the selected-K sum; rejected post-renorm
+/// scaling (would silently un-normalize) and full-row denominators (would
+/// contradict `renormalize` naming the selected weights). Per SI-51.
+pub fn moe_route(
+    op: &MoeRouteOp,
+    logits: &TensorView<'_>,
+    bias: Option<&TensorView<'_>>,
+    expert_ids: &mut TensorViewMut<'_>,
+    weights: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    logits.validate_backing("logits")?;
+    if let Some(b) = bias {
+        b.validate_backing("bias")?;
+    }
+    expert_ids.validate_backing("expert_ids")?;
+    weights.validate_backing("weights")?;
+
+    let mut problems = Vec::new();
+
+    if logits.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "logits",
+            expected: 2,
+            got: logits.rank(),
+            shape: logits.shape().to_vec(),
+        });
+    }
+    if logits.dtype() != DType::F32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "logits",
+            expected: vec![DType::F32],
+            got: logits.dtype(),
+        });
+    }
+    if logits.layout() != LayoutId::CONTIGUOUS && logits.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "logits",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: logits.layout(),
+        });
+    }
+
+    if let Some(b) = bias {
+        if b.rank() != 1 {
+            problems.push(T0Error::RankMismatch {
+                tensor: "bias",
+                expected: 1,
+                got: b.rank(),
+                shape: b.shape().to_vec(),
+            });
+        }
+        if b.dtype() != DType::F32 {
+            problems.push(T0Error::DTypeMismatch {
+                tensor: "bias",
+                expected: vec![DType::F32],
+                got: b.dtype(),
+            });
+        }
+        if b.layout() != LayoutId::CONTIGUOUS && b.layout() != LayoutId::L0 {
+            problems.push(T0Error::LayoutMismatch {
+                tensor: "bias",
+                expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+                got: b.layout(),
+            });
+        }
+    }
+
+    if expert_ids.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "expert_ids",
+            expected: 2,
+            got: expert_ids.rank(),
+            shape: expert_ids.shape().to_vec(),
+        });
+    }
+    if expert_ids.dtype() != DType::U32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "expert_ids",
+            expected: vec![DType::U32],
+            got: expert_ids.dtype(),
+        });
+    }
+    if weights.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "weights",
+            expected: 2,
+            got: weights.rank(),
+            shape: weights.shape().to_vec(),
+        });
+    }
+    if weights.dtype() != DType::F32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "weights",
+            expected: vec![DType::F32],
+            got: weights.dtype(),
+        });
+    }
+
+    if op.top_k == 0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "moe_route",
+            attribute: "top_k",
+            reason: "top_k must be > 0".to_string(),
+        });
+    }
+    if !op.scale.is_finite() || op.scale <= 0.0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "moe_route",
+            attribute: "scale",
+            reason: format!("scale must be finite and > 0, got {}", op.scale),
+        });
+    }
+    if op.group.is_some() {
+        problems.push(T0Error::InvalidAttribute {
+            op: "moe_route",
+            attribute: "group",
+            reason: "grouped expert routing has no specified selection algorithm (SI-51)"
+                .to_string(),
+        });
+    }
+    match op.scoring {
+        MoeScoring::Softmax | MoeScoring::Sigmoid => {}
+    }
+
+    T0Error::from_problems(problems)?;
+
+    let t = logits.shape()[0];
+    let e = logits.shape()[1];
+    let k = op.top_k as usize;
+
+    if t == 0 || e == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "moe_route",
+            tensor: "logits",
+        });
+    }
+    if k > e {
+        return Err(T0Error::InvalidAttribute {
+            op: "moe_route",
+            attribute: "top_k",
+            reason: format!("top_k {k} cannot exceed number of experts E={e}"),
+        });
+    }
+    let _ = u32::try_from(t).map_err(|_| T0Error::ArithmeticOverflow {
+        op: "moe_route",
+        detail: format!("dimension T exceeds u32: {t}"),
+    })?;
+    let _ = u32::try_from(e).map_err(|_| T0Error::ArithmeticOverflow {
+        op: "moe_route",
+        detail: format!("dimension E exceeds u32: {e}"),
+    })?;
+
+    let mut problems = Vec::new();
+    if let Some(b) = bias {
+        if b.shape()[0] != e {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "E",
+                expected_from: "logits",
+                expected: e,
+                tensor: "bias",
+                got: b.shape()[0],
+            });
+        }
+    }
+    if expert_ids.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "logits",
+            expected: t,
+            tensor: "expert_ids",
+            got: expert_ids.shape()[0],
+        });
+    }
+    if expert_ids.shape()[1] != k {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "K",
+            expected_from: "top_k",
+            expected: k,
+            tensor: "expert_ids",
+            got: expert_ids.shape()[1],
+        });
+    }
+    if weights.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "logits",
+            expected: t,
+            tensor: "weights",
+            got: weights.shape()[0],
+        });
+    }
+    if weights.shape()[1] != k {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "K",
+            expected_from: "top_k",
+            expected: k,
+            tensor: "weights",
+            got: weights.shape()[1],
+        });
+    }
+    // Collect every non-finite logit before touching any output.
+    for row in 0..t {
+        for col in 0..e {
+            let v = logits.read_f32(row * e + col);
+            if !v.is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "moe_route",
+                    attribute: "logits",
+                    reason: format!("non-finite logit at (t={row}, e={col}): {v}"),
+                });
+            }
+        }
+    }
+    if let Some(b) = bias {
+        for col in 0..e.min(b.backing_len()) {
+            let v = b.read_f32(col);
+            if !v.is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "moe_route",
+                    attribute: "bias",
+                    reason: format!("non-finite bias at (e={col}): {v}"),
+                });
+            }
+        }
+    }
+    T0Error::from_problems(problems)?;
+
+    // Validated: compute into staged buffers, then commit to outputs.
+    // NaN/Inf guards (SI-51): post-bias scores, the renormalize divisor, and
+    // staged weights are all checked per row before either output mutates, so
+    // a degenerate row is a typed refusal rather than silent NaN weights.
+    let mut staged_ids = vec![0u32; t * k];
+    let mut staged_w = vec![0.0f32; t * k];
+    let mut problems = Vec::new();
+    for row in 0..t {
+        let mut scores = vec![0.0f32; e];
+        for col in 0..e {
+            let mut s = logits.read_f32(row * e + col);
+            if let Some(b) = bias {
+                s += b.read_f32(col);
+            }
+            scores[col] = s;
+        }
+        match op.scoring {
+            MoeScoring::Softmax => {
+                let mut max = scores[0];
+                for c in 1..e {
+                    if scores[c] > max {
+                        max = scores[c];
+                    }
+                }
+                let mut sum = 0.0f32;
+                for c in 0..e {
+                    let v = (scores[c] - max).exp();
+                    scores[c] = v;
+                    sum += v;
+                }
+                for c in 0..e {
+                    scores[c] /= sum;
+                }
+            }
+            MoeScoring::Sigmoid => {
+                for c in 0..e {
+                    scores[c] = 1.0 / (1.0 + (-scores[c]).exp());
+                }
+            }
+        }
+        // Finite logits/bias can still overflow their f32 sum or scoring
+        // transform; no NaN/Inf may reach the comparator or the outputs.
+        let mut row_finite = true;
+        for c in 0..e {
+            if !scores[c].is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "moe_route",
+                    attribute: "logits",
+                    reason: format!(
+                        "non-finite post-bias score at (t={row}, e={c}): {} (SI-51)",
+                        scores[c]
+                    ),
+                });
+                row_finite = false;
+            }
+        }
+        if !row_finite {
+            continue;
+        }
+        let mut order: Vec<usize> = (0..e).collect();
+        order.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]).then_with(|| a.cmp(&b)));
+        let mut selected_sum = 0.0f32;
+        for j in 0..k {
+            let col = order[j];
+            let w = scores[col] * op.scale;
+            staged_ids[row * k + j] = col as u32;
+            staged_w[row * k + j] = w;
+            selected_sum += w;
+        }
+        if op.renormalize {
+            // A degenerate sigmoid row (e.g. all extreme-negative logits)
+            // selects all-zero scores; dividing would emit NaN weights.
+            if !selected_sum.is_finite() || selected_sum == 0.0 {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "moe_route",
+                    attribute: "weights",
+                    reason: format!(
+                        "non-finite or zero selected-K sum {selected_sum} at row {row} with renormalize (SI-51)"
+                    ),
+                });
+                continue;
+            }
+            for j in 0..k {
+                staged_w[row * k + j] /= selected_sum;
+            }
+        }
+        for j in 0..k {
+            let w = staged_w[row * k + j];
+            if !w.is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "moe_route",
+                    attribute: "weights",
+                    reason: format!("non-finite staged weight at (t={row}, slot={j}): {w} (SI-51)"),
+                });
+            }
+        }
+    }
+    T0Error::from_problems(problems)?;
+
+    for (i, &id) in staged_ids.iter().enumerate() {
+        write_id(expert_ids, i, id)?;
+    }
+    for (i, &w) in staged_w.iter().enumerate() {
+        weights.write_f32(i, w);
+    }
+    Ok(())
+}
+
+/// 64-bit reference router for testing (Spec 1 §4.C, §6.1).
+///
+/// Independent `f64` path: never calls [`moe_route`]. Returns
+/// `(expert_ids [T, K], weights [T, K])` mirroring the T0 algorithm in `f64`.
+/// Slice lengths and `top_k` are validated with typed errors; checked
+/// products guard every extent, so no silent empty fallback exists.
+#[allow(clippy::too_many_arguments)]
+pub fn moe_route_f64_reference(
+    logits: &[f64],
+    t: usize,
+    e: usize,
+    bias: Option<&[f64]>,
+    top_k: u32,
+    scoring: MoeScoring,
+    renormalize: bool,
+    scale: f64,
+) -> Result<(Vec<u32>, Vec<f64>), T0Error> {
+    const OP: &str = "moe_route";
+    let k = top_k as usize;
+    let mut problems = Vec::new();
+    if k == 0 || k > e {
+        problems.push(T0Error::InvalidAttribute {
+            op: OP,
+            attribute: "top_k",
+            reason: format!("top_k {k} must satisfy 0 < top_k <= E={e}"),
+        });
+    }
+    if t == 0 || e == 0 {
+        problems.push(T0Error::EmptyInput {
+            op: OP,
+            tensor: "logits",
+        });
+    }
+    let te = t
+        .checked_mul(e)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * E overflows usize for T={t}, E={e}"),
+        })?;
+    if logits.len() != te {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "logits",
+            expected: te,
+            got: logits.len(),
+            detail: "logits length must equal T * E".to_string(),
+        });
+    }
+    if let Some(b) = bias {
+        if b.len() != e {
+            problems.push(T0Error::ShapeLengthMismatch {
+                op: OP,
+                tensor: "bias",
+                expected: e,
+                got: b.len(),
+                detail: "bias length must equal E".to_string(),
+            });
+        }
+    }
+    T0Error::from_problems(problems)?;
+    let tk = t
+        .checked_mul(k)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * K overflows usize for T={t}, K={k}"),
+        })?;
+    let mut ids = vec![0u32; tk];
+    let mut ws = vec![0.0f64; tk];
+    for row in 0..t {
+        let mut scores = vec![0.0f64; e];
+        for col in 0..e {
+            let mut s = logits[row * e + col];
+            if let Some(b) = bias {
+                s += b[col];
+            }
+            scores[col] = s;
+        }
+        match scoring {
+            MoeScoring::Softmax => {
+                let mut max = scores[0];
+                for c in 1..e {
+                    if scores[c] > max {
+                        max = scores[c];
+                    }
+                }
+                let mut sum = 0.0f64;
+                for c in 0..e {
+                    let v = (scores[c] - max).exp();
+                    scores[c] = v;
+                    sum += v;
+                }
+                for c in 0..e {
+                    scores[c] /= sum;
+                }
+            }
+            MoeScoring::Sigmoid => {
+                for c in 0..e {
+                    scores[c] = 1.0 / (1.0 + (-scores[c]).exp());
+                }
+            }
+        }
+        let mut order: Vec<usize> = (0..e).collect();
+        order.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]).then_with(|| a.cmp(&b)));
+        let mut selected_sum = 0.0f64;
+        for j in 0..k {
+            let col = order[j];
+            let w = scores[col] * scale;
+            ids[row * k + j] = col as u32;
+            ws[row * k + j] = w;
+            selected_sum += w;
+        }
+        if renormalize {
+            for j in 0..k {
+                ws[row * k + j] /= selected_sum;
+            }
+        }
+    }
+    Ok((ids, ws))
+}

--- a/crates/r9v-t0/src/ngram_gather.rs
+++ b/crates/r9v-t0/src/ngram_gather.rs
@@ -1,0 +1,1242 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Scalar T0 implementations of `ngram_gather` (Spec 1 §4.A, Card A1.9).
+//!
+//! Staged mode dequantizes host-gathered rows and lays them out; device mode
+//! hashes on the fly through a caller-supplied [`NgramHash`] and gathers from
+//! the device table. Both modes stage outputs and commit once.
+
+use r9v_format::{FormatError, SchemeId};
+use r9v_ir::{DType, LayoutId, NgramCombine, NgramGatherOp, NgramSource, QuantScheme};
+
+use crate::buffer::{TensorData, TensorView, TensorViewMut};
+use crate::error::T0Error;
+
+/// N-gram row hash execution parameter (Spec 1 §4.A, SI-53).
+///
+/// The spec names no `HashId` enumeration, so T0 never hard-codes a hash
+/// family: the caller (scheduler/models scope, where `NgramSpec.hash` lives)
+/// supplies the hash. `tokens` is the full `[T]` id slice, `pos` the querying
+/// position, `order` the head's n-gram order, `table_size` the head's table
+/// extent; the returned row must satisfy `row < table_size`.
+pub trait NgramHash {
+    /// Resolves the table row for `(pos, order)` in a head table of `table_size` rows.
+    fn row(&self, tokens: &[u32], pos: usize, order: u32, table_size: u32) -> u32;
+}
+
+/// Executes scalar T0 staged `ngram_gather` (Spec 1 §4.A, Card A1.9).
+///
+/// Inputs `(gather_staging [T, Np, Dn] i4|i8, row_scales)`; the host already
+/// gathered rows into the pinned staging buffer and T0 only dequantizes and
+/// lays out: Concat → `y [T, Np·Dn]`, Sum → `y [T, Dn]` (elementwise `f32`
+/// sum across heads, ascending), cast once to `out_dtype`.
+///
+/// Row contract: `Scheme(I8R)` rows carry one scalar scale per `(t, h)` in
+/// `row_scales` for any `Dn`; `Scheme(I8B128)` rows require `Dn == 128` so the
+/// single row scale is the block scale. Multi-block rows under one scalar
+/// have no specified scale application and fail closed, as do `I4K` staged
+/// rows (a superblock record cannot be named by a scalar) — SI-53.
+///
+/// DECISION(A1.9): staged tables are row-major (`CONTIGUOUS`/`L0`) with a
+/// separate scalar `row_scales` carrier; rejected inline scale records because
+/// the `[T, Np, Dn]` shape leaves no room for them. Per SI-53.
+pub fn ngram_gather(
+    op: &NgramGatherOp,
+    staging: &TensorView<'_>,
+    row_scales: &TensorView<'_>,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    staging.validate_backing("gather_staging")?;
+    row_scales.validate_backing("row_scales")?;
+    y.validate_backing("y")?;
+
+    if op.source != NgramSource::Staged {
+        return Err(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "source",
+            reason: "staged entry point requires NgramSource::Staged".to_string(),
+        });
+    }
+
+    let mut problems = Vec::new();
+    if staging.rank() != 3 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "gather_staging",
+            expected: 3,
+            got: staging.rank(),
+            shape: staging.shape().to_vec(),
+        });
+    }
+    if staging.layout() != LayoutId::CONTIGUOUS && staging.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "gather_staging",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: staging.layout(),
+        });
+    }
+    if !matches!(staging.dtype(), DType::I4 | DType::I8) {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "gather_staging",
+            expected: vec![DType::I4, DType::I8],
+            got: staging.dtype(),
+        });
+    }
+    if row_scales.rank() != 1 && row_scales.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "row_scales",
+            expected: 2,
+            got: row_scales.rank(),
+            shape: row_scales.shape().to_vec(),
+        });
+    }
+    if !matches!(row_scales.dtype(), DType::F32 | DType::F16) {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "row_scales",
+            expected: vec![DType::F32, DType::F16],
+            got: row_scales.dtype(),
+        });
+    }
+    if y.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
+    }
+    if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "out_dtype",
+            reason: format!("must be f16, bf16, or f32, got {:?}", op.out_dtype),
+        });
+    }
+    if y.dtype() != op.out_dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.out_dtype],
+            got: y.dtype(),
+        });
+    }
+    if op.heads == 0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "heads",
+            reason: "heads must be > 0".to_string(),
+        });
+    }
+    match op.combine {
+        NgramCombine::Concat | NgramCombine::Sum => {}
+    }
+    // Scheme gate: native schemes only; I4K and exotic schemes fail closed.
+    let block_only = match staging.quant() {
+        QuantScheme::Scheme(ir_s) => {
+            let sid = SchemeId::from_ir(ir_s)?;
+            if !sid.is_native() {
+                return Err(T0Error::Format(FormatError::ReservedScheme {
+                    scheme: sid.name(),
+                    owner: sid.owner_card(),
+                }));
+            }
+            match sid {
+                SchemeId::I8R => false,
+                SchemeId::I8B128 => true,
+                _ => {
+                    problems.push(T0Error::QuantMismatch {
+                        tensor: "gather_staging",
+                        expected: vec![
+                            QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                            QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                        ],
+                        got: staging.quant(),
+                    });
+                    false
+                }
+            }
+        }
+        _ => {
+            problems.push(T0Error::QuantMismatch {
+                tensor: "gather_staging",
+                expected: vec![
+                    QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                    QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                ],
+                got: staging.quant(),
+            });
+            false
+        }
+    };
+    T0Error::from_problems(problems)?;
+
+    let t = staging.shape()[0];
+    let np = staging.shape()[1];
+    let dn = staging.shape()[2];
+    if t == 0 || dn == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "ngram_gather",
+            tensor: "gather_staging",
+        });
+    }
+    if np == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "ngram_gather",
+            tensor: "gather_staging",
+        });
+    }
+    if np != op.heads as usize {
+        return Err(T0Error::DimensionMismatch {
+            dim_name: "Np",
+            expected_from: "heads",
+            expected: op.heads as usize,
+            tensor: "gather_staging",
+            got: np,
+        });
+    }
+    if block_only && dn != 128 {
+        return Err(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "row_scales",
+            reason: format!(
+                "I8B128 staged rows need Dn == 128 for the scalar row scale, got Dn={dn} (SI-53)"
+            ),
+        });
+    }
+    for dim in [t, np, dn] {
+        u32::try_from(dim).map_err(|_| T0Error::ArithmeticOverflow {
+            op: "ngram_gather",
+            detail: format!("dimension exceeds u32: {dim}"),
+        })?;
+    }
+
+    let mut problems = Vec::new();
+    if row_scales.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "gather_staging",
+            expected: t,
+            tensor: "row_scales",
+            got: row_scales.shape()[0],
+        });
+    }
+    if row_scales.rank() == 2 {
+        let h = row_scales.shape()[1];
+        if h != 1 && h != np {
+            problems.push(T0Error::DimensionMismatch {
+                dim_name: "Np",
+                expected_from: "gather_staging",
+                expected: np,
+                tensor: "row_scales",
+                got: h,
+            });
+        }
+    }
+    let expected_y1 = match op.combine {
+        NgramCombine::Concat => np
+            .checked_mul(dn)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "ngram_gather",
+                detail: format!("Np * Dn overflows usize for Np={np}, Dn={dn}"),
+            })?,
+        NgramCombine::Sum => dn,
+    };
+    if y.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "gather_staging",
+            expected: t,
+            tensor: "y",
+            got: y.shape()[0],
+        });
+    }
+    if y.shape()[1] != expected_y1 {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dn",
+            expected_from: "gather_staging",
+            expected: expected_y1,
+            tensor: "y",
+            got: y.shape()[1],
+        });
+    }
+    // Row scales must be finite; every offender is collected.
+    for row in 0..t {
+        for head in 0..np {
+            let s = read_row_scale(row_scales, row, head);
+            if !s.is_finite() {
+                problems.push(T0Error::InvalidAttribute {
+                    op: "ngram_gather",
+                    attribute: "row_scales",
+                    reason: format!("non-finite scale at (t={row}, h={head}): {s}"),
+                });
+            }
+        }
+    }
+    T0Error::from_problems(problems)?;
+
+    let y_len = t
+        .checked_mul(expected_y1)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "ngram_gather",
+            detail: "output buffer size overflows usize".to_string(),
+        })?;
+    let mut y_tmp = vec![0.0f32; y_len];
+    for row in 0..t {
+        for head in 0..np {
+            let scale = read_row_scale(row_scales, row, head);
+            for d in 0..dn {
+                let q = read_staging_q(staging, row, head, d, np, dn)?;
+                let v = (q as f32) * scale;
+                match op.combine {
+                    NgramCombine::Concat => {
+                        y_tmp[row * expected_y1 + head * dn + d] = v;
+                    }
+                    NgramCombine::Sum => {
+                        y_tmp[row * expected_y1 + d] += v;
+                    }
+                }
+            }
+        }
+    }
+    for (idx, &val) in y_tmp.iter().enumerate() {
+        y.write_f32(idx, val);
+    }
+    Ok(())
+}
+
+/// Reads one `i8` staging element (typed or raw-byte backing).
+fn read_staging_q(
+    staging: &TensorView<'_>,
+    row: usize,
+    head: usize,
+    d: usize,
+    np: usize,
+    dn: usize,
+) -> Result<i8, T0Error> {
+    let idx = row
+        .checked_mul(np)
+        .and_then(|v| v.checked_add(head))
+        .and_then(|v| v.checked_mul(dn))
+        .and_then(|v| v.checked_add(d))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "ngram_gather",
+            detail: "staging index overflows usize".to_string(),
+        })?;
+    match &staging.data {
+        TensorData::I8(slice) => {
+            slice
+                .get(idx)
+                .copied()
+                .ok_or_else(|| T0Error::BufferLengthMismatch {
+                    tensor: "gather_staging",
+                    buffer_len: slice.len(),
+                    expected_len: idx + 1,
+                    shape: staging.shape().to_vec(),
+                })
+        }
+        TensorData::Bytes(_, slice) => {
+            slice
+                .get(idx)
+                .copied()
+                .map(|b| b as i8)
+                .ok_or_else(|| T0Error::BufferLengthMismatch {
+                    tensor: "gather_staging",
+                    buffer_len: slice.len(),
+                    expected_len: idx + 1,
+                    shape: staging.shape().to_vec(),
+                })
+        }
+        _ => Err(T0Error::DTypeMismatch {
+            tensor: "gather_staging",
+            expected: vec![DType::I8],
+            got: staging.dtype(),
+        }),
+    }
+}
+
+/// Reads one row scale for `(row, head)` from `[T]` or `[T, 1|Np]` scales.
+fn read_row_scale(scales: &TensorView<'_>, row: usize, head: usize) -> f32 {
+    if scales.rank() == 2 {
+        if scales.shape()[1] == 1 {
+            scales.read_f32(row)
+        } else {
+            scales.read_f32(row * scales.shape()[1] + head)
+        }
+    } else {
+        scales.read_f32(row)
+    }
+}
+
+/// Executes scalar T0 device-table `ngram_gather` (Spec 1 §4.A, Card A1.9).
+///
+/// Inputs `(token_ids [T] u32, table [Σ table_sizes, Dn])`; per `(t, head)`,
+/// `row = hash.row(token_ids, t, orders[head], table_sizes[head])` selects a
+/// row of head `head`'s table segment (segments concatenate in head order),
+/// which is dequantized and laid out exactly like the staged mode.
+///
+/// `table_scale` carries the table's scale records when the table is
+/// quantized (falling back to `table.scale()` when `None`, mirroring
+/// `matmul`); unquantized tables take no scale. Only row-major
+/// (`CONTIGUOUS`/`L0`) tables are accepted.
+///
+/// Fail-closed (SI-53): any `orders[head] > 1` is rejected — order-n context
+/// rows are not in the signature, so the hash input for them cannot be named.
+/// Unknown `HashId` values never reach T0: the hash arrives as `&dyn
+/// NgramHash`, so T0 maps no hash family itself.
+///
+/// DECISION(A1.9): quantized device tables require the separate scale carrier
+/// (`[entries]`/`[entries, Dn/128]` `F16` bytes, `[entries, Dn/256, 4]` `U32`
+/// bytes); rejected inline scale rows because hashed row addressing needs
+/// fixed row strides. Per SI-53.
+pub fn ngram_gather_device(
+    op: &NgramGatherOp,
+    token_ids: &TensorView<'_>,
+    table: &TensorView<'_>,
+    table_scale: Option<&TensorView<'_>>,
+    hash: &dyn NgramHash,
+    y: &mut TensorViewMut<'_>,
+) -> Result<(), T0Error> {
+    token_ids.validate_backing("token_ids")?;
+    table.validate_backing("table")?;
+    if let Some(s) = table_scale {
+        s.validate_backing("table_scale")?;
+    }
+    y.validate_backing("y")?;
+    let table_scale = table_scale.or_else(|| table.scale());
+    if let Some(s) = table_scale {
+        s.validate_backing("table_scale")?;
+    }
+
+    if op.source != NgramSource::Device {
+        return Err(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "source",
+            reason: "device entry point requires NgramSource::Device".to_string(),
+        });
+    }
+
+    let mut problems = Vec::new();
+    if token_ids.rank() != 1 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "token_ids",
+            expected: 1,
+            got: token_ids.rank(),
+            shape: token_ids.shape().to_vec(),
+        });
+    }
+    if token_ids.dtype() != DType::U32 {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "token_ids",
+            expected: vec![DType::U32],
+            got: token_ids.dtype(),
+        });
+    }
+    if table.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "table",
+            expected: 2,
+            got: table.rank(),
+            shape: table.shape().to_vec(),
+        });
+    }
+    if table.layout() != LayoutId::CONTIGUOUS && table.layout() != LayoutId::L0 {
+        problems.push(T0Error::LayoutMismatch {
+            tensor: "table",
+            expected: vec![LayoutId::CONTIGUOUS, LayoutId::L0],
+            got: table.layout(),
+        });
+    }
+    if !matches!(
+        table.dtype(),
+        DType::I4 | DType::I8 | DType::F16 | DType::Bf16 | DType::F32
+    ) {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "table",
+            expected: vec![DType::I4, DType::I8, DType::F16, DType::Bf16, DType::F32],
+            got: table.dtype(),
+        });
+    }
+    if y.rank() != 2 {
+        problems.push(T0Error::RankMismatch {
+            tensor: "y",
+            expected: 2,
+            got: y.rank(),
+            shape: y.shape().to_vec(),
+        });
+    }
+    if !matches!(op.out_dtype, DType::F16 | DType::Bf16 | DType::F32) {
+        problems.push(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "out_dtype",
+            reason: format!("must be f16, bf16, or f32, got {:?}", op.out_dtype),
+        });
+    }
+    if y.dtype() != op.out_dtype {
+        problems.push(T0Error::DTypeMismatch {
+            tensor: "y",
+            expected: vec![op.out_dtype],
+            got: y.dtype(),
+        });
+    }
+    if op.heads == 0 {
+        problems.push(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "heads",
+            reason: "heads must be > 0".to_string(),
+        });
+    }
+    match op.combine {
+        NgramCombine::Concat | NgramCombine::Sum => {}
+    }
+    if op.orders.len() != op.heads as usize {
+        problems.push(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "orders",
+            reason: format!(
+                "orders length {} must equal heads {}",
+                op.orders.len(),
+                op.heads
+            ),
+        });
+    }
+    if op.table_sizes.len() != op.heads as usize {
+        problems.push(T0Error::InvalidAttribute {
+            op: "ngram_gather",
+            attribute: "table_sizes",
+            reason: format!(
+                "table_sizes length {} must equal heads {}",
+                op.table_sizes.len(),
+                op.heads
+            ),
+        });
+    }
+    for (head, &order) in op.orders.iter().enumerate() {
+        if order != 1 {
+            problems.push(T0Error::InvalidAttribute {
+                op: "ngram_gather",
+                attribute: "orders",
+                reason: format!(
+                    "device mode supports order 1 only, got order {order} at head {head} (SI-53)"
+                ),
+            });
+        }
+    }
+    // Table quant gate: unquantized float tables, PerRow I8, or native block
+    // schemes with a separate scale carrier.
+    let table_scheme = match (table.dtype(), table.quant()) {
+        (DType::F16 | DType::Bf16 | DType::F32, QuantScheme::None) => None,
+        (DType::I8, QuantScheme::PerRow) => Some(SchemeId::I8R),
+        (DType::I8 | DType::I4, QuantScheme::Scheme(ir_s)) => {
+            let sid = SchemeId::from_ir(ir_s)?;
+            if !sid.is_native() {
+                return Err(T0Error::Format(FormatError::ReservedScheme {
+                    scheme: sid.name(),
+                    owner: sid.owner_card(),
+                }));
+            }
+            match sid {
+                SchemeId::I8R | SchemeId::I8B128 if table.dtype() == DType::I8 => Some(sid),
+                SchemeId::I4K if table.dtype() == DType::I4 => Some(sid),
+                _ => {
+                    problems.push(T0Error::QuantMismatch {
+                        tensor: "table",
+                        expected: vec![
+                            QuantScheme::None,
+                            QuantScheme::PerRow,
+                            QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                            QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                            QuantScheme::Scheme(SchemeId::I4K.to_ir()),
+                        ],
+                        got: table.quant(),
+                    });
+                    None
+                }
+            }
+        }
+        _ => {
+            problems.push(T0Error::QuantMismatch {
+                tensor: "table",
+                expected: vec![
+                    QuantScheme::None,
+                    QuantScheme::PerRow,
+                    QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                    QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                    QuantScheme::Scheme(SchemeId::I4K.to_ir()),
+                ],
+                got: table.quant(),
+            });
+            None
+        }
+    };
+    T0Error::from_problems(problems)?;
+
+    let t = token_ids.shape()[0];
+    let entries = table.shape()[0];
+    let dn = table.shape()[1];
+    if t == 0 || entries == 0 || dn == 0 {
+        return Err(T0Error::EmptyInput {
+            op: "ngram_gather",
+            tensor: "table",
+        });
+    }
+    let np = op.heads as usize;
+    // Head segment bases with checked arithmetic.
+    let mut bases = vec![0usize; np];
+    let mut total = 0usize;
+    for (head, &size) in op.table_sizes.iter().enumerate() {
+        bases[head] = total;
+        total = total
+            .checked_add(size as usize)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "ngram_gather",
+                detail: format!("sum of table_sizes overflows usize at head {head}"),
+            })?;
+    }
+    if total != entries {
+        return Err(T0Error::DimensionMismatch {
+            dim_name: "entries",
+            expected_from: "table_sizes_sum",
+            expected: total,
+            tensor: "table",
+            got: entries,
+        });
+    }
+    // Block-scheme row widths must hold whole blocks.
+    match table_scheme {
+        Some(SchemeId::I8B128) if !dn.is_multiple_of(128) => {
+            return Err(T0Error::DimensionMismatch {
+                dim_name: "Dn",
+                expected_from: "block_size_128",
+                expected: 128,
+                tensor: "table",
+                got: dn,
+            });
+        }
+        Some(SchemeId::I4K) if !dn.is_multiple_of(256) => {
+            return Err(T0Error::DimensionMismatch {
+                dim_name: "Dn",
+                expected_from: "superblock_256",
+                expected: 256,
+                tensor: "table",
+                got: dn,
+            });
+        }
+        _ => {}
+    }
+    validate_device_table_scales(table, table_scale, table_scheme, entries, dn)?;
+    // Resolve token ids once (validated U32 above).
+    let mut tokens = vec![0u32; t];
+    for (idx, slot) in tokens.iter_mut().enumerate() {
+        *slot = token_ids.try_read_u32(idx, "token_ids").map_err(|_| {
+            T0Error::BufferLengthMismatch {
+                tensor: "token_ids",
+                buffer_len: token_ids.backing_len(),
+                expected_len: idx + 1,
+                shape: token_ids.shape().to_vec(),
+            }
+        })?;
+    }
+    // Resolve and bounds-check every hashed row before touching `y`.
+    let row_count = t
+        .checked_mul(np)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "ngram_gather",
+            detail: "T * Np overflows usize".to_string(),
+        })?;
+    let mut row_ids = vec![0usize; row_count];
+    let mut problems = Vec::new();
+    for row in 0..t {
+        for head in 0..np {
+            let size = op.table_sizes[head];
+            let prow = hash.row(&tokens, row, op.orders[head], size);
+            if prow >= size {
+                problems.push(T0Error::RowIndexOutOfRange {
+                    op: "ngram_gather",
+                    tensor: "table",
+                    position: row * np + head,
+                    index: prow,
+                    upper_bound: size as usize,
+                });
+            } else {
+                row_ids[row * np + head] = bases[head] + prow as usize;
+            }
+        }
+    }
+    let expected_y1 = match op.combine {
+        NgramCombine::Concat => np
+            .checked_mul(dn)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: "ngram_gather",
+                detail: format!("Np * Dn overflows usize for Np={np}, Dn={dn}"),
+            })?,
+        NgramCombine::Sum => dn,
+    };
+    if y.shape()[0] != t {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "T",
+            expected_from: "token_ids",
+            expected: t,
+            tensor: "y",
+            got: y.shape()[0],
+        });
+    }
+    if y.shape()[1] != expected_y1 {
+        problems.push(T0Error::DimensionMismatch {
+            dim_name: "Dn",
+            expected_from: "table",
+            expected: expected_y1,
+            tensor: "y",
+            got: y.shape()[1],
+        });
+    }
+    T0Error::from_problems(problems)?;
+
+    let y_len = t
+        .checked_mul(expected_y1)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "ngram_gather",
+            detail: "output buffer size overflows usize".to_string(),
+        })?;
+    let mut y_tmp = vec![0.0f32; y_len];
+    for row in 0..t {
+        for head in 0..np {
+            let entry = row_ids[row * np + head];
+            for d in 0..dn {
+                let val = decode_device_entry(table, table_scale, table_scheme, entry, d, dn)?;
+                match op.combine {
+                    NgramCombine::Concat => {
+                        y_tmp[row * expected_y1 + head * dn + d] = val;
+                    }
+                    NgramCombine::Sum => {
+                        y_tmp[row * expected_y1 + d] += val;
+                    }
+                }
+            }
+        }
+    }
+    for (idx, &val) in y_tmp.iter().enumerate() {
+        y.write_f32(idx, val);
+    }
+    Ok(())
+}
+
+/// Validates the device-table scale carrier (Spec 1 §4.A).
+///
+/// Quantized tables require a separate `CONTIGUOUS` raw-byte carrier:
+/// `[entries]`/`[entries, Dn/128]` `F16` bytes for `I8R`/`I8B128`,
+/// `[entries, Dn/256, 4]` `U32` bytes for `I4K`. Unquantized tables take no
+/// scale. Quantized table values must be raw bytes (mirrors matmul).
+fn validate_device_table_scales(
+    table: &TensorView<'_>,
+    table_scale: Option<&TensorView<'_>>,
+    scheme: Option<SchemeId>,
+    entries: usize,
+    dn: usize,
+) -> Result<(), T0Error> {
+    const OP: &str = "ngram_gather";
+    if scheme.is_some() {
+        match &table.data {
+            TensorData::Bytes(_, _) => {}
+            _ => {
+                return Err(T0Error::BackingRepresentationMismatch {
+                    op: OP,
+                    dtype: table.dtype(),
+                });
+            }
+        }
+    }
+    let Some(sid) = scheme else {
+        if table_scale.is_some() {
+            return Err(T0Error::InvalidAttribute {
+                op: OP,
+                attribute: "table_scale",
+                reason: "table_scale provided for unquantized table".to_string(),
+            });
+        }
+        return Ok(());
+    };
+    let Some(ws) = table_scale else {
+        return Err(T0Error::MissingOperand {
+            op: OP,
+            operand: "table_scale",
+            detail: "table_scale required for quantized device tables".to_string(),
+        });
+    };
+    if ws.layout() != LayoutId::CONTIGUOUS {
+        return Err(T0Error::LayoutMismatch {
+            tensor: "table_scale",
+            expected: vec![LayoutId::CONTIGUOUS],
+            got: ws.layout(),
+        });
+    }
+    let ws_bytes: &[u8] = match &ws.data {
+        TensorData::Bytes(_, slice) => slice,
+        _ => {
+            return Err(T0Error::BackingRepresentationMismatch {
+                op: OP,
+                dtype: ws.dtype(),
+            });
+        }
+    };
+    match sid {
+        SchemeId::I8R | SchemeId::I8B128 => {
+            if ws.dtype() != DType::F16 {
+                return Err(T0Error::DTypeMismatch {
+                    tensor: "table_scale",
+                    expected: vec![DType::F16],
+                    got: ws.dtype(),
+                });
+            }
+            let blocks = match sid {
+                SchemeId::I8R => 1,
+                _ => dn / 128,
+            };
+            let req_elems =
+                entries
+                    .checked_mul(blocks)
+                    .ok_or_else(|| T0Error::ArithmeticOverflow {
+                        op: OP,
+                        detail: "table scale element count overflows usize".to_string(),
+                    })?;
+            let shapes_match = if blocks == 1 {
+                ws.shape() == [entries].as_slice()
+            } else {
+                ws.shape() == [entries, blocks].as_slice()
+            };
+            if !shapes_match {
+                return Err(T0Error::DimensionMismatch {
+                    dim_name: "scale_shape",
+                    expected_from: "table",
+                    expected: req_elems,
+                    tensor: "table_scale",
+                    got: ws.num_elements(),
+                });
+            }
+            if ws_bytes.len() != req_elems * 2 {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "table_scale",
+                    buffer_len: ws_bytes.len(),
+                    expected_len: req_elems * 2,
+                    shape: ws.shape().to_vec(),
+                });
+            }
+        }
+        SchemeId::I4K => {
+            if ws.dtype() != DType::U32 {
+                return Err(T0Error::DTypeMismatch {
+                    tensor: "table_scale",
+                    expected: vec![DType::U32],
+                    got: ws.dtype(),
+                });
+            }
+            let sbs = dn / 256;
+            if ws.shape() != [entries, sbs, 4].as_slice() {
+                return Err(T0Error::DimensionMismatch {
+                    dim_name: "scale_shape",
+                    expected_from: "table",
+                    expected: entries * sbs * 4,
+                    tensor: "table_scale",
+                    got: ws.num_elements(),
+                });
+            }
+            let req_bytes = entries * sbs * 16;
+            if ws_bytes.len() != req_bytes {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "table_scale",
+                    buffer_len: ws_bytes.len(),
+                    expected_len: req_bytes,
+                    shape: ws.shape().to_vec(),
+                });
+            }
+        }
+        _ => {
+            return Err(T0Error::QuantMismatch {
+                tensor: "table",
+                expected: vec![
+                    QuantScheme::None,
+                    QuantScheme::PerRow,
+                    QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                    QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                    QuantScheme::Scheme(SchemeId::I4K.to_ir()),
+                ],
+                got: table.quant(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Reads one `F16`-backed scale as `f32` with bounds reporting.
+fn scale_f16_at(scale_bytes: &[u8], idx: usize) -> Result<f32, T0Error> {
+    let off = idx
+        .checked_mul(2)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: "ngram_gather",
+            detail: format!("table scale index overflows usize at {idx}"),
+        })?;
+    let raw: [u8; 2] = scale_bytes
+        .get(off..off + 2)
+        .and_then(|s| s.try_into().ok())
+        .ok_or_else(|| T0Error::BufferLengthMismatch {
+            tensor: "table_scale",
+            buffer_len: scale_bytes.len(),
+            expected_len: off + 2,
+            shape: vec![off + 2],
+        })?;
+    Ok(crate::dtype::f16_to_f32(u16::from_le_bytes(raw)))
+}
+
+/// Decodes one device-table element to `f32` (Spec 1 §4.A).
+fn decode_device_entry(
+    table: &TensorView<'_>,
+    table_scale: Option<&TensorView<'_>>,
+    scheme: Option<SchemeId>,
+    entry: usize,
+    d: usize,
+    dn: usize,
+) -> Result<f32, T0Error> {
+    const OP: &str = "ngram_gather";
+    let scale_bytes_of = || -> Result<&[u8], T0Error> {
+        match &table_scale {
+            Some(ws) => match &ws.data {
+                TensorData::Bytes(_, slice) => Ok(slice),
+                _ => Err(T0Error::BackingRepresentationMismatch {
+                    op: OP,
+                    dtype: ws.dtype(),
+                }),
+            },
+            None => Err(T0Error::MissingOperand {
+                op: OP,
+                operand: "table_scale",
+                detail: "table_scale required for quantized device tables".to_string(),
+            }),
+        }
+    };
+    let table_bytes_of = || -> Result<&[u8], T0Error> {
+        match &table.data {
+            TensorData::Bytes(_, slice) => Ok(slice),
+            _ => Err(T0Error::BackingRepresentationMismatch {
+                op: OP,
+                dtype: table.dtype(),
+            }),
+        }
+    };
+    match scheme {
+        None => {
+            let idx = entry
+                .checked_mul(dn)
+                .and_then(|v| v.checked_add(d))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: OP,
+                    detail: "table index overflows usize".to_string(),
+                })?;
+            if idx >= table.backing_len() {
+                return Err(T0Error::BufferLengthMismatch {
+                    tensor: "table",
+                    buffer_len: table.backing_len(),
+                    expected_len: idx + 1,
+                    shape: table.shape().to_vec(),
+                });
+            }
+            Ok(table.read_f32(idx))
+        }
+        Some(SchemeId::I8R) => {
+            let bytes = table_bytes_of()?;
+            let idx = entry
+                .checked_mul(dn)
+                .and_then(|v| v.checked_add(d))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: OP,
+                    detail: "table index overflows usize".to_string(),
+                })?;
+            let q = bytes
+                .get(idx)
+                .copied()
+                .ok_or_else(|| T0Error::BufferLengthMismatch {
+                    tensor: "table",
+                    buffer_len: bytes.len(),
+                    expected_len: idx + 1,
+                    shape: table.shape().to_vec(),
+                })? as i8;
+            Ok((q as f32) * scale_f16_at(scale_bytes_of()?, entry)?)
+        }
+        Some(SchemeId::I8B128) => {
+            let bytes = table_bytes_of()?;
+            let idx = entry
+                .checked_mul(dn)
+                .and_then(|v| v.checked_add(d))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: OP,
+                    detail: "table index overflows usize".to_string(),
+                })?;
+            let q = bytes
+                .get(idx)
+                .copied()
+                .ok_or_else(|| T0Error::BufferLengthMismatch {
+                    tensor: "table",
+                    buffer_len: bytes.len(),
+                    expected_len: idx + 1,
+                    shape: table.shape().to_vec(),
+                })? as i8;
+            let blocks = dn / 128;
+            let scale_idx = entry
+                .checked_mul(blocks)
+                .and_then(|v| v.checked_add(d / 128))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: OP,
+                    detail: "table scale index overflows usize".to_string(),
+                })?;
+            Ok((q as f32) * scale_f16_at(scale_bytes_of()?, scale_idx)?)
+        }
+        Some(SchemeId::I4K) => {
+            let bytes = table_bytes_of()?;
+            let sb = d / 256;
+            let sub = (d % 256) / 32;
+            let sbs = dn / 256;
+            let ws_bytes = scale_bytes_of()?;
+            let header_off = entry
+                .checked_mul(sbs)
+                .and_then(|v| v.checked_add(sb))
+                .and_then(|v| v.checked_mul(16))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: OP,
+                    detail: "table header index overflows usize".to_string(),
+                })?;
+            let raw: [u8; 16] = ws_bytes
+                .get(header_off..header_off + 16)
+                .and_then(|s| s.try_into().ok())
+                .ok_or_else(|| T0Error::BufferLengthMismatch {
+                    tensor: "table_scale",
+                    buffer_len: ws_bytes.len(),
+                    expected_len: header_off + 16,
+                    shape: table.shape().to_vec(),
+                })?;
+            let header = r9v_format::records::I4KSuperblock::from_bytes(&raw);
+            let sc = header.scales();
+            let mn = header.mins();
+            let s_block = header.d_value(sb as u64)? * (sc[sub] as f32);
+            let m_block = header.dmin_value(sb as u64)? * (mn[sub] as f32);
+            let flat = entry
+                .checked_mul(dn)
+                .and_then(|v| v.checked_add(d))
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: OP,
+                    detail: "table nibble index overflows usize".to_string(),
+                })?;
+            let byte =
+                bytes
+                    .get(flat / 2)
+                    .copied()
+                    .ok_or_else(|| T0Error::BufferLengthMismatch {
+                        tensor: "table",
+                        buffer_len: bytes.len(),
+                        expected_len: flat / 2 + 1,
+                        shape: table.shape().to_vec(),
+                    })?;
+            // Nibble parity follows the flat element index (even packs low).
+            let q = if flat % 2 == 0 {
+                (byte & 0x0F) as i32
+            } else {
+                ((byte >> 4) & 0x0F) as i32
+            };
+            Ok(s_block * (q as f32) - m_block)
+        }
+        Some(other) => Err(T0Error::QuantMismatch {
+            tensor: "table",
+            expected: vec![
+                QuantScheme::None,
+                QuantScheme::PerRow,
+                QuantScheme::Scheme(SchemeId::I8R.to_ir()),
+                QuantScheme::Scheme(SchemeId::I8B128.to_ir()),
+                QuantScheme::Scheme(SchemeId::I4K.to_ir()),
+            ],
+            got: QuantScheme::Scheme(other.to_ir()),
+        }),
+    }
+}
+
+/// 64-bit reference staged n-gram gather for testing (Spec 1 §4.A).
+///
+/// Independent `f64` path: plain nested loops over `&[i8]` rows and `f64`
+/// scales, never calling [`ngram_gather`]. `scales` carries one `f64` scale
+/// per `(t, head)` in row-major order. Slice lengths and every extent
+/// product are validated with typed errors; there is no silent empty
+/// fallback.
+pub fn ngram_gather_f64_reference_staged(
+    staging_i8: &[i8],
+    scales: &[f64],
+    t: usize,
+    np: usize,
+    dn: usize,
+    combine: NgramCombine,
+) -> Result<Vec<f64>, T0Error> {
+    const OP: &str = "ngram_gather";
+    let staging_len = t
+        .checked_mul(np)
+        .and_then(|v| v.checked_mul(dn))
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "T * Np * Dn overflows usize".to_string(),
+        })?;
+    let scales_len = t
+        .checked_mul(np)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * Np overflows usize for T={t}, Np={np}"),
+        })?;
+    let mut problems = Vec::new();
+    if staging_i8.len() != staging_len {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "staging_i8",
+            expected: staging_len,
+            got: staging_i8.len(),
+            detail: "staging length must equal T * Np * Dn".to_string(),
+        });
+    }
+    if scales.len() != scales_len {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "scales",
+            expected: scales_len,
+            got: scales.len(),
+            detail: "scales length must equal T * Np".to_string(),
+        });
+    }
+    T0Error::from_problems(problems)?;
+    let out1 = match combine {
+        NgramCombine::Concat => np
+            .checked_mul(dn)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: OP,
+                detail: format!("Np * Dn overflows usize for Np={np}, Dn={dn}"),
+            })?,
+        NgramCombine::Sum => dn,
+    };
+    let y_len = t
+        .checked_mul(out1)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "output buffer size overflows usize".to_string(),
+        })?;
+    let mut y = vec![0.0f64; y_len];
+    for row in 0..t {
+        for head in 0..np {
+            let scale = scales[row * np + head];
+            for d in 0..dn {
+                let v = staging_i8[(row * np + head) * dn + d] as f64 * scale;
+                match combine {
+                    NgramCombine::Concat => {
+                        y[row * out1 + head * dn + d] = v;
+                    }
+                    NgramCombine::Sum => {
+                        y[row * out1 + d] += v;
+                    }
+                }
+            }
+        }
+    }
+    Ok(y)
+}
+
+/// 64-bit reference device-table n-gram layout for testing (Spec 1 §4.A).
+///
+/// Independent `f64` path over already-resolved `row_ids [T·Np]` and an `f64`
+/// table: covers layout/combine only, while hash resolution and bounds
+/// rejection are tested directly against [`ngram_gather_device`]. Slice
+/// lengths, row bounds, and every extent product are validated with typed
+/// errors; there is no silent empty fallback.
+pub fn ngram_gather_f64_reference_rows(
+    table_f64: &[f64],
+    entries: usize,
+    dn: usize,
+    row_ids: &[u32],
+    t: usize,
+    np: usize,
+    combine: NgramCombine,
+) -> Result<Vec<f64>, T0Error> {
+    const OP: &str = "ngram_gather";
+    let table_len = entries
+        .checked_mul(dn)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "entries * Dn overflows usize".to_string(),
+        })?;
+    let ids_len = t
+        .checked_mul(np)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: format!("T * Np overflows usize for T={t}, Np={np}"),
+        })?;
+    let mut problems = Vec::new();
+    if table_f64.len() != table_len {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "table_f64",
+            expected: table_len,
+            got: table_f64.len(),
+            detail: "table length must equal entries * Dn".to_string(),
+        });
+    }
+    if row_ids.len() != ids_len {
+        problems.push(T0Error::ShapeLengthMismatch {
+            op: OP,
+            tensor: "row_ids",
+            expected: ids_len,
+            got: row_ids.len(),
+            detail: "row_ids length must equal T * Np".to_string(),
+        });
+    }
+    for (pos, &id) in row_ids.iter().enumerate() {
+        if (id as usize) >= entries {
+            problems.push(T0Error::RowIndexOutOfRange {
+                op: OP,
+                tensor: "row_ids",
+                position: pos,
+                index: id,
+                upper_bound: entries,
+            });
+        }
+    }
+    T0Error::from_problems(problems)?;
+    let out1 = match combine {
+        NgramCombine::Concat => np
+            .checked_mul(dn)
+            .ok_or_else(|| T0Error::ArithmeticOverflow {
+                op: OP,
+                detail: format!("Np * Dn overflows usize for Np={np}, Dn={dn}"),
+            })?,
+        NgramCombine::Sum => dn,
+    };
+    let y_len = t
+        .checked_mul(out1)
+        .ok_or_else(|| T0Error::ArithmeticOverflow {
+            op: OP,
+            detail: "output buffer size overflows usize".to_string(),
+        })?;
+    let mut y = vec![0.0f64; y_len];
+    for row in 0..t {
+        for head in 0..np {
+            let entry = row_ids[row * np + head] as usize;
+            if entry >= entries {
+                return Err(T0Error::RowIndexOutOfRange {
+                    op: OP,
+                    tensor: "row_ids",
+                    position: row * np + head,
+                    index: row_ids[row * np + head],
+                    upper_bound: entries,
+                });
+            }
+            for d in 0..dn {
+                let v = table_f64[entry * dn + d];
+                match combine {
+                    NgramCombine::Concat => {
+                        y[row * out1 + head * dn + d] = v;
+                    }
+                    NgramCombine::Sum => {
+                        y[row * out1 + d] += v;
+                    }
+                }
+            }
+        }
+    }
+    Ok(y)
+}

--- a/crates/r9v-t0/src/segments.rs
+++ b/crates/r9v-t0/src/segments.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::needless_range_loop)]
+//! Explicit execution-only sequence segmentation descriptor (Spec 1 §4.E, Card A1.9).
+//!
+//! The IR signatures of `causal_conv1d` and `linear_attn_scan` carry `[T, ...]`
+//! token-major tensors with no sequence-boundary input (SI-48): rows of `x`
+//! are not self-delimiting. Both T0 entry points therefore take an explicit
+//! [`SeqLayout`] execution parameter plus per-sequence state slots, and reset
+//! their recurrences at every segment boundary. The IR arity is unchanged.
+//!
+//! DECISION(A1.9): sequence boundaries travel as an explicit `&SeqLayout`
+//! execution parameter with per-sequence state slots carrying a leading `S`
+//! axis (`[S, Wk-1, C]` conv, `[S, H, D, Dv]` scan); rejected threading
+//! boundary metadata through fake tensor edges because `DType` is closed and
+//! SI-12 keeps non-tensor execution metadata out of the tensor signature.
+//! Per SI-48.
+
+use crate::error::T0Error;
+
+/// Explicit per-step sequence segmentation over the token axis (Spec 1 §4.E, SI-48).
+///
+/// `seq_lens[s]` is the token count of sequence `s`; the lengths sum to `T`.
+/// Both `causal_conv1d` and `linear_attn_scan` reset their recurrence at every
+/// segment boundary and address per-sequence state slot `s` for that segment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeqLayout {
+    seq_lens: Vec<u32>,
+    total: usize,
+}
+
+impl SeqLayout {
+    /// Builds a segmentation from per-sequence token counts (Spec 1 §4.E, SI-48).
+    ///
+    /// Fails with [`T0Error::EmptyInput`] when no sequences are given or any
+    /// sequence is zero-length, and with [`T0Error::ArithmeticOverflow`] when
+    /// the token total overflows `usize`.
+    pub fn new(seq_lens: &[u32]) -> Result<Self, T0Error> {
+        if seq_lens.is_empty() {
+            return Err(T0Error::EmptyInput {
+                op: "seq_layout",
+                tensor: "seq_lens",
+            });
+        }
+        let mut total: usize = 0;
+        for (s, &len) in seq_lens.iter().enumerate() {
+            if len == 0 {
+                return Err(T0Error::EmptyInput {
+                    op: "seq_layout",
+                    tensor: "seq_lens",
+                });
+            }
+            total = total
+                .checked_add(len as usize)
+                .ok_or_else(|| T0Error::ArithmeticOverflow {
+                    op: "seq_layout",
+                    detail: format!("token total overflows usize at sequence {s}"),
+                })?;
+        }
+        Ok(Self {
+            seq_lens: seq_lens.to_vec(),
+            total,
+        })
+    }
+
+    /// Returns the per-sequence token counts.
+    pub fn seq_lens(&self) -> &[u32] {
+        &self.seq_lens
+    }
+
+    /// Returns the number of sequences `S`.
+    pub fn seq_count(&self) -> usize {
+        self.seq_lens.len()
+    }
+
+    /// Returns the total token count `T`.
+    pub fn total(&self) -> usize {
+        self.total
+    }
+
+    /// Checks that the segmentation covers exactly `t` tokens (Spec 1 §4.E, SI-48).
+    pub(crate) fn check_total(&self, tensor: &'static str, t: usize) -> Result<(), T0Error> {
+        if self.total != t {
+            return Err(T0Error::DimensionMismatch {
+                dim_name: "T",
+                expected_from: "seq_lens_sum",
+                expected: t,
+                tensor,
+                got: self.total,
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/r9v-t0/tests/api_shape.rs
+++ b/crates/r9v-t0/tests/api_shape.rs
@@ -453,3 +453,118 @@ fn test_execute_matmul_and_lookup_op_dispatch() {
     let mut scatter_outputs = [y.as_view_mut()];
     assert!(execute_lookup_op(&scatter_op, &scatter_inputs, &mut scatter_outputs).is_ok());
 }
+
+#[test]
+fn test_a19_public_surface_markers_and_dispatch() {
+    use r9v_ir::{
+        AllReduceOp, BarrierOp, CausalConv1dOp, ConvActivation, LinearAttnKind, LinearAttnScanOp,
+        MoeFfnOp, MoeRouteOp, MoeScoring, NgramCombine, NgramGatherOp, NgramSource, Op, ReduceOp,
+        StateHandle, StateKind,
+    };
+
+    assert_send::<SeqLayout>();
+    assert_sync::<SeqLayout>();
+
+    // MoE dispatch: route runs through execute_moe_op.
+    let route_op = Op::MoeRoute(MoeRouteOp {
+        top_k: 1,
+        scoring: MoeScoring::Softmax,
+        renormalize: false,
+        group: None,
+        scale: 1.0,
+    });
+    let logits = TypedBuffer::from_f32(&[2, 3], &[0.1, 0.2, 0.3, 0.3, 0.2, 0.1]);
+    let mut ids = TypedBuffer::zeros(&[2, 1], DType::U32);
+    let mut weights = TypedBuffer::zeros(&[2, 1], DType::F32);
+    assert!(execute_moe_op(
+        &route_op,
+        &[logits.as_view()],
+        &mut [ids.as_view_mut(), weights.as_view_mut()],
+    )
+    .is_ok());
+    // MoE dispatch: ffn arity is enforced here; behavior is covered in moe_ffn_tests.
+    let ffn_op = Op::MoeFfn(MoeFfnOp {
+        act: r9v_ir::ActivationKind::Silu,
+        out_dtype: DType::F32,
+        shared_experts: 0,
+    });
+    let z = TypedBuffer::zeros(&[1, 2], DType::F32);
+    let mut y_ffn = TypedBuffer::zeros(&[1, 2], DType::F32);
+    assert!(execute_moe_op(&ffn_op, &[z.as_view()], &mut [y_ffn.as_view_mut()]).is_err());
+
+    // State/scan dispatch: conv runs; scan form flag is accepted.
+    let conv_op = Op::CausalConv1d(CausalConv1dOp {
+        kernel: 2,
+        act: ConvActivation::Identity,
+        handle: StateHandle::new(0, StateKind::ConvWindow),
+    });
+    let xc = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let wc = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let sc = TypedBuffer::from_f16(&[1, 1, 2], &[0; 2]);
+    let mut yc = TypedBuffer::zeros(&[2, 2], DType::F32);
+    let mut soc = TypedBuffer::zeros(&[1, 1, 2], DType::F16);
+    let seq = SeqLayout::new(&[2]).unwrap();
+    assert!(execute_state_scan_op(
+        &conv_op,
+        &[xc.as_view(), wc.as_view()],
+        &sc.as_view(),
+        &seq,
+        &mut [yc.as_view_mut()],
+        &mut soc.as_view_mut(),
+        false,
+    )
+    .is_ok());
+    let scan_op = Op::LinearAttnScan(LinearAttnScanOp {
+        kind: LinearAttnKind::GLA,
+        chunk: 2,
+        out_dtype: DType::F32,
+        handle: StateHandle::new(0, StateKind::Recurrent),
+    });
+    assert!(execute_state_scan_op(
+        &scan_op,
+        &[xc.as_view()],
+        &sc.as_view(),
+        &seq,
+        &mut [yc.as_view_mut()],
+        &mut soc.as_view_mut(),
+        true,
+    )
+    .is_err());
+
+    // N-gram dispatch: staged runs through views.
+    let ngram_op = Op::NgramGather(NgramGatherOp {
+        source: NgramSource::Staged,
+        orders: vec![1u32].into_boxed_slice(),
+        heads: 1,
+        hash: r9v_ir::HashId::new(0),
+        table_sizes: vec![8u32].into_boxed_slice(),
+        combine: NgramCombine::Sum,
+        out_dtype: DType::F32,
+    });
+    let staging = TypedBuffer::from_i8(&[2, 1, 4], &[1i8; 8]).with_quant(
+        r9v_ir::QuantScheme::Scheme(r9v_format::SchemeId::I8R.to_ir()),
+    );
+    let scales = TypedBuffer::from_f32(&[2, 1], &[0.5; 2]);
+    let mut yn = TypedBuffer::zeros(&[2, 4], DType::F32);
+    assert!(execute_ngram_op(
+        &ngram_op,
+        &[staging.as_view(), scales.as_view()],
+        &mut [yn.as_view_mut()]
+    )
+    .is_ok());
+
+    // Collective dispatch: barrier and send run; recv fails closed.
+    let barrier_op = Op::Barrier(BarrierOp {
+        group: r9v_ir::GroupId::new(0),
+    });
+    assert!(execute_collective_op(&barrier_op, &[], &mut []).is_ok());
+    let reduce_op = Op::AllReduce(AllReduceOp {
+        group: r9v_ir::GroupId::new(0),
+        op: ReduceOp::Sum,
+        dtype: DType::F32,
+        reduce_in: DType::F32,
+    });
+    let xr = TypedBuffer::from_f32(&[2, 2], &[1.0; 4]);
+    let mut yr = TypedBuffer::zeros(&[2, 2], DType::F32);
+    assert!(execute_collective_op(&reduce_op, &[xr.as_view()], &mut [yr.as_view_mut()]).is_ok());
+}

--- a/crates/r9v-t0/tests/causal_conv1d_tests.rs
+++ b/crates/r9v-t0/tests/causal_conv1d_tests.rs
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for scalar T0 `causal_conv1d` (Spec 1 §4.E, Card A1.9).
+
+use r9v_common::SeededRng;
+use r9v_ir::{CausalConv1dOp, ConvActivation, DType, Op, StateHandle, StateKind};
+use r9v_t0::buffer::TypedBuffer;
+use r9v_t0::dtype::{f16_to_f32, f32_to_f16};
+use r9v_t0::error::T0Error;
+use r9v_t0::{
+    causal_conv1d, causal_conv1d_f64_reference, execute_state_scan_op, SeqLayout, Tolerance,
+};
+
+fn conv_op(kernel: u32, act: ConvActivation) -> CausalConv1dOp {
+    CausalConv1dOp {
+        kernel,
+        act,
+        handle: StateHandle::new(0, StateKind::ConvWindow),
+    }
+}
+
+fn next_f32(rng: &mut SeededRng, lo: f32, hi: f32) -> f32 {
+    let u = ((rng.next_u64() >> 11) as f64) / (1u64 << 53) as f64;
+    lo + (u as f32) * (hi - lo)
+}
+
+fn f16_of(vals: &[f32]) -> Vec<u16> {
+    vals.iter().map(|&v| f32_to_f16(v)).collect()
+}
+
+fn f64_of_f16(bits: &[u16]) -> Vec<f64> {
+    bits.iter().map(|&b| f16_to_f32(b) as f64).collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_conv(
+    op: &CausalConv1dOp,
+    x: &[f32],
+    t: usize,
+    c: usize,
+    w: &[f32],
+    wk: usize,
+    bias: Option<&[f32]>,
+    state: &[u16],
+    s: usize,
+    lens: &[u32],
+) -> (Vec<f32>, Vec<u16>) {
+    let xb = TypedBuffer::from_f32(&[t, c], x);
+    let wb = TypedBuffer::from_f32(&[c, wk], w);
+    let bb = bias.map(|b| TypedBuffer::from_f32(&[c], b));
+    let hist = wk - 1;
+    let sb = TypedBuffer::from_f16(&[s, hist, c], state);
+    let mut yb = TypedBuffer::zeros(&[t, c], DType::F32);
+    let mut sob = TypedBuffer::zeros(&[s, hist, c], DType::F16);
+    let seq = SeqLayout::new(lens).unwrap();
+    let bias_view = bb.as_ref().map(|b| b.as_view());
+    causal_conv1d(
+        op,
+        &xb.as_view(),
+        &wb.as_view(),
+        bias_view.as_ref(),
+        &sb.as_view(),
+        &seq,
+        &mut yb.as_view_mut(),
+        &mut sob.as_view_mut(),
+    )
+    .unwrap();
+    // Read back f16 state bits exactly.
+    let mut state_bits = vec![0u16; s * hist * c];
+    for (i, v) in sob.to_f32_vec().iter().enumerate() {
+        state_bits[i] = f32_to_f16(*v);
+    }
+    (yb.to_f32_vec(), state_bits)
+}
+
+#[test]
+fn split_runs_with_carried_state_match_oneshot_bit_exact() {
+    // The done-when continuity test: (T1+T2 with carried state) vs one-shot.
+    // Inputs are exactly f16-representable, so the f16 state carry round-trips
+    // without loss and the two runs must agree bit-exactly.
+    for wk in [1usize, 2, 4, 8] {
+        for act in [ConvActivation::Silu, ConvActivation::Identity] {
+            for with_bias in [false, true] {
+                let mut rng = SeededRng::new(0xC0 + wk as u64 * 2 + with_bias as u64);
+                let (t1, t2, c) = (5, 7, 4);
+                let t = t1 + t2;
+                let exact = |v: f32| f16_to_f32(f32_to_f16(v));
+                let x: Vec<f32> = (0..t * c)
+                    .map(|_| exact(next_f32(&mut rng, -1.0, 1.0)))
+                    .collect();
+                let w: Vec<f32> = (0..c * wk)
+                    .map(|_| exact(next_f32(&mut rng, -0.5, 0.5)))
+                    .collect();
+                let bias: Vec<f32> = (0..c)
+                    .map(|_| exact(next_f32(&mut rng, -0.25, 0.25)))
+                    .collect();
+                let hist = wk - 1;
+                let init: Vec<f32> = (0..hist * c)
+                    .map(|_| exact(next_f32(&mut rng, -1.0, 1.0)))
+                    .collect();
+                let op = conv_op(wk as u32, act);
+                let bias_opt = if with_bias {
+                    Some(bias.as_slice())
+                } else {
+                    None
+                };
+
+                let (y_full, _) = run_conv(
+                    &op,
+                    &x,
+                    t,
+                    c,
+                    &w,
+                    wk,
+                    bias_opt,
+                    &f16_of(&init),
+                    1,
+                    &[t as u32],
+                );
+
+                // Chunked: first T1 from init, then T2 from carried state.
+                let (y_a, s_a) = run_conv(
+                    &op,
+                    &x[..t1 * c],
+                    t1,
+                    c,
+                    &w,
+                    wk,
+                    bias_opt,
+                    &f16_of(&init),
+                    1,
+                    &[t1 as u32],
+                );
+                let (y_b, _) = run_conv(
+                    &op,
+                    &x[t1 * c..],
+                    t2,
+                    c,
+                    &w,
+                    wk,
+                    bias_opt,
+                    &s_a,
+                    1,
+                    &[t2 as u32],
+                );
+                let mut y_split = y_a;
+                y_split.extend_from_slice(&y_b);
+
+                assert_eq!(y_split, y_full, "wk={wk} act={act:?} bias={with_bias}");
+            }
+        }
+    }
+}
+
+#[test]
+fn general_values_split_matches_prerounded_oneshot_bit_exact() {
+    // With general (non-f16-exact) values the ONLY split-vs-oneshot divergence
+    // is the f16 rounding of carry-boundary rows: chunk 1's outputs match the
+    // plain one-shot exactly, and chunk 2's outputs match a one-shot whose
+    // boundary rows [T1-hist, T1) were pre-rounded to f16. This pins the carry
+    // mechanism precisely instead of hiding the rounding in a tolerance.
+    let mut rng = SeededRng::new(0xC41);
+    let (t1, t2, c, wk) = (5, 7, 4, 4);
+    let hist = wk - 1;
+    let t = t1 + t2;
+    let x: Vec<f32> = (0..t * c).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let w: Vec<f32> = (0..c * wk).map(|_| next_f32(&mut rng, -0.5, 0.5)).collect();
+    let init: Vec<f32> = (0..hist * c)
+        .map(|_| next_f32(&mut rng, -1.0, 1.0))
+        .collect();
+    let op = conv_op(wk as u32, ConvActivation::Silu);
+
+    let (y_plain, _) = run_conv(&op, &x, t, c, &w, wk, None, &f16_of(&init), 1, &[t as u32]);
+    let (y_a, s_a) = run_conv(
+        &op,
+        &x[..t1 * c],
+        t1,
+        c,
+        &w,
+        wk,
+        None,
+        &f16_of(&init),
+        1,
+        &[t1 as u32],
+    );
+    let (y_b, _) = run_conv(
+        &op,
+        &x[t1 * c..],
+        t2,
+        c,
+        &w,
+        wk,
+        None,
+        &s_a,
+        1,
+        &[t2 as u32],
+    );
+
+    // Chunk 1 sees no carries in its own computation: exact prefix match.
+    assert_eq!(&y_a[..], &y_plain[..t1 * c]);
+
+    // Chunk 2 matches the pre-rounded one-shot on its suffix exactly.
+    let mut x_rounded = x.clone();
+    for r in (t1 - hist)..t1 {
+        for ch in 0..c {
+            x_rounded[r * c + ch] = f16_to_f32(f32_to_f16(x[r * c + ch]));
+        }
+    }
+    let (y_pre, _) = run_conv(
+        &op,
+        &x_rounded,
+        t,
+        c,
+        &w,
+        wk,
+        None,
+        &f16_of(&init),
+        1,
+        &[t as u32],
+    );
+    assert_eq!(&y_b[..], &y_pre[t1 * c..]);
+}
+
+#[test]
+fn general_values_split_continuity_within_f32_tolerance() {
+    // General (non-f16-exact) values: split-vs-oneshot is NOT bit-exact, by
+    // the specified f16 state quantization of the carry-boundary rows. The
+    // divergence is bounded: the split run must match the plain one-shot
+    // within the existing named f32 tolerance. No unconditional L0 is
+    // claimed; the exact carry mechanism is pinned by the two L0 tests above.
+    let mut rng = SeededRng::new(0x6E1);
+    let (t1, t2, c, wk) = (5, 7, 4, 4);
+    let t = t1 + t2;
+    let x: Vec<f32> = (0..t * c).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let w: Vec<f32> = (0..c * wk).map(|_| next_f32(&mut rng, -0.5, 0.5)).collect();
+    let bias: Vec<f32> = (0..c).map(|_| next_f32(&mut rng, -0.25, 0.25)).collect();
+    let hist = wk - 1;
+    let init: Vec<f32> = (0..hist * c)
+        .map(|_| next_f32(&mut rng, -1.0, 1.0))
+        .collect();
+    let op = conv_op(wk as u32, ConvActivation::Silu);
+
+    let (y_full, _) = run_conv(
+        &op,
+        &x,
+        t,
+        c,
+        &w,
+        wk,
+        Some(&bias),
+        &f16_of(&init),
+        1,
+        &[t as u32],
+    );
+    let (y_a, s_a) = run_conv(
+        &op,
+        &x[..t1 * c],
+        t1,
+        c,
+        &w,
+        wk,
+        Some(&bias),
+        &f16_of(&init),
+        1,
+        &[t1 as u32],
+    );
+    let (y_b, _) = run_conv(
+        &op,
+        &x[t1 * c..],
+        t2,
+        c,
+        &w,
+        wk,
+        Some(&bias),
+        &s_a,
+        1,
+        &[t2 as u32],
+    );
+    let mut y_split = y_a;
+    y_split.extend_from_slice(&y_b);
+
+    let tol = Tolerance::f32();
+    for (i, (&actual, &exp)) in y_split.iter().zip(y_full.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp as f64, &format!("split y[{i}]"));
+    }
+}
+
+#[test]
+fn state_tail_matches_last_history_rows_bit_exact() {
+    let mut rng = SeededRng::new(0x5A1);
+    let (t, c, wk) = (6, 3, 4);
+    let hist = wk - 1;
+    let x: Vec<f32> = (0..t * c).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let w: Vec<f32> = (0..c * wk).map(|_| next_f32(&mut rng, -0.5, 0.5)).collect();
+    let init: Vec<f32> = (0..hist * c)
+        .map(|_| next_f32(&mut rng, -1.0, 1.0))
+        .collect();
+    let op = conv_op(wk as u32, ConvActivation::Identity);
+    let (_, s_out) = run_conv(&op, &x, t, c, &w, wk, None, &f16_of(&init), 1, &[t as u32]);
+    // Tail is the last `hist` x rows encoded f16 (t >= hist here).
+    for h in 0..hist {
+        for ch in 0..c {
+            let expect = f32_to_f16(x[(t - hist + h) * c + ch]);
+            assert_eq!(s_out[h * c + ch], expect, "tail row {h} ch {ch}");
+        }
+    }
+}
+
+#[test]
+fn multi_segment_recurrence_resets_per_sequence() {
+    // Two segments: the second segment's outputs must equal a lone run of its
+    // own tokens from zero state, proving reset at boundaries.
+    let mut rng = SeededRng::new(0x9E9);
+    let (l0, l1, c, wk) = (4, 5, 3, 3);
+    let t = l0 + l1;
+    let x: Vec<f32> = (0..t * c).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let w: Vec<f32> = (0..c * wk).map(|_| next_f32(&mut rng, -0.5, 0.5)).collect();
+    let op = conv_op(wk as u32, ConvActivation::Silu);
+    let zero = vec![0u16; 2 * (wk - 1) * c];
+    let (y_both, _) = run_conv(
+        &op,
+        &x,
+        t,
+        c,
+        &w,
+        wk,
+        None,
+        &zero,
+        2,
+        &[l0 as u32, l1 as u32],
+    );
+    let (y_lone, _) = run_conv(
+        &op,
+        &x[l0 * c..],
+        l1,
+        c,
+        &w,
+        wk,
+        None,
+        &vec![0u16; (wk - 1) * c],
+        1,
+        &[l1 as u32],
+    );
+    assert_eq!(&y_both[l0 * c..], y_lone.as_slice());
+}
+
+#[test]
+fn oneshot_matches_f64_oracle_within_f32_tolerance() {
+    let mut rng = SeededRng::new(0xA01);
+    let (t, c, wk, s) = (7, 4, 3, 2);
+    let lens = [3u32, 4u32];
+    let x: Vec<f32> = (0..t * c).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let w: Vec<f32> = (0..c * wk).map(|_| next_f32(&mut rng, -0.5, 0.5)).collect();
+    let bias: Vec<f32> = (0..c).map(|_| next_f32(&mut rng, -0.25, 0.25)).collect();
+    let hist = wk - 1;
+    let init: Vec<f32> = (0..s * hist * c)
+        .map(|_| next_f32(&mut rng, -1.0, 1.0))
+        .collect();
+    let op = conv_op(wk as u32, ConvActivation::Silu);
+    let (y, _) = run_conv(&op, &x, t, c, &w, wk, Some(&bias), &f16_of(&init), s, &lens);
+
+    let x64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
+    let w64: Vec<f64> = w.iter().map(|&v| v as f64).collect();
+    let b64: Vec<f64> = bias.iter().map(|&v| v as f64).collect();
+    let (exp_y, _) = causal_conv1d_f64_reference(
+        &x64,
+        t,
+        c,
+        &w64,
+        wk,
+        Some(&b64),
+        ConvActivation::Silu,
+        &f64_of_f16(&f16_of(&init)),
+        s,
+        &lens,
+    )
+    .unwrap();
+    let tol = Tolerance::f32();
+    for (i, (&actual, &expected)) in y.iter().zip(exp_y.iter()).enumerate() {
+        tol.assert_within(actual as f64, expected, &format!("y[{i}]"));
+    }
+}
+
+#[test]
+fn determinism_and_token_batch_invariance() {
+    let mut rng = SeededRng::new(0xB01);
+    let (t, c, wk) = (5, 3, 4);
+    let hist = wk - 1;
+    let x: Vec<f32> = (0..t * c).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let w: Vec<f32> = (0..c * wk).map(|_| next_f32(&mut rng, -0.5, 0.5)).collect();
+    let init: Vec<f32> = (0..hist * c)
+        .map(|_| next_f32(&mut rng, -1.0, 1.0))
+        .collect();
+    let op = conv_op(wk as u32, ConvActivation::Silu);
+    let (y1, s1) = run_conv(&op, &x, t, c, &w, wk, None, &f16_of(&init), 1, &[t as u32]);
+    let (y2, s2) = run_conv(&op, &x, t, c, &w, wk, None, &f16_of(&init), 1, &[t as u32]);
+    assert_eq!(y1, y2);
+    assert_eq!(s1, s2);
+    // Batch invariance across segmentation with f16-exact values: per-token
+    // segments with chained state equal the one-shot output bit-exactly
+    // (the carry round-trips losslessly on exact inputs).
+    let exact = |v: f32| f16_to_f32(f32_to_f16(v));
+    let xe: Vec<f32> = x.iter().map(|&v| exact(v)).collect();
+    let we: Vec<f32> = w.iter().map(|&v| exact(v)).collect();
+    let init_exact: Vec<f32> = init.iter().map(|&v| exact(v)).collect();
+    let (ye, _) = run_conv(
+        &op,
+        &xe,
+        t,
+        c,
+        &we,
+        wk,
+        None,
+        &f16_of(&init_exact),
+        1,
+        &[t as u32],
+    );
+    let mut chained_y = Vec::new();
+    let mut st = f16_of(&init_exact);
+    for row in 0..t {
+        let (yr, sr) = run_conv(
+            &op,
+            &xe[row * c..(row + 1) * c],
+            1,
+            c,
+            &we,
+            wk,
+            None,
+            &st,
+            1,
+            &[1],
+        );
+        chained_y.extend_from_slice(&yr);
+        st = sr;
+    }
+    assert_eq!(chained_y, ye);
+}
+
+#[test]
+fn quantized_weights_fail_closed() {
+    let op = conv_op(2, ConvActivation::Identity);
+    let xb = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let wb = TypedBuffer::from_bytes(&[2, 2], DType::I8, &[1i8 as u8; 4]);
+    let sb = TypedBuffer::from_f16(&[1, 1, 2], &[0; 2]);
+    let mut yb = TypedBuffer::zeros(&[2, 2], DType::F32);
+    let mut sob = TypedBuffer::zeros(&[1, 1, 2], DType::F16);
+    let seq = SeqLayout::new(&[2]).unwrap();
+    let err = causal_conv1d(
+        &op,
+        &xb.as_view(),
+        &wb.as_view(),
+        None,
+        &sb.as_view(),
+        &seq,
+        &mut yb.as_view_mut(),
+        &mut sob.as_view_mut(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, T0Error::QuantMismatch { .. }));
+    assert_eq!(yb.to_f32_vec(), vec![0.0; 4]);
+}
+
+#[test]
+fn dispatch_enforces_conv_arity_and_form() {
+    let op = Op::CausalConv1d(conv_op(2, ConvActivation::Identity));
+    let xb = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let wb = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let sb = TypedBuffer::from_f16(&[1, 1, 2], &[0; 2]);
+    let mut yb = TypedBuffer::zeros(&[2, 2], DType::F32);
+    let mut sob = TypedBuffer::zeros(&[1, 1, 2], DType::F16);
+    let seq = SeqLayout::new(&[2]).unwrap();
+    assert!(execute_state_scan_op(
+        &op,
+        &[xb.as_view()],
+        &sb.as_view(),
+        &seq,
+        &mut [yb.as_view_mut()],
+        &mut sob.as_view_mut(),
+        false,
+    )
+    .is_err());
+    assert!(execute_state_scan_op(
+        &op,
+        &[xb.as_view(), wb.as_view()],
+        &sb.as_view(),
+        &seq,
+        &mut [yb.as_view_mut()],
+        &mut sob.as_view_mut(),
+        false,
+    )
+    .is_ok());
+}

--- a/crates/r9v-t0/tests/collectives_tests.rs
+++ b/crates/r9v-t0/tests/collectives_tests.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for scalar T0 rank-1 collectives (Spec 1 §4.G, Card A1.9).
+
+use r9v_common::SeededRng;
+use r9v_ir::{
+    AllGatherOp, AllReduceOp, AllToAllOp, BarrierOp, DType, GroupId, Op, RecvOp, ReduceOp,
+    ReduceScatterOp, SendOp,
+};
+use r9v_t0::buffer::TypedBuffer;
+use r9v_t0::error::T0Error;
+use r9v_t0::{
+    all_gather, all_reduce, all_to_all, barrier, execute_collective_op, recv, reduce_scatter, send,
+};
+
+fn group() -> GroupId {
+    GroupId::new(0)
+}
+
+fn next_f32(rng: &mut SeededRng, lo: f32, hi: f32) -> f32 {
+    let u = ((rng.next_u64() >> 11) as f64) / (1u64 << 53) as f64;
+    lo + (u as f32) * (hi - lo)
+}
+
+#[test]
+fn all_reduce_rank1_is_bit_exact_identity() {
+    let mut rng = SeededRng::new(0xC011);
+    // Include values that would NOT survive an f32 round-trip as other types.
+    let vals: Vec<f32> = (0..24).map(|_| next_f32(&mut rng, -10.0, 10.0)).collect();
+    let op = AllReduceOp {
+        group: group(),
+        op: ReduceOp::Sum,
+        dtype: DType::F32,
+        reduce_in: DType::F32,
+    };
+    let x_buf = TypedBuffer::from_f32(&[4, 6], &vals);
+    let mut y_buf = TypedBuffer::zeros(&[4, 6], DType::F32);
+    all_reduce(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap();
+    assert_eq!(y_buf.to_f32_vec(), vals);
+
+    // U32 with values above 2^24: only a byte-exact copy survives.
+    let big = vec![16_777_217u32, u32::MAX, 0, 1, 123_456_789, 4_000_000_011];
+    let op_u = AllReduceOp {
+        group: group(),
+        op: ReduceOp::Sum,
+        dtype: DType::U32,
+        reduce_in: DType::F32,
+    };
+    let xu = TypedBuffer::from_u32(&[2, 3], &big);
+    let mut yu = TypedBuffer::zeros(&[2, 3], DType::U32);
+    all_reduce(&op_u, &xu.as_view(), &mut yu.as_view_mut()).unwrap();
+    assert_eq!(yu.to_u32_vec(), big);
+}
+
+#[test]
+fn gather_scatter_alltoall_rank1_copy_inputs() {
+    let mut rng = SeededRng::new(0x6A7);
+    let vals: Vec<f32> = (0..12).map(|_| next_f32(&mut rng, -5.0, 5.0)).collect();
+    let x_buf = TypedBuffer::from_f32(&[3, 4], &vals);
+
+    let ag = AllGatherOp {
+        group: group(),
+        axis: 0,
+        dtype: DType::F32,
+    };
+    let mut y = TypedBuffer::zeros(&[3, 4], DType::F32);
+    all_gather(&ag, &x_buf.as_view(), &mut y.as_view_mut()).unwrap();
+    assert_eq!(y.to_f32_vec(), vals);
+
+    let rs = ReduceScatterOp {
+        group: group(),
+        axis: 1,
+        op: ReduceOp::Sum,
+        dtype: DType::F32,
+        reduce_in: DType::F32,
+    };
+    let mut y2 = TypedBuffer::zeros(&[3, 4], DType::F32);
+    reduce_scatter(&rs, &x_buf.as_view(), &mut y2.as_view_mut()).unwrap();
+    assert_eq!(y2.to_f32_vec(), vals);
+
+    let a2a = AllToAllOp {
+        group: group(),
+        dtype: DType::F32,
+    };
+    let counts = TypedBuffer::from_u32(&[1], &[3]);
+    let mut y3 = TypedBuffer::zeros(&[3, 4], DType::F32);
+    all_to_all(
+        &a2a,
+        &x_buf.as_view(),
+        &counts.as_view(),
+        &mut y3.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y3.to_f32_vec(), vals);
+}
+
+#[test]
+fn bad_axis_counts_and_peers_rejected() {
+    let x_buf = TypedBuffer::from_f32(&[3, 4], &[1.0; 12]);
+    let mut y_buf = TypedBuffer::zeros(&[3, 4], DType::F32);
+
+    let ag = AllGatherOp {
+        group: group(),
+        axis: 2,
+        dtype: DType::F32,
+    };
+    let err = all_gather(&ag, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
+    assert!(matches!(
+        err,
+        T0Error::InvalidAttribute {
+            op: "all_gather",
+            attribute: "axis",
+            ..
+        }
+    ));
+
+    let rs = ReduceScatterOp {
+        group: group(),
+        axis: 9,
+        op: ReduceOp::Sum,
+        dtype: DType::F32,
+        reduce_in: DType::F32,
+    };
+    let err = reduce_scatter(&rs, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
+    assert!(matches!(
+        err,
+        T0Error::InvalidAttribute {
+            op: "reduce_scatter",
+            ..
+        }
+    ));
+
+    let a2a = AllToAllOp {
+        group: group(),
+        dtype: DType::F32,
+    };
+    let bad_counts = TypedBuffer::from_u32(&[1], &[2]);
+    let err = all_to_all(
+        &a2a,
+        &x_buf.as_view(),
+        &bad_counts.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, T0Error::DimensionMismatch { .. }));
+
+    let send_bad = SendOp {
+        group: group(),
+        peer: 1,
+        dtype: DType::F32,
+    };
+    let err = send(&send_bad, &x_buf.as_view()).unwrap_err();
+    assert!(matches!(err, T0Error::InvalidAttribute { op: "send", .. }));
+}
+
+#[test]
+fn send_peer0_ok_barrier_ok_recv_fails_closed() {
+    let x_buf = TypedBuffer::from_f32(&[2, 2], &[1.0; 4]);
+    let send_ok = SendOp {
+        group: group(),
+        peer: 0,
+        dtype: DType::F32,
+    };
+    assert!(send(&send_ok, &x_buf.as_view()).is_ok());
+    assert!(barrier(&BarrierOp { group: group() }).is_ok());
+
+    let recv_op = RecvOp {
+        group: group(),
+        peer: 0,
+        shape: vec![r9v_ir::Dim::Concrete(2), r9v_ir::Dim::Concrete(2)].into_boxed_slice(),
+        dtype: DType::F32,
+    };
+    let mut y_buf = TypedBuffer::zeros(&[2, 2], DType::F32);
+    let err = recv(&recv_op, &mut y_buf.as_view_mut()).unwrap_err();
+    assert!(matches!(err, T0Error::InvalidAttribute { op: "recv", .. }));
+    assert_eq!(y_buf.to_f32_vec(), vec![0.0; 4]);
+}
+
+#[test]
+fn dtype_mismatches_report_op_tensors() {
+    let x_buf = TypedBuffer::from_f32(&[2, 2], &[1.0; 4]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 2], DType::F32);
+    let op = AllReduceOp {
+        group: group(),
+        op: ReduceOp::Sum,
+        dtype: DType::F16,
+        reduce_in: DType::F32,
+    };
+    let err = all_reduce(&op, &x_buf.as_view(), &mut y_buf.as_view_mut()).unwrap_err();
+    assert!(matches!(err, T0Error::Multiple { .. }));
+}
+
+#[test]
+fn dispatch_enforces_collective_arity() {
+    let x_buf = TypedBuffer::from_f32(&[2, 2], &[1.0; 4]);
+    let counts = TypedBuffer::from_u32(&[1], &[2]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 2], DType::F32);
+
+    let ar = Op::AllReduce(AllReduceOp {
+        group: group(),
+        op: ReduceOp::Sum,
+        dtype: DType::F32,
+        reduce_in: DType::F32,
+    });
+    assert!(execute_collective_op(&ar, &[], &mut [y_buf.as_view_mut()]).is_err());
+    assert!(execute_collective_op(&ar, &[x_buf.as_view()], &mut [y_buf.as_view_mut()]).is_ok());
+
+    let a2a = Op::AllToAll(AllToAllOp {
+        group: group(),
+        dtype: DType::F32,
+    });
+    assert!(execute_collective_op(&a2a, &[x_buf.as_view()], &mut [y_buf.as_view_mut()]).is_err());
+    assert!(execute_collective_op(
+        &a2a,
+        &[x_buf.as_view(), counts.as_view()],
+        &mut [y_buf.as_view_mut()]
+    )
+    .is_ok());
+
+    let send_op = Op::Send(SendOp {
+        group: group(),
+        peer: 0,
+        dtype: DType::F32,
+    });
+    assert!(execute_collective_op(&send_op, &[x_buf.as_view()], &mut []).is_ok());
+    assert!(
+        execute_collective_op(&send_op, &[x_buf.as_view()], &mut [y_buf.as_view_mut()]).is_err()
+    );
+
+    let barrier_op = Op::Barrier(BarrierOp { group: group() });
+    assert!(execute_collective_op(&barrier_op, &[], &mut []).is_ok());
+    assert!(execute_collective_op(&barrier_op, &[x_buf.as_view()], &mut []).is_err());
+
+    let recv_op = Op::Recv(RecvOp {
+        group: group(),
+        peer: 0,
+        shape: vec![r9v_ir::Dim::Concrete(2), r9v_ir::Dim::Concrete(2)].into_boxed_slice(),
+        dtype: DType::F32,
+    });
+    assert!(execute_collective_op(&recv_op, &[], &mut [y_buf.as_view_mut()]).is_err());
+}

--- a/crates/r9v-t0/tests/linear_attn_scan_tests.rs
+++ b/crates/r9v-t0/tests/linear_attn_scan_tests.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for scalar T0 `linear_attn_scan` (Spec 1 §4.E, Card A1.9).
+
+use r9v_common::SeededRng;
+use r9v_ir::{DType, LinearAttnKind, LinearAttnScanOp, Op, StateHandle, StateKind};
+use r9v_t0::buffer::TypedBuffer;
+use r9v_t0::{
+    execute_state_scan_op, linear_attn_scan_chunked, linear_attn_scan_f64_reference,
+    linear_attn_scan_recurrent, SeqLayout, Tolerance,
+};
+
+fn scan_op(kind: LinearAttnKind, chunk: u32) -> LinearAttnScanOp {
+    LinearAttnScanOp {
+        kind,
+        chunk,
+        out_dtype: DType::F32,
+        handle: StateHandle::new(0, StateKind::Recurrent),
+    }
+}
+
+fn next_f32(rng: &mut SeededRng, lo: f32, hi: f32) -> f32 {
+    let u = ((rng.next_u64() >> 11) as f64) / (1u64 << 53) as f64;
+    lo + (u as f32) * (hi - lo)
+}
+
+struct ScanCase {
+    t: usize,
+    h: usize,
+    d: usize,
+    dv: usize,
+    s: usize,
+    lens: Vec<u32>,
+    q: Vec<f32>,
+    k: Vec<f32>,
+    v: Vec<f32>,
+    alpha: Vec<f32>,
+    beta: Vec<f32>,
+    state: Vec<f32>,
+}
+
+fn make_case(seed: u64, t: usize, h: usize, d: usize, dv: usize, lens: &[u32]) -> ScanCase {
+    let mut rng = SeededRng::new(seed);
+    let s = lens.len();
+    ScanCase {
+        t,
+        h,
+        d,
+        dv,
+        s,
+        lens: lens.to_vec(),
+        q: (0..t * h * d)
+            .map(|_| next_f32(&mut rng, -1.0, 1.0))
+            .collect(),
+        k: (0..t * h * d)
+            .map(|_| next_f32(&mut rng, -1.0, 1.0))
+            .collect(),
+        v: (0..t * h * dv)
+            .map(|_| next_f32(&mut rng, -1.0, 1.0))
+            .collect(),
+        // Gates near 1 / small keep the recurrence bounded and oracle-meaningful.
+        alpha: (0..t * h).map(|_| next_f32(&mut rng, 0.8, 1.0)).collect(),
+        beta: (0..t * h).map(|_| next_f32(&mut rng, 0.0, 0.5)).collect(),
+        state: (0..s * h * d * dv)
+            .map(|_| next_f32(&mut rng, -0.25, 0.25))
+            .collect(),
+    }
+}
+
+fn run_form(
+    case: &ScanCase,
+    kind: LinearAttnKind,
+    chunk: u32,
+    chunked: bool,
+) -> (Vec<f32>, Vec<f32>) {
+    let op = scan_op(kind, chunk);
+    let qb = TypedBuffer::from_f32(&[case.t, case.h, case.d], &case.q);
+    let kb = TypedBuffer::from_f32(&[case.t, case.h, case.d], &case.k);
+    let vb = TypedBuffer::from_f32(&[case.t, case.h, case.dv], &case.v);
+    let ab = TypedBuffer::from_f32(&[case.t, case.h], &case.alpha);
+    let bb = TypedBuffer::from_f32(&[case.t, case.h], &case.beta);
+    let sb = TypedBuffer::from_f32(&[case.s, case.h, case.d, case.dv], &case.state);
+    let mut ob = TypedBuffer::zeros(&[case.t, case.h, case.dv], DType::F32);
+    let mut sob = TypedBuffer::zeros(&[case.s, case.h, case.d, case.dv], DType::F32);
+    let seq = SeqLayout::new(&case.lens).unwrap();
+    let r = if chunked {
+        linear_attn_scan_chunked(
+            &op,
+            &qb.as_view(),
+            &kb.as_view(),
+            &vb.as_view(),
+            &ab.as_view(),
+            &bb.as_view(),
+            &sb.as_view(),
+            &seq,
+            &mut ob.as_view_mut(),
+            &mut sob.as_view_mut(),
+        )
+    } else {
+        linear_attn_scan_recurrent(
+            &op,
+            &qb.as_view(),
+            &kb.as_view(),
+            &vb.as_view(),
+            &ab.as_view(),
+            &bb.as_view(),
+            &sb.as_view(),
+            &seq,
+            &mut ob.as_view_mut(),
+            &mut sob.as_view_mut(),
+        )
+    };
+    r.unwrap();
+    (ob.to_f32_vec(), sob.to_f32_vec())
+}
+
+#[test]
+fn chunked_and_recurrent_agree_bit_exact_all_kinds() {
+    // The done-when scan agreement test across kinds, chunks, and D != Dv.
+    for kind in [
+        LinearAttnKind::GatedDeltaNet,
+        LinearAttnKind::GLA,
+        LinearAttnKind::Mamba2,
+    ] {
+        for chunk in [1u32, 2, 3, 32, 64] {
+            for (d, dv) in [(4, 4), (3, 5), (6, 2)] {
+                let case = make_case(0x100 + chunk as u64, 9, 2, d, dv, &[4, 5]);
+                let (oc, sc) = run_form(&case, kind, chunk, true);
+                let (or, sr) = run_form(&case, kind, chunk, false);
+                assert_eq!(oc, or, "kind={kind:?} chunk={chunk} d={d} dv={dv} outputs");
+                assert_eq!(sc, sr, "kind={kind:?} chunk={chunk} d={d} dv={dv} states");
+            }
+        }
+    }
+}
+
+#[test]
+fn both_forms_match_f64_oracle_within_f32_tolerance() {
+    for kind in [
+        LinearAttnKind::GatedDeltaNet,
+        LinearAttnKind::GLA,
+        LinearAttnKind::Mamba2,
+    ] {
+        let case = make_case(0x200, 7, 3, 4, 5, &[2, 5]);
+        let (oc, sc) = run_form(&case, kind, 2, true);
+        let to64 = |v: &[f32]| v.iter().map(|&x| x as f64).collect::<Vec<f64>>();
+        let (exp_o, exp_s) = linear_attn_scan_f64_reference(
+            &to64(&case.q),
+            &to64(&case.k),
+            &to64(&case.v),
+            &to64(&case.alpha),
+            &to64(&case.beta),
+            case.t,
+            case.h,
+            case.d,
+            case.dv,
+            &to64(&case.state),
+            case.s,
+            &case.lens,
+        )
+        .unwrap();
+        let tol = Tolerance::f32();
+        for (i, (&actual, &expected)) in oc.iter().zip(exp_o.iter()).enumerate() {
+            tol.assert_within(actual as f64, expected, &format!("kind={kind:?} o[{i}]"));
+        }
+        for (i, (&actual, &expected)) in sc.iter().zip(exp_s.iter()).enumerate() {
+            tol.assert_within(actual as f64, expected, &format!("kind={kind:?} s[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn state_out_matches_recompute_from_slot_a() {
+    // A-slot discipline: recomputing the accepted prefix from A into a fresh B
+    // reproduces the carried-B state (spec 3 §4.2 at T0 level).
+    let case = make_case(0x300, 6, 2, 4, 4, &[6]);
+    let (o_full, s_full) = run_form(&case, LinearAttnKind::GLA, 64, true);
+    // Split: first 4 tokens, then tokens 4..6 from the carried state.
+    let mut prefix = make_case(0x300, 4, 2, 4, 4, &[4]);
+    prefix.q = case.q[..4 * 2 * 4].to_vec();
+    prefix.k = case.k[..4 * 2 * 4].to_vec();
+    prefix.v = case.v[..4 * 2 * 4].to_vec();
+    prefix.alpha = case.alpha[..4 * 2].to_vec();
+    prefix.beta = case.beta[..4 * 2].to_vec();
+    prefix.state = case.state.clone();
+    let (_, s_prefix) = run_form(&prefix, LinearAttnKind::GLA, 64, false);
+    // Recompute the accepted prefix (4 tokens) from A into B again: same state.
+    let (_, s_recompute) = run_form(&prefix, LinearAttnKind::GLA, 64, true);
+    assert_eq!(s_prefix, s_recompute);
+    // And the recomputed state advances the suffix identically.
+    let mut suffix = make_case(0x300, 2, 2, 4, 4, &[2]);
+    suffix.q = case.q[4 * 2 * 4..].to_vec();
+    suffix.k = case.k[4 * 2 * 4..].to_vec();
+    suffix.v = case.v[4 * 2 * 4..].to_vec();
+    suffix.alpha = case.alpha[4 * 2..].to_vec();
+    suffix.beta = case.beta[4 * 2..].to_vec();
+    suffix.state = s_prefix.clone();
+    let (o_suffix, _) = run_form(&suffix, LinearAttnKind::GLA, 64, false);
+    assert_eq!(&o_full[4 * 2 * 4..], o_suffix.as_slice());
+    let _ = s_full;
+}
+
+#[test]
+fn determinism_and_segment_batch_invariance() {
+    let case = make_case(0x400, 8, 2, 4, 6, &[3, 5]);
+    let (o1, s1) = run_form(&case, LinearAttnKind::Mamba2, 3, true);
+    let (o2, s2) = run_form(&case, LinearAttnKind::Mamba2, 3, true);
+    assert_eq!(o1, o2);
+    assert_eq!(s1, s2);
+    // Same tokens as one segment with the first slot's state must reproduce
+    // the first segment's outputs exactly.
+    let mut first = make_case(0x400, 3, 2, 4, 6, &[3]);
+    first.q = case.q[..3 * 2 * 4].to_vec();
+    first.k = case.k[..3 * 2 * 4].to_vec();
+    first.v = case.v[..3 * 2 * 6].to_vec();
+    first.alpha = case.alpha[..3 * 2].to_vec();
+    first.beta = case.beta[..3 * 2].to_vec();
+    first.state = case.state[..2 * 4 * 6].to_vec();
+    let (o_first, _) = run_form(&first, LinearAttnKind::Mamba2, 3, false);
+    assert_eq!(&o1[..3 * 2 * 6], o_first.as_slice());
+}
+
+#[test]
+fn nonfinite_gates_rejected_with_locations() {
+    let mut case = make_case(0x500, 3, 2, 2, 2, &[3]);
+    case.alpha[2] = f32::NAN;
+    case.beta[2 * 2 + 1] = f32::INFINITY;
+    let op = scan_op(LinearAttnKind::GLA, 2);
+    let qb = TypedBuffer::from_f32(&[3, 2, 2], &case.q);
+    let kb = TypedBuffer::from_f32(&[3, 2, 2], &case.k);
+    let vb = TypedBuffer::from_f32(&[3, 2, 2], &case.v);
+    let ab = TypedBuffer::from_f32(&[3, 2], &case.alpha);
+    let bb = TypedBuffer::from_f32(&[3, 2], &case.beta);
+    let sb = TypedBuffer::from_f32(&[1, 2, 2, 2], &case.state);
+    let mut ob = TypedBuffer::zeros(&[3, 2, 2], DType::F32);
+    let mut sob = TypedBuffer::zeros(&[1, 2, 2, 2], DType::F32);
+    let seq = SeqLayout::new(&[3]).unwrap();
+    let err = linear_attn_scan_chunked(
+        &op,
+        &qb.as_view(),
+        &kb.as_view(),
+        &vb.as_view(),
+        &ab.as_view(),
+        &bb.as_view(),
+        &sb.as_view(),
+        &seq,
+        &mut ob.as_view_mut(),
+        &mut sob.as_view_mut(),
+    )
+    .unwrap_err();
+    match err {
+        r9v_t0::error::T0Error::Multiple { problems } => {
+            assert_eq!(problems.len(), 2);
+            let text = format!("{problems:?}");
+            assert!(text.contains("(t=1, h=0)"));
+            assert!(text.contains("(t=2, h=1)"));
+        }
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+    assert_eq!(ob.to_f32_vec(), vec![0.0; 12]);
+}
+
+#[test]
+fn dispatch_selects_both_scan_forms() {
+    let case = make_case(0x600, 4, 1, 2, 2, &[4]);
+    let op = Op::LinearAttnScan(scan_op(LinearAttnKind::GLA, 2));
+    let run = |chunked: bool| {
+        let qb = TypedBuffer::from_f32(&[4, 1, 2], &case.q);
+        let kb = TypedBuffer::from_f32(&[4, 1, 2], &case.k);
+        let vb = TypedBuffer::from_f32(&[4, 1, 2], &case.v);
+        let ab = TypedBuffer::from_f32(&[4, 1], &case.alpha);
+        let bb = TypedBuffer::from_f32(&[4, 1], &case.beta);
+        let sb = TypedBuffer::from_f32(&[1, 1, 2, 2], &case.state);
+        let mut ob = TypedBuffer::zeros(&[4, 1, 2], DType::F32);
+        let mut sob = TypedBuffer::zeros(&[1, 1, 2, 2], DType::F32);
+        let seq = SeqLayout::new(&[4]).unwrap();
+        execute_state_scan_op(
+            &op,
+            &[
+                qb.as_view(),
+                kb.as_view(),
+                vb.as_view(),
+                ab.as_view(),
+                bb.as_view(),
+            ],
+            &sb.as_view(),
+            &seq,
+            &mut [ob.as_view_mut()],
+            &mut sob.as_view_mut(),
+            chunked,
+        )
+        .unwrap();
+        ob.to_f32_vec()
+    };
+    assert_eq!(run(true), run(false));
+}

--- a/crates/r9v-t0/tests/moe_ffn_tests.rs
+++ b/crates/r9v-t0/tests/moe_ffn_tests.rs
@@ -1,0 +1,1944 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for scalar T0 `moe_ffn` (Spec 1 §4.C, §6.2, Card A1.9).
+
+use r9v_common::SeededRng;
+use r9v_format::E4m3;
+use r9v_format::{
+    encode_e4m3_block128, encode_halfs_le, encode_i4k_superblock, encode_i8_block128,
+    l1_forward_elems, l1_forward_index, scale_geometry, Layout, PaddedDims, SchemeId,
+};
+use r9v_ir::{ActivationKind, DType, Epilogue, LayoutId, MatmulOp, MoeFfnOp, Op, QuantScheme};
+use r9v_t0::buffer::TypedBuffer;
+use r9v_t0::dtype::{f16_to_f32, f32_to_f16};
+use r9v_t0::error::T0Error;
+use r9v_t0::matmul::matmul_with_scales;
+use r9v_t0::{execute_moe_op, moe_ffn, moe_ffn_f64_reference, Tolerance};
+
+fn next_f32(rng: &mut SeededRng, lo: f32, hi: f32) -> f32 {
+    let u = ((rng.next_u64() >> 11) as f64) / (1u64 << 53) as f64;
+    lo + (u as f32) * (hi - lo)
+}
+
+fn f16_bytes(vals: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vals.len() * 2);
+    for &v in vals {
+        out.extend_from_slice(&f32_to_f16(v).to_le_bytes());
+    }
+    out
+}
+
+/// Builds an inline-I8R `[rows, cols]` weight buffer: values plus `f16` scale per row.
+fn i8r_inline(values: &[i8], rows: usize, cols: usize, scale: f32) -> Vec<u8> {
+    assert_eq!(values.len(), rows * cols);
+    let sbits = f32_to_f16(scale);
+    let mut out = vec![0u8; rows * (cols + 2)];
+    for r in 0..rows {
+        for c in 0..cols {
+            out[r * (cols + 2) + c] = values[r * cols + c] as u8;
+        }
+        out[r * (cols + 2) + cols..r * (cols + 2) + cols + 2].copy_from_slice(&sbits.to_le_bytes());
+    }
+    out
+}
+
+fn ffn_op(act: ActivationKind) -> MoeFfnOp {
+    MoeFfnOp {
+        act,
+        out_dtype: DType::F32,
+        shared_experts: 0,
+    }
+}
+
+#[test]
+fn hand_computed_single_token_identity_pipeline() {
+    // T=1, Dm=2, Dff=2, E=1, K=1, act=Identity, all F16.
+    // x=[1,0]; gate rows [2,3] picked by x; up rows [4,5]; h=[8,15];
+    // Wd=[[6,7],[8,9]]; y=[153,199] exactly.
+    let op = ffn_op(ActivationKind::Identity);
+    let x_buf = TypedBuffer::from_f16(&[1, 2], &[f32_to_f16(1.0), f32_to_f16(0.0)]);
+    let ids_buf = TypedBuffer::from_u32(&[1, 1], &[0]);
+    let wgt_buf = TypedBuffer::from_f32(&[1, 1], &[1.0]);
+    let gu = f16_bytes(&[2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0]);
+    let gu_buf = TypedBuffer::from_bytes(&[1, 4, 2], DType::F16, &gu);
+    let wd = f16_bytes(&[6.0, 7.0, 8.0, 9.0]);
+    let wd_buf = TypedBuffer::from_bytes(&[1, 2, 2], DType::F16, &wd);
+    let mut y_buf = TypedBuffer::zeros(&[1, 2], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    assert_eq!(y_buf.to_f32_vec(), vec![153.0, 199.0]);
+}
+
+#[test]
+fn down_path_differential_matches_matmul_branch_d_bit_exact() {
+    // Real differential guard for the Branch-D mirror: the same rigged
+    // down-projection inputs run through `moe_ffn` (T=1, K=1, weight 1.0,
+    // gate/up rigged so the hidden row is exactly [8,15]) and through
+    // `matmul_with_scales` Branch D (F16 x=[8,15] against the same Wd
+    // bytes) must agree bit-exactly, and both must equal [153,199].
+    let op = ffn_op(ActivationKind::Identity);
+    let x_buf = TypedBuffer::from_f16(&[1, 2], &[f32_to_f16(1.0), f32_to_f16(0.0)]);
+    let ids_buf = TypedBuffer::from_u32(&[1, 1], &[0]);
+    let wgt_buf = TypedBuffer::from_f32(&[1, 1], &[1.0]);
+    let gu = f16_bytes(&[2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0]);
+    let gu_buf = TypedBuffer::from_bytes(&[1, 4, 2], DType::F16, &gu);
+    let wd = f16_bytes(&[6.0, 7.0, 8.0, 9.0]);
+    let wd_buf = TypedBuffer::from_bytes(&[1, 2, 2], DType::F16, &wd);
+    let mut y_moe_buf = TypedBuffer::zeros(&[1, 2], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_moe_buf.as_view_mut(),
+    )
+    .unwrap();
+    let y_moe = y_moe_buf.to_f32_vec();
+
+    let gemm = MatmulOp {
+        out_dtype: DType::F32,
+        epilogue: Epilogue::None,
+        transpose_w: false,
+    };
+    let h_bits = [f32_to_f16(8.0), f32_to_f16(15.0)];
+    let h_buf = TypedBuffer::from_f16(&[1, 2], &h_bits);
+    let w_buf = TypedBuffer::from_bytes(&[2, 2], DType::F16, &wd);
+    let mut y_mm_buf = TypedBuffer::zeros(&[1, 2], DType::F32);
+    matmul_with_scales(
+        &gemm,
+        &h_buf.as_view(),
+        None,
+        &w_buf.as_view(),
+        None,
+        None,
+        None,
+        &mut y_mm_buf.as_view_mut(),
+    )
+    .unwrap();
+    let y_mm = y_mm_buf.to_f32_vec();
+
+    assert_eq!(y_moe, vec![153.0, 199.0]);
+    assert_eq!(y_moe, y_mm);
+}
+
+#[test]
+fn f16_experts_match_f64_oracle_within_f16_tolerance() {
+    let mut rng = SeededRng::new(0xF19);
+    let (t, dm, dff, e, k) = (4, 6, 8, 3, 2);
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x_f16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x_f64: Vec<f64> = x_f16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let gu_f64: Vec<f64> = gu.iter().map(|&v| v as f64).collect();
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let wd_f64: Vec<f64> = wd.iter().map(|&v| v as f64).collect();
+    // Fixed routing covering experts 0..2 (expert 2 gets one token).
+    let ids = vec![0u32, 1, 1, 2, 2, 0, 0, 2];
+    let weights: Vec<f32> = (0..t * k).map(|_| next_f32(&mut rng, 0.2, 1.0)).collect();
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+
+    let op = ffn_op(ActivationKind::Silu);
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x_f16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+    let wd_buf = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &f16_bytes(&wd));
+    let mut y_buf = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    // Oracle decodes the same f16 bits the T0 path consumed.
+    let gu_dec: Vec<f64> = gu_f64
+        .iter()
+        .enumerate()
+        .map(|(i, _)| f16_to_f32(f32_to_f16(gu[i])) as f64)
+        .collect();
+    let wd_dec: Vec<f64> = wd_f64
+        .iter()
+        .enumerate()
+        .map(|(i, _)| f16_to_f32(f32_to_f16(wd[i])) as f64)
+        .collect();
+    let expected = moe_ffn_f64_reference(
+        &x_f64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+    let tol = Tolerance::f16_bf16();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("y[{i}]"));
+    }
+}
+
+#[test]
+fn i8_per_row_experts_match_f64_oracle_within_i8_tolerance() {
+    let mut rng = SeededRng::new(0x1F9);
+    let (t, dm, dff, e, k) = (3, 8, 8, 2, 2);
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x_f16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x_f64: Vec<f64> = x_f16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu_q: Vec<i8> = (0..e * 2 * dff * dm)
+        .map(|_| (rng.next_u64() % 13) as i8 - 6)
+        .collect();
+    let wd_q: Vec<i8> = (0..e * dm * dff)
+        .map(|_| (rng.next_u64() % 11) as i8 - 5)
+        .collect();
+    let gu_scale = 0.25f32;
+    let wd_scale = 0.125f32;
+    let gu_bytes = i8r_inline(&gu_q, e * 2 * dff, dm, gu_scale);
+    let wd_bytes = i8r_inline(&wd_q, e * dm, dff, wd_scale);
+    let ids = vec![0u32, 1, 1, 0, 0, 1];
+    let weights = vec![0.6f32, 0.4, 0.3, 0.7, 0.5, 0.5];
+
+    let op = ffn_op(ActivationKind::Relu2);
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x_f16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::I8, &gu_bytes)
+        .with_quant(QuantScheme::PerRow);
+    let wd_buf = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &wd_bytes)
+        .with_quant(QuantScheme::PerRow);
+    let mut y_buf = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let gu_dec: Vec<f64> = gu_q.iter().map(|&q| q as f64 * gu_scale as f64).collect();
+    let wd_dec: Vec<f64> = wd_q.iter().map(|&q| q as f64 * wd_scale as f64).collect();
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x_f64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Relu2,
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("y[{i}]"));
+    }
+}
+
+#[test]
+fn token_permutation_preserves_per_token_outputs() {
+    // Permuting input token order with per-token routing fixed must preserve
+    // each token's output bits (the done-when combine-order test).
+    let mut rng = SeededRng::new(0x2F9);
+    let (t, dm, dff, e, k) = (6, 4, 6, 3, 2);
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let ids: Vec<u32> = (0..t * k).map(|i| (i as u32 * 7 + 1) % e as u32).collect();
+    let weights: Vec<f32> = (0..t * k).map(|_| next_f32(&mut rng, 0.1, 1.0)).collect();
+
+    // Activations run in F16 end to end (F32 is outside the GEMM family).
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let run16 = |order: &[usize]| {
+        let op = ffn_op(ActivationKind::Gelu);
+        let mut xr = vec![0u16; t * dm];
+        let mut ir = vec![0u32; t * k];
+        let mut wr = vec![0f32; t * k];
+        for (new_t, &old_t) in order.iter().enumerate() {
+            xr[new_t * dm..(new_t + 1) * dm].copy_from_slice(&x16[old_t * dm..(old_t + 1) * dm]);
+            ir[new_t * k..(new_t + 1) * k].copy_from_slice(&ids[old_t * k..(old_t + 1) * k]);
+            wr[new_t * k..(new_t + 1) * k].copy_from_slice(&weights[old_t * k..(old_t + 1) * k]);
+        }
+        let xb = TypedBuffer::from_f16(&[t, dm], &xr);
+        let ib = TypedBuffer::from_u32(&[t, k], &ir);
+        let wb = TypedBuffer::from_f32(&[t, k], &wr);
+        let gb = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+        let db = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &f16_bytes(&wd));
+        let mut yb = TypedBuffer::zeros(&[t, dm], DType::F32);
+        moe_ffn(
+            &op,
+            &xb.as_view(),
+            &ib.as_view(),
+            &wb.as_view(),
+            &gb.as_view(),
+            None,
+            &db.as_view(),
+            None,
+            None,
+            &mut yb.as_view_mut(),
+        )
+        .unwrap();
+        (yb.to_f32_vec(), order.to_vec())
+    };
+    let (y_base, _) = run16(&[0, 1, 2, 3, 4, 5]);
+    let (y_perm, perm) = run16(&[5, 2, 0, 4, 1, 3]);
+    for (new_t, &old_t) in perm.iter().enumerate() {
+        assert_eq!(
+            &y_perm[new_t * dm..(new_t + 1) * dm],
+            &y_base[old_t * dm..(old_t + 1) * dm],
+            "token {old_t} moved to row {new_t}"
+        );
+    }
+}
+
+#[test]
+fn duplicate_expert_slots_combine_deterministically() {
+    // Routing token 0 to expert 1 twice with 0.5/0.5 equals a single 1.0 slot.
+    // Dims: T=2, Dm=2, Dff=2, E=2, K=2.
+    let op = ffn_op(ActivationKind::Silu);
+    let x_buf = TypedBuffer::from_f16(
+        &[2, 2],
+        &[
+            f32_to_f16(0.5),
+            f32_to_f16(-0.25),
+            f32_to_f16(0.1),
+            f32_to_f16(0.2),
+        ],
+    );
+    let gu = f16_bytes(&[
+        0.1, -0.2, 0.3, 0.4, 0.5, -0.5, 0.25, -0.25, 0.1, 0.2, 0.3, 0.4, -0.1, -0.2, -0.3, -0.4,
+    ]);
+    let wd = f16_bytes(&[0.2, 0.1, -0.1, -0.2, 0.3, 0.4, 0.5, 0.6]);
+    let gu_buf = TypedBuffer::from_bytes(&[2, 4, 2], DType::F16, &gu);
+    let wd_buf = TypedBuffer::from_bytes(&[2, 2, 2], DType::F16, &wd);
+
+    let run = |ids: &[u32], weights: &[f32]| {
+        let ib = TypedBuffer::from_u32(&[2, 2], ids);
+        let wb = TypedBuffer::from_f32(&[2, 2], weights);
+        let mut yb = TypedBuffer::zeros(&[2, 2], DType::F32);
+        moe_ffn(
+            &op,
+            &x_buf.as_view(),
+            &ib.as_view(),
+            &wb.as_view(),
+            &gu_buf.as_view(),
+            None,
+            &wd_buf.as_view(),
+            None,
+            None,
+            &mut yb.as_view_mut(),
+        )
+        .unwrap();
+        yb.to_f32_vec()
+    };
+    // Token 0 -> expert 1 twice (0.5 + 0.5); token 1 -> expert 0 once + expert 1 zero-weighted.
+    let y_dup = run(&[1, 1, 0, 1], &[0.5, 0.5, 1.0, 0.0]);
+    let y_single = run(&[1, 0, 0, 1], &[1.0, 0.0, 1.0, 0.0]);
+    assert_eq!(y_dup, y_single);
+}
+
+#[test]
+fn shared_experts_ignored_for_compute_but_bounded() {
+    let x_buf = TypedBuffer::from_f16(&[1, 2], &[f32_to_f16(1.0), f32_to_f16(0.0)]);
+    let ids_buf = TypedBuffer::from_u32(&[1, 1], &[0]);
+    let wgt_buf = TypedBuffer::from_f32(&[1, 1], &[1.0]);
+    let gu_buf = TypedBuffer::from_bytes(
+        &[1, 4, 2],
+        DType::F16,
+        &f16_bytes(&[2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0]),
+    );
+    let wd_buf = TypedBuffer::from_bytes(&[1, 2, 2], DType::F16, &f16_bytes(&[6.0, 7.0, 8.0, 9.0]));
+    let run = |shared: u32| {
+        let op = MoeFfnOp {
+            act: ActivationKind::Identity,
+            out_dtype: DType::F32,
+            shared_experts: shared,
+        };
+        let mut yb = TypedBuffer::zeros(&[1, 2], DType::F32);
+        moe_ffn(
+            &op,
+            &x_buf.as_view(),
+            &ids_buf.as_view(),
+            &wgt_buf.as_view(),
+            &gu_buf.as_view(),
+            None,
+            &wd_buf.as_view(),
+            None,
+            None,
+            &mut yb.as_view_mut(),
+        )
+        .map(|()| yb.to_f32_vec())
+    };
+    assert_eq!(run(0).unwrap(), vec![153.0, 199.0]);
+    assert_eq!(run(1).unwrap(), vec![153.0, 199.0]);
+    let err = run(2).unwrap_err();
+    assert!(matches!(
+        err,
+        T0Error::InvalidAttribute {
+            op: "moe_ffn",
+            attribute: "shared_experts",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn expert_id_out_of_range_collected_before_mutation() {
+    let op = ffn_op(ActivationKind::Silu);
+    let x_buf = TypedBuffer::from_f16(&[2, 2], &[f32_to_f16(0.5); 4]);
+    let ids_buf = TypedBuffer::from_u32(&[2, 2], &[0, 7, 9, 1]);
+    let wgt_buf = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let gu_buf = TypedBuffer::from_bytes(&[2, 4, 2], DType::F16, &[0u8; 2 * 4 * 2 * 2]);
+    let wd_buf = TypedBuffer::from_bytes(&[2, 2, 2], DType::F16, &[0u8; 2 * 2 * 2 * 2]);
+    let mut y_buf = TypedBuffer::from_f32(&[2, 2], &[99.0; 4]);
+    let err = moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    match err {
+        T0Error::Multiple { problems } => assert_eq!(problems.len(), 2),
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+    // y untouched.
+    assert_eq!(y_buf.to_f32_vec(), vec![99.0; 4]);
+}
+
+#[test]
+fn unused_expert_with_no_tokens_is_skipped() {
+    // E=3, expert 2 receives no tokens: still exact zeros for its absence.
+    let op = ffn_op(ActivationKind::Identity);
+    let x_buf = TypedBuffer::from_f16(
+        &[2, 2],
+        &[
+            f32_to_f16(1.0),
+            f32_to_f16(0.0),
+            f32_to_f16(0.0),
+            f32_to_f16(1.0),
+        ],
+    );
+    let ids_buf = TypedBuffer::from_u32(&[2, 1], &[0, 1]);
+    let wgt_buf = TypedBuffer::from_f32(&[2, 1], &[1.0, 1.0]);
+    let mut gu_vals = vec![0.0f32; 3 * 4 * 2];
+    for v in gu_vals.iter_mut() {
+        *v = 0.25;
+    }
+    let mut wd_vals = vec![0.0f32; 3 * 2 * 2];
+    for v in wd_vals.iter_mut() {
+        *v = 0.5;
+    }
+    let gu_buf = TypedBuffer::from_bytes(&[3, 4, 2], DType::F16, &f16_bytes(&gu_vals));
+    let wd_buf = TypedBuffer::from_bytes(&[3, 2, 2], DType::F16, &f16_bytes(&wd_vals));
+    let mut y_buf = TypedBuffer::zeros(&[2, 2], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    // gate = 0.25+0 = 0.25 (x row [1,0]); up same; h = 0.0625 each of 2;
+    // y = 0.0625*0.5 + 0.0625*0.5 = 0.0625 per channel.
+    let tol = Tolerance::f32();
+    for (i, &v) in y_buf.to_f32_vec().iter().enumerate() {
+        tol.assert_within(v as f64, 0.0625, &format!("y[{i}]"));
+    }
+}
+
+#[test]
+fn determinism_and_batch_invariance() {
+    let mut rng = SeededRng::new(0x3F9);
+    let (t, dm, dff, e, k) = (5, 4, 6, 3, 2);
+    let x: Vec<u16> = (0..t * dm)
+        .map(|_| f32_to_f16(next_f32(&mut rng, -1.0, 1.0)))
+        .collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let ids: Vec<u32> = (0..t * k).map(|i| (i as u32 * 5 + 2) % e as u32).collect();
+    let weights: Vec<f32> = (0..t * k).map(|_| next_f32(&mut rng, 0.1, 1.0)).collect();
+    let run = |xr: &[u16], ir: &[u32], wr: &[f32], tt: usize| {
+        let op = ffn_op(ActivationKind::Silu);
+        let xb = TypedBuffer::from_f16(&[tt, dm], xr);
+        let ib = TypedBuffer::from_u32(&[tt, k], ir);
+        let wb = TypedBuffer::from_f32(&[tt, k], wr);
+        let gb = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+        let db = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &f16_bytes(&wd));
+        let mut yb = TypedBuffer::zeros(&[tt, dm], DType::F32);
+        moe_ffn(
+            &op,
+            &xb.as_view(),
+            &ib.as_view(),
+            &wb.as_view(),
+            &gb.as_view(),
+            None,
+            &db.as_view(),
+            None,
+            None,
+            &mut yb.as_view_mut(),
+        )
+        .unwrap();
+        yb.to_f32_vec()
+    };
+    let y1 = run(&x, &ids, &weights, t);
+    let y2 = run(&x, &ids, &weights, t);
+    assert_eq!(y1, y2);
+    // Row 2 alone.
+    let xrow = x[2 * dm..3 * dm].to_vec();
+    let irow = ids[2 * k..3 * k].to_vec();
+    let wrow = weights[2 * k..3 * k].to_vec();
+    let yrow = run(&xrow, &irow, &wrow, 1);
+    assert_eq!(yrow, y1[2 * dm..3 * dm]);
+}
+
+/// Runs `moe_ffn` with F16 gate/up and returns `y`.
+#[allow(clippy::too_many_arguments)]
+fn run_ffn_down(
+    x: &TypedBuffer,
+    ids: &TypedBuffer,
+    wgt: &TypedBuffer,
+    gu: &TypedBuffer,
+    wd: &TypedBuffer,
+    wd_scale: Option<&TypedBuffer>,
+    x_scale: Option<&TypedBuffer>,
+    t: usize,
+    dm: usize,
+) -> Vec<f32> {
+    let op = ffn_op(ActivationKind::Silu);
+    let mut yb = TypedBuffer::zeros(&[t, dm], DType::F32);
+    let wd_s = wd_scale.map(|s| s.as_view());
+    let x_s = x_scale.map(|s| s.as_view());
+    moe_ffn(
+        &op,
+        &x.as_view(),
+        &ids.as_view(),
+        &wgt.as_view(),
+        &gu.as_view(),
+        None,
+        &wd.as_view(),
+        wd_s.as_ref(),
+        x_s.as_ref(),
+        &mut yb.as_view_mut(),
+    )
+    .unwrap();
+    yb.to_f32_vec()
+}
+
+#[test]
+fn i8b128_down_inline_separate_and_attached_match_f64() {
+    // Blocker 2: I8B128 down-projection via the canonical encoder, in all
+    // three scale-carrier forms. E=1, T=2, Dm=4, Dff=128 (one block/row).
+    let mut rng = SeededRng::new(0x1B28);
+    let (t, dm, dff, e, k) = (2usize, 4usize, 128usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    // One canonical block per down row.
+    let mut q_all = Vec::with_capacity(n_rows * dff);
+    let mut s_all = Vec::with_capacity(n_rows);
+    for r in 0..n_rows {
+        let row: Vec<f32> = (0..dff)
+            .map(|_| next_f32(&mut rng, -0.5, 0.5) + (r as f32) * 0.01)
+            .collect();
+        let (q, sc) = encode_i8_block128(&row).unwrap();
+        q_all.extend_from_slice(&q);
+        s_all.extend_from_slice(&sc);
+    }
+    let wd_dec: Vec<f64> = q_all
+        .iter()
+        .enumerate()
+        .map(|(i, &q)| q as f64 * f16_to_f32(s_all[i / dff].bits()) as f64)
+        .collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.7f32, 1.3];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    // Inline: values + trailing f16 block scale per row.
+    let mut inline_bytes = vec![0u8; n_rows * (dff + 2)];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            inline_bytes[r * (dff + 2) + c] = q_all[r * dff + c] as u8;
+        }
+        inline_bytes[r * (dff + 2) + dff..r * (dff + 2) + dff + 2]
+            .copy_from_slice(&s_all[r].to_bytes());
+    }
+    let wd_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &inline_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+    // Separate explicit carrier: values + [n_rows, 1] F16 view.
+    let mut values_bytes = vec![0u8; n_rows * dff];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            values_bytes[r * dff + c] = q_all[r * dff + c] as u8;
+        }
+    }
+    let mut scale_bytes = vec![0u8; n_rows * 2];
+    for r in 0..n_rows {
+        scale_bytes[r * 2..r * 2 + 2].copy_from_slice(&s_all[r].to_bytes());
+    }
+    let wd_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &values_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+    let wd_scale = TypedBuffer::from_bytes(&[n_rows, 1], DType::F16, &scale_bytes);
+    // Attached carrier: same values buffer with the scale view attached.
+    let wd_attached = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &values_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+
+    let tol = Tolerance::i8_weight();
+    let y_inline = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_inline, None, None, t, dm,
+    );
+    let y_sep = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_values,
+        Some(&wd_scale),
+        None,
+        t,
+        dm,
+    );
+    // Attached resolution: pass None and attach via with_scale.
+    let attached_view = wd_attached.as_view().with_scale(wd_scale.as_view());
+    let op = ffn_op(ActivationKind::Silu);
+    let mut yb = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &attached_view,
+        None,
+        None,
+        &mut yb.as_view_mut(),
+    )
+    .unwrap();
+    let y_att = yb.to_f32_vec();
+    for (name, y) in [
+        ("inline", y_inline),
+        ("separate", y_sep),
+        ("attached", y_att),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("i8b128 {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn i4k_down_inline_and_separate_match_f64() {
+    // Blocker 2: I4K down-projection via the canonical superblock encoder,
+    // inline and separate carriers. E=1, T=2, Dm=2, Dff=256. Nibble parity
+    // is even-index-low, matching the T0 decode.
+    let mut rng = SeededRng::new(0x14B4);
+    let (t, dm, dff, e, k) = (2usize, 2usize, 256usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let mut nibbles = vec![0u8; n_rows * dff];
+    let mut headers = Vec::with_capacity(n_rows);
+    for r in 0..n_rows {
+        let mut row = [0.0f32; 256];
+        for v in row.iter_mut().take(dff) {
+            *v = next_f32(&mut rng, -0.5, 0.5);
+        }
+        let (q, header) = encode_i4k_superblock(&row).unwrap();
+        for c in 0..dff {
+            nibbles[r * dff + c] = q[c];
+        }
+        headers.push(header);
+    }
+    // Pack even-low nibbles.
+    let mut packed = vec![0u8; n_rows * dff / 2];
+    for r in 0..n_rows {
+        for c in 0..dff / 2 {
+            packed[r * dff / 2 + c] =
+                (nibbles[r * dff + 2 * c] & 0x0F) | ((nibbles[r * dff + 2 * c + 1] & 0x0F) << 4);
+        }
+    }
+    // f64 decode mirroring the T0 zero-point form.
+    let mut wd_dec = vec![0.0f64; n_rows * dff];
+    for r in 0..n_rows {
+        let h = &headers[r];
+        let d = h.d_value(0).unwrap() as f64;
+        let dmin = h.dmin_value(0).unwrap() as f64;
+        let sc = h.scales();
+        let mn = h.mins();
+        for c in 0..dff {
+            let sub = (c % 256) / 32;
+            let s_block = d * sc[sub] as f64;
+            let m_block = dmin * mn[sub] as f64;
+            wd_dec[r * dff + c] = s_block * nibbles[r * dff + c] as f64 - m_block;
+        }
+    }
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.8f32, 0.6];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    // Inline: packed values + 16-byte header per row.
+    let mut inline_bytes = vec![0u8; n_rows * (dff / 2 + 16)];
+    for r in 0..n_rows {
+        inline_bytes[r * (dff / 2 + 16)..r * (dff / 2 + 16) + dff / 2]
+            .copy_from_slice(&packed[r * dff / 2..(r + 1) * dff / 2]);
+        inline_bytes[r * (dff / 2 + 16) + dff / 2..(r + 1) * (dff / 2 + 16)]
+            .copy_from_slice(&headers[r].to_bytes());
+    }
+    let wd_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::I4, &inline_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()));
+    // Separate: packed values + [n_rows, 1, 4] U32 header view.
+    let wd_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::I4, &packed)
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()));
+    let mut header_bytes = vec![0u8; n_rows * 16];
+    for r in 0..n_rows {
+        header_bytes[r * 16..(r + 1) * 16].copy_from_slice(&headers[r].to_bytes());
+    }
+    let wd_scale = TypedBuffer::from_bytes(&[n_rows, 1, 4], DType::U32, &header_bytes);
+
+    let tol = Tolerance::i8_weight();
+    for (name, y) in [
+        (
+            "inline",
+            run_ffn_down(
+                &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_inline, None, None, t, dm,
+            ),
+        ),
+        (
+            "separate",
+            run_ffn_down(
+                &x_buf,
+                &ids_buf,
+                &wgt_buf,
+                &gu_buf,
+                &wd_values,
+                Some(&wd_scale),
+                None,
+                t,
+                dm,
+            ),
+        ),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("i4k {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn e4m3b128_down_inline_and_separate_match_f64() {
+    // Blocker 2: E4M3B128 down-projection via the canonical block encoder.
+    // E=1, T=2, Dm=4, Dff=128.
+    let mut rng = SeededRng::new(0xE4B3);
+    let (t, dm, dff, e, k) = (2usize, 4usize, 128usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let mut q_all = Vec::with_capacity(n_rows * dff);
+    let mut s_all = Vec::with_capacity(n_rows);
+    for _ in 0..n_rows {
+        let row: Vec<f32> = (0..dff).map(|_| next_f32(&mut rng, -2.0, 2.0)).collect();
+        let (q, sc) = encode_e4m3_block128(&row).unwrap();
+        q_all.extend(q.iter().map(|v| v.bits()));
+        s_all.extend_from_slice(&sc);
+    }
+    let wd_dec: Vec<f64> = q_all
+        .iter()
+        .enumerate()
+        .map(|(i, &qb)| E4m3::new(qb).to_f32() as f64 * f16_to_f32(s_all[i / dff].bits()) as f64)
+        .collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.9f32, 1.1];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    let mut inline_bytes = vec![0u8; n_rows * (dff + 2)];
+    for r in 0..n_rows {
+        inline_bytes[r * (dff + 2)..r * (dff + 2) + dff]
+            .copy_from_slice(&q_all[r * dff..(r + 1) * dff]);
+        inline_bytes[r * (dff + 2) + dff..r * (dff + 2) + dff + 2]
+            .copy_from_slice(&s_all[r].to_bytes());
+    }
+    let wd_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::E4m3, &inline_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::E4M3B128.to_ir()));
+    let mut values_bytes = vec![0u8; n_rows * dff];
+    values_bytes.copy_from_slice(&q_all);
+    let wd_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::E4m3, &values_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::E4M3B128.to_ir()));
+    let mut scale_bytes = vec![0u8; n_rows * 2];
+    for r in 0..n_rows {
+        scale_bytes[r * 2..r * 2 + 2].copy_from_slice(&s_all[r].to_bytes());
+    }
+    let wd_scale = TypedBuffer::from_bytes(&[n_rows, 1], DType::F16, &scale_bytes);
+
+    let tol = Tolerance::e4m3_cache();
+    for (name, y) in [
+        (
+            "inline",
+            run_ffn_down(
+                &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_inline, None, None, t, dm,
+            ),
+        ),
+        (
+            "separate",
+            run_ffn_down(
+                &x_buf,
+                &ids_buf,
+                &wgt_buf,
+                &gu_buf,
+                &wd_values,
+                Some(&wd_scale),
+                None,
+                t,
+                dm,
+            ),
+        ),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("e4m3 {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn l1_f16_experts_match_l0_bits_and_f64_oracle() {
+    // Blocker 2: L1 flattened expert layout via the canonical tile
+    // permutation, for both gate/up and down matrices. E=1, T=2, Dm=16,
+    // Dff=16 (tile-aligned so padded == logical).
+    let mut rng = SeededRng::new(0x5119);
+    let (t, dm, dff, e, k) = (2usize, 16usize, 16usize, 1usize, 1usize);
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let gu16: Vec<u16> = gu.iter().map(|&v| f32_to_f16(v)).collect();
+    let wd16: Vec<u16> = wd.iter().map(|&v| f32_to_f16(v)).collect();
+    let gu_dec: Vec<f64> = gu16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let wd_dec: Vec<f64> = wd16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.6f32, 1.4];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    // L0 reference buffers.
+    let gu_l0 = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &encode_halfs_le(&gu16));
+    let wd_l0 = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &encode_halfs_le(&wd16));
+    // L1 tiled buffers over the flattened row spaces.
+    let gu_dims = PaddedDims::new((e * 2 * dff) as u32, dm as u32, Some(16)).unwrap();
+    let wd_dims = PaddedDims::new((e * dm) as u32, dff as u32, Some(16)).unwrap();
+    let gu_l1_bytes = encode_halfs_le(&l1_forward_elems(&gu16, &gu_dims).unwrap());
+    let wd_l1_bytes = encode_halfs_le(&l1_forward_elems(&wd16, &wd_dims).unwrap());
+    let gu_l1 = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &gu_l1_bytes)
+        .with_layout(LayoutId::L1);
+    let wd_l1 =
+        TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &wd_l1_bytes).with_layout(LayoutId::L1);
+
+    let y_l0 = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_l0, &wd_l0, None, None, t, dm,
+    );
+    let y_l1 = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_l1, &wd_l1, None, None, t, dm,
+    );
+    // The flattened L1 interpretation is bit-exact with L0 on tile-aligned shapes.
+    assert_eq!(y_l1, y_l0);
+    let tol = Tolerance::f16_bf16();
+    for (i, (&actual, &exp)) in y_l1.iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("l1 y[{i}]"));
+    }
+}
+
+#[test]
+fn l1_i8r_down_inline_and_separate_match_l0_bits_and_f64() {
+    // L1 + I8R down-projection via the canonical A2.1 tiling: values
+    // scattered with `l1_forward_index`, row scales in the SoA tail via
+    // `scale_geometry` record offsets. Non-tile-aligned down shape
+    // (n_rows=6, Dff=20 over E=1, Dm=6) so padding is exercised in both
+    // dims. L0-inline is the bit reference; the f64 oracle decodes the
+    // same logical (q, scale) pairs independently.
+    let mut rng = SeededRng::new(0x1181);
+    let (t, dm, dff, e, k) = (2usize, 6usize, 20usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let q: Vec<i8> = (0..n_rows * dff)
+        .map(|_| (rng.next_u64() % 13) as i8 - 6)
+        .collect();
+    // Distinct per-row scales so the scale path is load-bearing.
+    let scales: Vec<f32> = (0..n_rows).map(|r| 0.1 + 0.05 * r as f32).collect();
+    assert!(
+        scales.windows(2).any(|w| w[0] != w[1]),
+        "row scales must vary"
+    );
+    assert!(q.iter().min() != q.iter().max(), "quant values must vary");
+    let wd_dec: Vec<f64> = q
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| v as f64 * scales[i / dff] as f64)
+        .collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.7f32, 1.3];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    // L0-inline bit reference: values plus trailing f16 row scale per row.
+    let mut l0_bytes = vec![0u8; n_rows * (dff + 2)];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            l0_bytes[r * (dff + 2) + c] = q[r * dff + c] as u8;
+        }
+        l0_bytes[r * (dff + 2) + dff..r * (dff + 2) + dff + 2]
+            .copy_from_slice(&f32_to_f16(scales[r]).to_le_bytes());
+    }
+    let wd_l0 = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &l0_bytes)
+        .with_quant(QuantScheme::PerRow);
+
+    // L1 tiling over the flattened [E*Dm, Dff] row space (canonical A2.1).
+    let sid = SchemeId::I8R;
+    let w_dims = PaddedDims::new(n_rows as u32, dff as u32, Some(16)).unwrap();
+    let geom = scale_geometry(sid, Layout::L1, &w_dims).unwrap();
+    let vals_len = w_dims.n_padded() as usize * w_dims.k_padded() as usize;
+    let mut l1_vals = vec![0u8; vals_len];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            let idx = l1_forward_index(r as u32, c as u32, &w_dims).unwrap() as usize;
+            l1_vals[idx] = q[r * dff + c] as u8;
+        }
+    }
+    let mut soa = vec![0u8; geom.region_bytes as usize];
+    for (r, &scale) in scales.iter().enumerate() {
+        let off = geom
+            .record_offset((r / 16) as u64, 0, (r % 16) as u32)
+            .unwrap() as usize;
+        soa[off..off + 2].copy_from_slice(&f32_to_f16(scale).to_le_bytes());
+    }
+    let mut l1_inline_bytes = l1_vals.clone();
+    l1_inline_bytes.extend_from_slice(&soa);
+    let wd_l1_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &l1_inline_bytes)
+        .with_quant(QuantScheme::PerRow)
+        .with_layout(LayoutId::L1);
+    let wd_l1_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &l1_vals)
+        .with_quant(QuantScheme::PerRow)
+        .with_layout(LayoutId::L1);
+    let wd_l1_scale = TypedBuffer::from_bytes(
+        &[geom.n_blocks as usize, geom.k_blocks as usize, 16],
+        DType::F16,
+        &soa,
+    );
+
+    let y_l0 = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_l0, None, None, t, dm,
+    );
+    let y_l1_inline = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_inline,
+        None,
+        None,
+        t,
+        dm,
+    );
+    let y_l1_sep = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_values,
+        Some(&wd_l1_scale),
+        None,
+        t,
+        dm,
+    );
+    // The tiled L1 interpretation is bit-exact with L0 on the same logical data.
+    assert_eq!(y_l1_inline, y_l0);
+    assert_eq!(y_l1_sep, y_l0);
+    let tol = Tolerance::i8_weight();
+    for (name, y) in [
+        ("l0", y_l0),
+        ("l1-inline", y_l1_inline),
+        ("l1-separate", y_l1_sep),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("l1-i8r {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn l1_i8b128_down_inline_and_separate_match_l0_bits_and_f64() {
+    // L1 + I8B128 down-projection via the canonical A2.1 tiling and SoA
+    // scale records. E=2, Dm=9 gives n_rows=18, spanning two SoA row-blocks
+    // (rows 16-17 land in block 1). L0-inline is the bit reference; the
+    // f64 oracle decodes the canonical encoder output independently.
+    let mut rng = SeededRng::new(0x1B81);
+    let (t, dm, dff, e, k) = (3usize, 9usize, 128usize, 2usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    // One canonical block per down row (Dff=128).
+    let mut q_all = Vec::with_capacity(n_rows * dff);
+    let mut s_all = Vec::with_capacity(n_rows);
+    for r in 0..n_rows {
+        let row: Vec<f32> = (0..dff)
+            .map(|_| next_f32(&mut rng, -0.5, 0.5) + (r as f32) * 0.01)
+            .collect();
+        let (qq, sc) = encode_i8_block128(&row).unwrap();
+        q_all.extend_from_slice(&qq);
+        s_all.extend_from_slice(&sc);
+    }
+    // Scales must vary across rows so the SoA path is load-bearing.
+    let s0 = s_all[0].bits();
+    assert!(
+        s_all.iter().any(|s| s.bits() != s0),
+        "block scales must vary across rows"
+    );
+    let wd_dec: Vec<f64> = q_all
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| v as f64 * f16_to_f32(s_all[i / dff].bits()) as f64)
+        .collect();
+    let ids = vec![0u32, 1, 0];
+    let weights = vec![0.7f32, 1.1, 0.9];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    // L0-inline bit reference.
+    let mut l0_bytes = vec![0u8; n_rows * (dff + 2)];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            l0_bytes[r * (dff + 2) + c] = q_all[r * dff + c] as u8;
+        }
+        l0_bytes[r * (dff + 2) + dff..r * (dff + 2) + dff + 2]
+            .copy_from_slice(&s_all[r].to_bytes());
+    }
+    let wd_l0 = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &l0_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+
+    // L1 tiling over the flattened [E*Dm, Dff] row space (canonical A2.1).
+    let sid = SchemeId::I8B128;
+    let w_dims = PaddedDims::new(n_rows as u32, dff as u32, Some(128)).unwrap();
+    let geom = scale_geometry(sid, Layout::L1, &w_dims).unwrap();
+    let vals_len = w_dims.n_padded() as usize * w_dims.k_padded() as usize;
+    let mut l1_vals = vec![0u8; vals_len];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            let idx = l1_forward_index(r as u32, c as u32, &w_dims).unwrap() as usize;
+            l1_vals[idx] = q_all[r * dff + c] as u8;
+        }
+    }
+    let mut soa = vec![0u8; geom.region_bytes as usize];
+    for (r, s) in s_all.iter().enumerate() {
+        let off = geom
+            .record_offset((r / 16) as u64, 0, (r % 16) as u32)
+            .unwrap() as usize;
+        soa[off..off + 2].copy_from_slice(&s.to_bytes());
+    }
+    let mut l1_inline_bytes = l1_vals.clone();
+    l1_inline_bytes.extend_from_slice(&soa);
+    let wd_l1_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &l1_inline_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()))
+        .with_layout(LayoutId::L1);
+    let wd_l1_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::I8, &l1_vals)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()))
+        .with_layout(LayoutId::L1);
+    let wd_l1_scale = TypedBuffer::from_bytes(
+        &[geom.n_blocks as usize, geom.k_blocks as usize, 16],
+        DType::F16,
+        &soa,
+    );
+
+    let y_l0 = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_l0, None, None, t, dm,
+    );
+    let y_l1_inline = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_inline,
+        None,
+        None,
+        t,
+        dm,
+    );
+    let y_l1_sep = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_values,
+        Some(&wd_l1_scale),
+        None,
+        t,
+        dm,
+    );
+    assert_eq!(y_l1_inline, y_l0);
+    assert_eq!(y_l1_sep, y_l0);
+    let tol = Tolerance::i8_weight();
+    for (name, y) in [
+        ("l0", y_l0),
+        ("l1-inline", y_l1_inline),
+        ("l1-separate", y_l1_sep),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("l1-i8b128 {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn l1_e4m3b128_down_inline_and_separate_match_l0_bits_and_f64() {
+    // L1 + E4M3B128 down-projection via the canonical A2.1 tiling and SoA
+    // scale records. L0-inline is the bit reference; the f64 oracle
+    // decodes the canonical encoder output independently.
+    let mut rng = SeededRng::new(0xE481);
+    let (t, dm, dff, e, k) = (2usize, 4usize, 128usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let mut q_all = Vec::with_capacity(n_rows * dff);
+    let mut s_all = Vec::with_capacity(n_rows);
+    for _ in 0..n_rows {
+        let row: Vec<f32> = (0..dff).map(|_| next_f32(&mut rng, -2.0, 2.0)).collect();
+        let (qq, sc) = encode_e4m3_block128(&row).unwrap();
+        q_all.extend(qq.iter().map(|v| v.bits()));
+        s_all.extend_from_slice(&sc);
+    }
+    let s0 = s_all[0].bits();
+    assert!(
+        s_all.iter().any(|s| s.bits() != s0),
+        "block scales must vary across rows"
+    );
+    let wd_dec: Vec<f64> = q_all
+        .iter()
+        .enumerate()
+        .map(|(i, &qb)| E4m3::new(qb).to_f32() as f64 * f16_to_f32(s_all[i / dff].bits()) as f64)
+        .collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.9f32, 1.1];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    // L0-inline bit reference.
+    let mut l0_bytes = vec![0u8; n_rows * (dff + 2)];
+    for r in 0..n_rows {
+        l0_bytes[r * (dff + 2)..r * (dff + 2) + dff]
+            .copy_from_slice(&q_all[r * dff..(r + 1) * dff]);
+        l0_bytes[r * (dff + 2) + dff..r * (dff + 2) + dff + 2]
+            .copy_from_slice(&s_all[r].to_bytes());
+    }
+    let wd_l0 = TypedBuffer::from_bytes(&[e, dm, dff], DType::E4m3, &l0_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::E4M3B128.to_ir()));
+
+    // L1 tiling over the flattened [E*Dm, Dff] row space (canonical A2.1).
+    let sid = SchemeId::E4M3B128;
+    let w_dims = PaddedDims::new(n_rows as u32, dff as u32, Some(128)).unwrap();
+    let geom = scale_geometry(sid, Layout::L1, &w_dims).unwrap();
+    let vals_len = w_dims.n_padded() as usize * w_dims.k_padded() as usize;
+    let mut l1_vals = vec![0u8; vals_len];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            let idx = l1_forward_index(r as u32, c as u32, &w_dims).unwrap() as usize;
+            l1_vals[idx] = q_all[r * dff + c];
+        }
+    }
+    let mut soa = vec![0u8; geom.region_bytes as usize];
+    for (r, s) in s_all.iter().enumerate() {
+        let off = geom
+            .record_offset((r / 16) as u64, 0, (r % 16) as u32)
+            .unwrap() as usize;
+        soa[off..off + 2].copy_from_slice(&s.to_bytes());
+    }
+    let mut l1_inline_bytes = l1_vals.clone();
+    l1_inline_bytes.extend_from_slice(&soa);
+    let wd_l1_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::E4m3, &l1_inline_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::E4M3B128.to_ir()))
+        .with_layout(LayoutId::L1);
+    let wd_l1_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::E4m3, &l1_vals)
+        .with_quant(QuantScheme::Scheme(SchemeId::E4M3B128.to_ir()))
+        .with_layout(LayoutId::L1);
+    let wd_l1_scale = TypedBuffer::from_bytes(
+        &[geom.n_blocks as usize, geom.k_blocks as usize, 16],
+        DType::F16,
+        &soa,
+    );
+
+    let y_l0 = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_l0, None, None, t, dm,
+    );
+    let y_l1_inline = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_inline,
+        None,
+        None,
+        t,
+        dm,
+    );
+    let y_l1_sep = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_values,
+        Some(&wd_l1_scale),
+        None,
+        t,
+        dm,
+    );
+    assert_eq!(y_l1_inline, y_l0);
+    assert_eq!(y_l1_sep, y_l0);
+    let tol = Tolerance::e4m3_cache();
+    for (name, y) in [
+        ("l0", y_l0),
+        ("l1-inline", y_l1_inline),
+        ("l1-separate", y_l1_sep),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("l1-e4m3 {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn l1_i4k_down_inline_and_separate_match_l0_bits_and_f64() {
+    // L1 + I4K down-projection via the canonical A2.1 tiling (nibble-packed,
+    // even-index-low) and SoA superblock records. L0-inline is the bit
+    // reference; the f64 oracle uses the independent `s·q−m` formula. The
+    // mixed-nibble assertion keeps parity load-bearing.
+    let mut rng = SeededRng::new(0x14B1);
+    let (t, dm, dff, e, k) = (2usize, 2usize, 256usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let mut nibbles = vec![0u8; n_rows * dff];
+    let mut headers = Vec::with_capacity(n_rows);
+    for r in 0..n_rows {
+        let mut row = [0.0f32; 256];
+        for v in row.iter_mut().take(dff) {
+            *v = next_f32(&mut rng, -0.5, 0.5);
+        }
+        let (qq, header) = encode_i4k_superblock(&row).unwrap();
+        for c in 0..dff {
+            nibbles[r * dff + c] = qq[c];
+        }
+        headers.push(header);
+    }
+    // Nibble parity is load-bearing: the fixture must mix low and high
+    // nibble positions (even-low packing distinguishes them).
+    let mixed = nibbles
+        .iter()
+        .enumerate()
+        .filter(|(i, &v)| v != nibbles[(i + 1) % nibbles.len()])
+        .count();
+    assert!(mixed > 0, "i4k fixture must mix nibble values");
+    assert!(
+        nibbles.iter().min() != nibbles.iter().max(),
+        "i4k nibbles must vary"
+    );
+    // f64 decode mirroring the T0 zero-point form.
+    let mut wd_dec = vec![0.0f64; n_rows * dff];
+    for r in 0..n_rows {
+        let h = &headers[r];
+        let d = h.d_value(0).unwrap() as f64;
+        let dmin = h.dmin_value(0).unwrap() as f64;
+        let sc = h.scales();
+        let mn = h.mins();
+        for c in 0..dff {
+            let sub = (c % 256) / 32;
+            let s_block = d * sc[sub] as f64;
+            let m_block = dmin * mn[sub] as f64;
+            wd_dec[r * dff + c] = s_block * nibbles[r * dff + c] as f64 - m_block;
+        }
+    }
+    let ids = vec![0u32; t * k];
+    let weights = vec![0.8f32, 0.6];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+
+    // L0-inline bit reference: packed values (even-low) plus 16-byte header.
+    let mut packed = vec![0u8; n_rows * dff / 2];
+    for r in 0..n_rows {
+        for c in 0..dff / 2 {
+            packed[r * dff / 2 + c] =
+                (nibbles[r * dff + 2 * c] & 0x0F) | ((nibbles[r * dff + 2 * c + 1] & 0x0F) << 4);
+        }
+    }
+    let mut l0_bytes = vec![0u8; n_rows * (dff / 2 + 16)];
+    for r in 0..n_rows {
+        l0_bytes[r * (dff / 2 + 16)..r * (dff / 2 + 16) + dff / 2]
+            .copy_from_slice(&packed[r * dff / 2..(r + 1) * dff / 2]);
+        l0_bytes[r * (dff / 2 + 16) + dff / 2..(r + 1) * (dff / 2 + 16)]
+            .copy_from_slice(&headers[r].to_bytes());
+    }
+    let wd_l0 = TypedBuffer::from_bytes(&[e, dm, dff], DType::I4, &l0_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()));
+
+    // L1 tiling over the flattened [E*Dm, Dff] row space (canonical A2.1):
+    // element index via `l1_forward_index`, even-low nibble packing.
+    let sid = SchemeId::I4K;
+    let w_dims = PaddedDims::new(n_rows as u32, dff as u32, Some(256)).unwrap();
+    let geom = scale_geometry(sid, Layout::L1, &w_dims).unwrap();
+    let vals_len = w_dims.n_padded() as usize * w_dims.k_padded() as usize / 2;
+    let mut l1_vals = vec![0u8; vals_len];
+    for r in 0..n_rows {
+        for c in 0..dff {
+            let elem = l1_forward_index(r as u32, c as u32, &w_dims).unwrap() as usize;
+            let nib = nibbles[r * dff + c] & 0x0F;
+            if elem.is_multiple_of(2) {
+                l1_vals[elem / 2] |= nib;
+            } else {
+                l1_vals[elem / 2] |= nib << 4;
+            }
+        }
+    }
+    let mut soa = vec![0u8; geom.region_bytes as usize];
+    for (r, h) in headers.iter().enumerate() {
+        let off = geom
+            .record_offset((r / 16) as u64, 0, (r % 16) as u32)
+            .unwrap() as usize;
+        soa[off..off + 16].copy_from_slice(&h.to_bytes());
+    }
+    let mut l1_inline_bytes = l1_vals.clone();
+    l1_inline_bytes.extend_from_slice(&soa);
+    let wd_l1_inline = TypedBuffer::from_bytes(&[e, dm, dff], DType::I4, &l1_inline_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()))
+        .with_layout(LayoutId::L1);
+    let wd_l1_values = TypedBuffer::from_bytes(&[e, dm, dff], DType::I4, &l1_vals)
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()))
+        .with_layout(LayoutId::L1);
+    let wd_l1_scale = TypedBuffer::from_bytes(
+        &[geom.n_blocks as usize, geom.k_blocks as usize, 16, 4],
+        DType::U32,
+        &soa,
+    );
+
+    let y_l0 = run_ffn_down(
+        &x_buf, &ids_buf, &wgt_buf, &gu_buf, &wd_l0, None, None, t, dm,
+    );
+    let y_l1_inline = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_inline,
+        None,
+        None,
+        t,
+        dm,
+    );
+    let y_l1_sep = run_ffn_down(
+        &x_buf,
+        &ids_buf,
+        &wgt_buf,
+        &gu_buf,
+        &wd_l1_values,
+        Some(&wd_l1_scale),
+        None,
+        t,
+        dm,
+    );
+    assert_eq!(y_l1_inline, y_l0);
+    assert_eq!(y_l1_sep, y_l0);
+    let tol = Tolerance::i8_weight();
+    for (name, y) in [
+        ("l0", y_l0),
+        ("l1-inline", y_l1_inline),
+        ("l1-separate", y_l1_sep),
+    ] {
+        for (i, (&actual, &exp)) in y.iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("l1-i4k {name} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn i8r_gate_up_inline_matches_f64_oracle() {
+    // Quantized gate/up matrices forward through `matmul_with_scales`: I8R
+    // inline gate/up with an F16 down projection vs the f64 oracle.
+    let mut rng = SeededRng::new(0x619);
+    let (t, dm, dff, e, k) = (2usize, 8usize, 8usize, 1usize, 1usize);
+    let x: Vec<f32> = (0..t * dm).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let x16: Vec<u16> = x.iter().map(|&v| f32_to_f16(v)).collect();
+    let x64: Vec<f64> = x16.iter().map(|&b| f16_to_f32(b) as f64).collect();
+    let gu_q: Vec<i8> = (0..e * 2 * dff * dm)
+        .map(|_| (rng.next_u64() % 13) as i8 - 6)
+        .collect();
+    let gu_scale = 0.2f32;
+    let gu_bytes = i8r_inline(&gu_q, e * 2 * dff, dm, gu_scale);
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let wd_dec: Vec<f64> = wd
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let gu_dec: Vec<f64> = gu_q.iter().map(|&q| q as f64 * gu_scale as f64).collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![1.0f32, 0.5];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let op = ffn_op(ActivationKind::Silu);
+    let x_buf = TypedBuffer::from_f16(&[t, dm], &x16);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::I8, &gu_bytes)
+        .with_quant(QuantScheme::PerRow);
+    let wd_buf = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &f16_bytes(&wd));
+    let mut y_buf = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("gu-i8r y[{i}]"));
+    }
+}
+
+#[test]
+fn pertoken_activation_matches_f64_oracle() {
+    // PerToken I8 activations with an explicit [T] scale carrier.
+    let mut rng = SeededRng::new(0x9E70);
+    let (t, dm, dff, e, k) = (3usize, 8usize, 8usize, 2usize, 2usize);
+    let x_q: Vec<i8> = (0..t * dm)
+        .map(|_| (rng.next_u64() % 17) as i8 - 8)
+        .collect();
+    let x_s: Vec<f32> = (0..t).map(|_| next_f32(&mut rng, 0.1, 0.5)).collect();
+    let x64: Vec<f64> = x_q
+        .iter()
+        .enumerate()
+        .map(|(i, &q)| q as f64 * x_s[i / dm] as f64)
+        .collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let wd_dec: Vec<f64> = wd
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let ids = vec![0u32, 1, 1, 0, 0, 1];
+    let weights = vec![0.6f32, 0.4, 0.3, 0.7, 0.5, 0.5];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Relu2,
+    )
+    .unwrap();
+
+    let op = MoeFfnOp {
+        act: ActivationKind::Relu2,
+        out_dtype: DType::F32,
+        shared_experts: 0,
+    };
+    let x_buf = TypedBuffer::from_i8(&[t, dm], &x_q).with_quant(QuantScheme::PerToken);
+    let xs_buf = TypedBuffer::from_f32(&[t], &x_s);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+    let wd_buf = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &f16_bytes(&wd));
+    let mut y_buf = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        Some(&xs_buf.as_view()),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("pertoken y[{i}]"));
+    }
+}
+
+#[test]
+fn perblock32_activation_matches_f64_oracle() {
+    // PerBlock32 I8 activations with an explicit [T, Dm/32] scale carrier.
+    let mut rng = SeededRng::new(0xB322);
+    let (t, dm, dff, e, k) = (2usize, 32usize, 8usize, 1usize, 1usize);
+    let x_q: Vec<i8> = (0..t * dm)
+        .map(|_| (rng.next_u64() % 11) as i8 - 5)
+        .collect();
+    let x_s: Vec<f32> = (0..t * dm / 32)
+        .map(|_| next_f32(&mut rng, 0.1, 0.5))
+        .collect();
+    let x64: Vec<f64> = x_q
+        .iter()
+        .enumerate()
+        .map(|(i, &q)| q as f64 * x_s[i / dm] as f64)
+        .collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let wd: Vec<f32> = (0..e * dm * dff)
+        .map(|_| next_f32(&mut rng, -0.25, 0.25))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let wd_dec: Vec<f64> = wd
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![1.0f32, 0.5];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Silu,
+    )
+    .unwrap();
+
+    let op = ffn_op(ActivationKind::Silu);
+    let x_buf = TypedBuffer::from_i8(&[t, dm], &x_q).with_quant(QuantScheme::PerBlock32);
+    let xs_buf = TypedBuffer::from_f32(&[t, dm / 32], &x_s);
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+    let wd_buf = TypedBuffer::from_bytes(&[e, dm, dff], DType::F16, &f16_bytes(&wd));
+    let mut y_buf = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_buf.as_view(),
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_buf.as_view(),
+        None,
+        Some(&xs_buf.as_view()),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("perblock32 y[{i}]"));
+    }
+}
+
+#[test]
+fn attached_i8r_down_and_pertoken_x_resolve_without_explicit_scales() {
+    // Attached carriers: I8R down values with the row-scale view attached to
+    // the weight, and PerToken activation scales attached to `x`; both scale
+    // parameters passed as `None` must resolve through the attached views.
+    let mut rng = SeededRng::new(0xA77);
+    let (t, dm, dff, e, k) = (2usize, 8usize, 8usize, 1usize, 1usize);
+    let n_rows = e * dm;
+    let x_q: Vec<i8> = (0..t * dm)
+        .map(|_| (rng.next_u64() % 13) as i8 - 6)
+        .collect();
+    let x_s: Vec<f32> = vec![0.3, 0.4];
+    let x64: Vec<f64> = x_q
+        .iter()
+        .enumerate()
+        .map(|(i, &q)| q as f64 * x_s[i / dm] as f64)
+        .collect();
+    let gu: Vec<f32> = (0..e * 2 * dff * dm)
+        .map(|_| next_f32(&mut rng, -0.5, 0.5))
+        .collect();
+    let gu_dec: Vec<f64> = gu
+        .iter()
+        .map(|&v| f16_to_f32(f32_to_f16(v)) as f64)
+        .collect();
+    let wd_q: Vec<i8> = (0..n_rows * dff)
+        .map(|_| (rng.next_u64() % 11) as i8 - 5)
+        .collect();
+    let wd_scale = 0.125f32;
+    let wd_dec: Vec<f64> = wd_q.iter().map(|&q| q as f64 * wd_scale as f64).collect();
+    let ids = vec![0u32; t * k];
+    let weights = vec![1.0f32, 0.5];
+    let weights_f64: Vec<f64> = weights.iter().map(|&v| v as f64).collect();
+    let expected = moe_ffn_f64_reference(
+        &x64,
+        t,
+        dm,
+        &ids,
+        &weights_f64,
+        k,
+        &gu_dec,
+        e,
+        dff,
+        &wd_dec,
+        ActivationKind::Identity,
+    )
+    .unwrap();
+
+    let op = ffn_op(ActivationKind::Identity);
+    let xs_buf = TypedBuffer::from_f32(&[t], &x_s);
+    let x_buf = TypedBuffer::from_i8(&[t, dm], &x_q).with_quant(QuantScheme::PerToken);
+    let x_view = x_buf.as_view().with_scale(xs_buf.as_view());
+    let ids_buf = TypedBuffer::from_u32(&[t, k], &ids);
+    let wgt_buf = TypedBuffer::from_f32(&[t, k], &weights);
+    let gu_buf = TypedBuffer::from_bytes(&[e, 2 * dff, dm], DType::F16, &f16_bytes(&gu));
+    // Values-only I8R down rows (no inline scales) with the row scales attached.
+    let wd_values = TypedBuffer::from_bytes(
+        &[e, dm, dff],
+        DType::I8,
+        &wd_q.iter().map(|&q| q as u8).collect::<Vec<u8>>(),
+    )
+    .with_quant(QuantScheme::PerRow);
+    let mut scale_bytes = vec![0u8; n_rows * 2];
+    let sbits = f32_to_f16(wd_scale);
+    for r in 0..n_rows {
+        scale_bytes[r * 2..r * 2 + 2].copy_from_slice(&sbits.to_le_bytes());
+    }
+    let wd_scale_buf = TypedBuffer::from_bytes(&[n_rows], DType::F16, &scale_bytes);
+    let wd_view = wd_values.as_view().with_scale(wd_scale_buf.as_view());
+    let mut y_buf = TypedBuffer::zeros(&[t, dm], DType::F32);
+    moe_ffn(
+        &op,
+        &x_view,
+        &ids_buf.as_view(),
+        &wgt_buf.as_view(),
+        &gu_buf.as_view(),
+        None,
+        &wd_view,
+        None,
+        None,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("attached y[{i}]"));
+    }
+}
+
+#[test]
+fn dispatch_enforces_ffn_arity() {
+    let op = Op::MoeFfn(ffn_op(ActivationKind::Silu));
+    let z = TypedBuffer::zeros(&[1, 2], DType::F32);
+    let mut y = TypedBuffer::zeros(&[1, 2], DType::F32);
+    let four = [z.as_view(), z.as_view(), z.as_view(), z.as_view()];
+    assert!(execute_moe_op(&op, &four, &mut [y.as_view_mut()]).is_err());
+    let five = [
+        z.as_view(),
+        z.as_view(),
+        z.as_view(),
+        z.as_view(),
+        z.as_view(),
+    ];
+    assert!(execute_moe_op(&op, &five, &mut []).is_err());
+}

--- a/crates/r9v-t0/tests/moe_route_tests.rs
+++ b/crates/r9v-t0/tests/moe_route_tests.rs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for scalar T0 `moe_route` (Spec 1 §4.C, §6.1, Card A1.9).
+
+use r9v_common::SeededRng;
+use r9v_ir::{DType, MoeGroup, MoeRouteOp, MoeScoring, Op};
+use r9v_t0::buffer::TypedBuffer;
+use r9v_t0::error::T0Error;
+use r9v_t0::{execute_moe_op, moe_route, moe_route_f64_reference, Tolerance};
+
+fn next_f32(rng: &mut SeededRng, lo: f32, hi: f32) -> f32 {
+    let u = ((rng.next_u64() >> 11) as f64) / (1u64 << 53) as f64;
+    lo + (u as f32) * (hi - lo)
+}
+
+fn route_op(top_k: u32, scoring: MoeScoring, renormalize: bool, scale: f32) -> MoeRouteOp {
+    MoeRouteOp {
+        top_k,
+        scoring,
+        renormalize,
+        group: None,
+        scale,
+    }
+}
+
+#[test]
+fn softmax_renormalized_weights_match_f64_oracle() {
+    let mut rng = SeededRng::new(0xA19);
+    let (t, e, k) = (5, 6, 3);
+    let logits: Vec<f32> = (0..t * e).map(|_| next_f32(&mut rng, -3.0, 3.0)).collect();
+    let logits_f64: Vec<f64> = logits.iter().map(|&v| v as f64).collect();
+    let op = route_op(k as u32, MoeScoring::Softmax, true, 1.7);
+
+    let l_buf = TypedBuffer::from_f32(&[t, e], &logits);
+    let mut ids_buf = TypedBuffer::zeros(&[t, k], DType::U32);
+    let mut w_buf = TypedBuffer::zeros(&[t, k], DType::F32);
+    moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids_buf.as_view_mut(),
+        &mut w_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let (exp_ids, exp_w) = moe_route_f64_reference(
+        &logits_f64,
+        t,
+        e,
+        None,
+        k as u32,
+        MoeScoring::Softmax,
+        true,
+        1.7,
+    )
+    .unwrap();
+    assert_eq!(ids_buf.to_u32_vec(), exp_ids);
+    let tol = Tolerance::f32();
+    for (i, (&actual, &expected)) in w_buf.to_f32_vec().iter().zip(exp_w.iter()).enumerate() {
+        tol.assert_within(actual as f64, expected, &format!("weight {i}"));
+    }
+    // Renormalized rows sum to 1.
+    for row in 0..t {
+        let sum: f32 = w_buf.to_f32_vec()[row * k..(row + 1) * k].iter().sum();
+        tol.assert_within(sum as f64, 1.0, &format!("row {row} sum"));
+    }
+}
+
+#[test]
+fn sigmoid_unrenormalized_weights_match_f64_oracle() {
+    let mut rng = SeededRng::new(0xB19);
+    let (t, e, k) = (4, 5, 2);
+    let logits: Vec<f32> = (0..t * e).map(|_| next_f32(&mut rng, -4.0, 4.0)).collect();
+    let logits_f64: Vec<f64> = logits.iter().map(|&v| v as f64).collect();
+    let op = route_op(k as u32, MoeScoring::Sigmoid, false, 0.5);
+
+    let l_buf = TypedBuffer::from_f32(&[t, e], &logits);
+    let mut ids_buf = TypedBuffer::zeros(&[t, k], DType::U32);
+    let mut w_buf = TypedBuffer::zeros(&[t, k], DType::F32);
+    moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids_buf.as_view_mut(),
+        &mut w_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let (exp_ids, exp_w) = moe_route_f64_reference(
+        &logits_f64,
+        t,
+        e,
+        None,
+        k as u32,
+        MoeScoring::Sigmoid,
+        false,
+        0.5,
+    )
+    .unwrap();
+    assert_eq!(ids_buf.to_u32_vec(), exp_ids);
+    let tol = Tolerance::f32();
+    for (i, (&actual, &expected)) in w_buf.to_f32_vec().iter().zip(exp_w.iter()).enumerate() {
+        tol.assert_within(actual as f64, expected, &format!("weight {i}"));
+    }
+}
+
+#[test]
+fn equal_logits_select_lowest_expert_indices() {
+    let (t, e, k) = (2, 6, 3);
+    let logits = vec![1.0f32; t * e];
+    for scoring in [MoeScoring::Softmax, MoeScoring::Sigmoid] {
+        let op = route_op(k as u32, scoring, true, 1.0);
+        let l_buf = TypedBuffer::from_f32(&[t, e], &logits);
+        let mut ids_buf = TypedBuffer::zeros(&[t, k], DType::U32);
+        let mut w_buf = TypedBuffer::zeros(&[t, k], DType::F32);
+        moe_route(
+            &op,
+            &l_buf.as_view(),
+            None,
+            &mut ids_buf.as_view_mut(),
+            &mut w_buf.as_view_mut(),
+        )
+        .unwrap();
+        assert_eq!(ids_buf.to_u32_vec(), vec![0, 1, 2, 0, 1, 2]);
+    }
+}
+
+#[test]
+fn bias_param_matches_manual_logit_shift() {
+    let mut rng = SeededRng::new(0xC19);
+    let (t, e, k) = (3, 5, 2);
+    let logits: Vec<f32> = (0..t * e).map(|_| next_f32(&mut rng, -2.0, 2.0)).collect();
+    let bias: Vec<f32> = (0..e).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+    let op = route_op(k as u32, MoeScoring::Softmax, true, 2.0);
+
+    let l_buf = TypedBuffer::from_f32(&[t, e], &logits);
+    let b_buf = TypedBuffer::from_f32(&[e], &bias);
+    let mut ids_a = TypedBuffer::zeros(&[t, k], DType::U32);
+    let mut w_a = TypedBuffer::zeros(&[t, k], DType::F32);
+    moe_route(
+        &op,
+        &l_buf.as_view(),
+        Some(&b_buf.as_view()),
+        &mut ids_a.as_view_mut(),
+        &mut w_a.as_view_mut(),
+    )
+    .unwrap();
+
+    let shifted: Vec<f32> = logits
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| v + bias[i % e])
+        .collect();
+    let s_buf = TypedBuffer::from_f32(&[t, e], &shifted);
+    let mut ids_b = TypedBuffer::zeros(&[t, k], DType::U32);
+    let mut w_b = TypedBuffer::zeros(&[t, k], DType::F32);
+    moe_route(
+        &op,
+        &s_buf.as_view(),
+        None,
+        &mut ids_b.as_view_mut(),
+        &mut w_b.as_view_mut(),
+    )
+    .unwrap();
+
+    assert_eq!(ids_a.to_u32_vec(), ids_b.to_u32_vec());
+    assert_eq!(w_a.to_f32_vec(), w_b.to_f32_vec());
+}
+
+#[test]
+fn run_twice_bit_identical() {
+    let mut rng = SeededRng::new(0xD19);
+    let (t, e, k) = (6, 8, 4);
+    let logits: Vec<f32> = (0..t * e).map(|_| next_f32(&mut rng, -5.0, 5.0)).collect();
+    let op = route_op(k as u32, MoeScoring::Softmax, true, 1.0);
+    let l_buf = TypedBuffer::from_f32(&[t, e], &logits);
+    let run = || {
+        let mut ids = TypedBuffer::zeros(&[t, k], DType::U32);
+        let mut w = TypedBuffer::zeros(&[t, k], DType::F32);
+        moe_route(
+            &op,
+            &l_buf.as_view(),
+            None,
+            &mut ids.as_view_mut(),
+            &mut w.as_view_mut(),
+        )
+        .unwrap();
+        (ids.to_u32_vec(), w.to_f32_vec())
+    };
+    let (ids1, w1) = run();
+    let (ids2, w2) = run();
+    assert_eq!(ids1, ids2);
+    assert_eq!(w1, w2);
+}
+
+#[test]
+fn token_rows_batch_invariant_alone_padded_embedded() {
+    // One fixed row must route identically alone, padded, and embedded.
+    let target = vec![0.5f32, -1.2, 2.1, 0.0, -0.3, 1.4];
+    let (e, k) = (6, 2);
+    let op = route_op(k as u32, MoeScoring::Softmax, false, 1.0);
+    let route_row = |rows: &[f32]| {
+        let t = rows.len() / e;
+        let buf = TypedBuffer::from_f32(&[t, e], rows);
+        let mut ids = TypedBuffer::zeros(&[t, k], DType::U32);
+        let mut w = TypedBuffer::zeros(&[t, k], DType::F32);
+        moe_route(
+            &op,
+            &buf.as_view(),
+            None,
+            &mut ids.as_view_mut(),
+            &mut w.as_view_mut(),
+        )
+        .unwrap();
+        (ids.to_u32_vec(), w.to_f32_vec())
+    };
+    let mut rng = SeededRng::new(0xE19);
+    let noise: Vec<f32> = (0..4 * e).map(|_| next_f32(&mut rng, -3.0, 3.0)).collect();
+
+    let (ids_alone, w_alone) = route_row(&target);
+    let mut padded = target.clone();
+    padded.extend_from_slice(&vec![0.0; 3 * e]);
+    let (ids_padded, w_padded) = route_row(&padded);
+    let mut embedded = noise[..2 * e].to_vec();
+    embedded.extend_from_slice(&target);
+    embedded.extend_from_slice(&noise[2 * e..]);
+    let (ids_emb, w_emb) = route_row(&embedded);
+
+    assert_eq!(&ids_alone[..k], &ids_padded[..k]);
+    assert_eq!(&w_alone[..k], &w_padded[..k]);
+    assert_eq!(&ids_alone[..k], &ids_emb[2 * k..3 * k]);
+    assert_eq!(&w_alone[..k], &w_emb[2 * k..3 * k]);
+}
+
+#[test]
+fn grouped_routing_fails_closed() {
+    let op = MoeRouteOp {
+        top_k: 2,
+        scoring: MoeScoring::Softmax,
+        renormalize: true,
+        group: Some(MoeGroup {
+            n_group: 2,
+            topk_group: 1,
+        }),
+        scale: 1.0,
+    };
+    let l_buf = TypedBuffer::from_f32(&[2, 4], &[0.1; 8]);
+    let mut ids = TypedBuffer::zeros(&[2, 2], DType::U32);
+    let mut w = TypedBuffer::zeros(&[2, 2], DType::F32);
+    let err = moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids.as_view_mut(),
+        &mut w.as_view_mut(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        T0Error::InvalidAttribute {
+            op: "moe_route",
+            attribute: "group",
+            ..
+        }
+    ));
+    // Outputs untouched on refusal.
+    assert_eq!(ids.to_u32_vec(), vec![0; 4]);
+    assert_eq!(w.to_f32_vec(), vec![0.0; 4]);
+}
+
+#[test]
+fn nonfinite_logits_collected_with_locations() {
+    let op = route_op(2, MoeScoring::Softmax, true, 1.0);
+    let mut logits = vec![0.1f32; 3 * 4];
+    logits[6] = f32::NAN; // (t=1, e=2)
+    logits[8] = f32::INFINITY; // (t=2, e=0)
+    let l_buf = TypedBuffer::from_f32(&[3, 4], &logits);
+    let mut ids = TypedBuffer::zeros(&[3, 2], DType::U32);
+    let mut w = TypedBuffer::zeros(&[3, 2], DType::F32);
+    let err = moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids.as_view_mut(),
+        &mut w.as_view_mut(),
+    )
+    .unwrap_err();
+    match err {
+        T0Error::Multiple { problems } => {
+            assert_eq!(problems.len(), 2);
+            let text = format!("{problems:?}");
+            assert!(text.contains("(t=1, e=2)"));
+            assert!(text.contains("(t=2, e=0)"));
+        }
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+    assert_eq!(ids.to_u32_vec(), vec![0; 6]);
+}
+
+#[test]
+fn sigmoid_renormalize_degenerate_zero_sum_refuses_before_mutation() {
+    // Blocker 1: all-`-1000.0` finite logits pass input validation, but the
+    // sigmoid arm scores every expert `0.0`, so the selected-K sum is `0.0`
+    // and renormalizing would emit `NaN` weights. Must refuse with a typed
+    // error naming the row, leaving both outputs untouched.
+    let (t, e, k) = (3, 4, 2);
+    let op = route_op(k as u32, MoeScoring::Sigmoid, true, 1.0);
+    let l_buf = TypedBuffer::from_f32(&[t, e], &vec![-1000.0f32; t * e]);
+    let mut ids = TypedBuffer::zeros(&[t, k], DType::U32);
+    let mut w = TypedBuffer::zeros(&[t, k], DType::F32);
+    let err = moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids.as_view_mut(),
+        &mut w.as_view_mut(),
+    )
+    .unwrap_err();
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("selected-K sum") && text.contains("SI-51"),
+        "expected zero-sum refusal, got {err:?}"
+    );
+    // Neither output mutated.
+    assert_eq!(ids.to_u32_vec(), vec![0; t * k]);
+    assert_eq!(w.to_f32_vec(), vec![0.0; t * k]);
+}
+
+#[test]
+fn sigmoid_renormalize_healthy_row_still_passes() {
+    // The zero-sum guard must not fire on ordinary finite rows.
+    let op = route_op(2, MoeScoring::Sigmoid, true, 1.0);
+    let l_buf = TypedBuffer::from_f32(&[2, 4], &[0.5, -0.2, 1.1, 0.0, -0.7, 0.3, 0.9, -1.5]);
+    let mut ids = TypedBuffer::zeros(&[2, 2], DType::U32);
+    let mut w = TypedBuffer::zeros(&[2, 2], DType::F32);
+    moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids.as_view_mut(),
+        &mut w.as_view_mut(),
+    )
+    .unwrap();
+    for v in w.to_f32_vec() {
+        assert!(v.is_finite());
+    }
+}
+
+#[test]
+fn post_bias_overflow_to_nonfinite_refuses_before_mutation() {
+    // Finite logits + finite bias whose f32 sum overflows to `+Inf` must be
+    // rejected as a non-finite post-bias score, not sorted into NaN weights.
+    let (t, e, k) = (2, 3, 2);
+    let op = route_op(k as u32, MoeScoring::Softmax, false, 1.0);
+    let l_buf = TypedBuffer::from_f32(&[t, e], &vec![2.0e38f32; t * e]);
+    let b_buf = TypedBuffer::from_f32(&[e], &vec![2.0e38f32; e]);
+    let mut ids = TypedBuffer::zeros(&[t, k], DType::U32);
+    let mut w = TypedBuffer::zeros(&[t, k], DType::F32);
+    let err = moe_route(
+        &op,
+        &l_buf.as_view(),
+        Some(&b_buf.as_view()),
+        &mut ids.as_view_mut(),
+        &mut w.as_view_mut(),
+    )
+    .unwrap_err();
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("post-bias score") && text.contains("SI-51"),
+        "expected post-bias refusal, got {err:?}"
+    );
+    assert_eq!(ids.to_u32_vec(), vec![0; t * k]);
+    assert_eq!(w.to_f32_vec(), vec![0.0; t * k]);
+}
+
+#[test]
+fn simultaneous_defects_report_single_multiple() {
+    let op = route_op(2, MoeScoring::Softmax, true, 1.0);
+    let l_buf = TypedBuffer::from_f32(&[3], &[0.1; 3]);
+    let mut ids = TypedBuffer::zeros(&[3, 2], DType::F32);
+    let mut w = TypedBuffer::zeros(&[3, 2], DType::F32);
+    let err = moe_route(
+        &op,
+        &l_buf.as_view(),
+        None,
+        &mut ids.as_view_mut(),
+        &mut w.as_view_mut(),
+    )
+    .unwrap_err();
+    match err {
+        T0Error::Multiple { problems } => assert!(problems.len() >= 2),
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+}
+
+#[test]
+fn dispatch_enforces_route_arity() {
+    let op = Op::MoeRoute(route_op(2, MoeScoring::Softmax, true, 1.0));
+    let l_buf = TypedBuffer::from_f32(&[2, 4], &[0.1; 8]);
+    let mut ids = TypedBuffer::zeros(&[2, 2], DType::U32);
+    let mut w = TypedBuffer::zeros(&[2, 2], DType::F32);
+    assert!(execute_moe_op(&op, &[], &mut [ids.as_view_mut(), w.as_view_mut()]).is_err());
+    assert!(execute_moe_op(&op, &[l_buf.as_view()], &mut [ids.as_view_mut()]).is_err());
+    assert!(execute_moe_op(
+        &op,
+        &[l_buf.as_view()],
+        &mut [ids.as_view_mut(), w.as_view_mut()],
+    )
+    .is_ok());
+    let other = Op::Barrier(r9v_ir::BarrierOp {
+        group: r9v_ir::GroupId::new(0),
+    });
+    assert!(execute_moe_op(
+        &other,
+        &[l_buf.as_view()],
+        &mut [ids.as_view_mut(), w.as_view_mut()],
+    )
+    .is_err());
+}

--- a/crates/r9v-t0/tests/ngram_gather_tests.rs
+++ b/crates/r9v-t0/tests/ngram_gather_tests.rs
@@ -1,0 +1,593 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for scalar T0 `ngram_gather` (Spec 1 §4.A, Card A1.9).
+
+use r9v_common::SeededRng;
+use r9v_format::SchemeId;
+use r9v_ir::{DType, HashId, NgramCombine, NgramGatherOp, NgramSource, Op, QuantScheme};
+use r9v_t0::buffer::TypedBuffer;
+use r9v_t0::dtype::{f16_to_f32, f32_to_f16};
+use r9v_t0::error::T0Error;
+use r9v_t0::{
+    execute_ngram_op, ngram_gather, ngram_gather_device, ngram_gather_f64_reference_rows,
+    ngram_gather_f64_reference_staged, NgramHash, Tolerance,
+};
+
+fn next_f32(rng: &mut SeededRng, lo: f32, hi: f32) -> f32 {
+    let u = ((rng.next_u64() >> 11) as f64) / (1u64 << 53) as f64;
+    lo + (u as f32) * (hi - lo)
+}
+
+fn staged_op(heads: u32, combine: NgramCombine) -> NgramGatherOp {
+    NgramGatherOp {
+        source: NgramSource::Staged,
+        orders: vec![1; heads as usize].into_boxed_slice(),
+        heads,
+        hash: HashId::new(0),
+        table_sizes: vec![64; heads as usize].into_boxed_slice(),
+        combine,
+        out_dtype: DType::F32,
+    }
+}
+
+fn device_op(heads: u32, sizes: &[u32], combine: NgramCombine) -> NgramGatherOp {
+    NgramGatherOp {
+        source: NgramSource::Device,
+        orders: vec![1; heads as usize].into_boxed_slice(),
+        heads,
+        hash: HashId::new(7),
+        table_sizes: sizes.to_vec().into_boxed_slice(),
+        combine,
+        out_dtype: DType::F32,
+    }
+}
+
+/// Fake hash: row = (token + pos + head_salt) mod table_size.
+struct FakeHash {
+    salts: Vec<u32>,
+}
+
+impl NgramHash for FakeHash {
+    fn row(&self, tokens: &[u32], pos: usize, _order: u32, table_size: u32) -> u32 {
+        let head = (pos * 31) % self.salts.len().max(1);
+        tokens[pos]
+            .wrapping_add(pos as u32)
+            .wrapping_add(self.salts[head % self.salts.len()])
+            % table_size
+    }
+}
+
+#[test]
+fn staged_concat_and_sum_match_f64_oracle() {
+    for combine in [NgramCombine::Concat, NgramCombine::Sum] {
+        let mut rng = SeededRng::new(0xB41);
+        let (t, np, dn) = (4, 3, 8);
+        let staging: Vec<i8> = (0..t * np * dn)
+            .map(|_| (rng.next_u64() % 21) as i8 - 10)
+            .collect();
+        let scales: Vec<f32> = (0..t * np).map(|_| next_f32(&mut rng, 0.05, 0.5)).collect();
+        let op = staged_op(np as u32, combine);
+
+        let st_buf = TypedBuffer::from_i8(&[t, np, dn], &staging)
+            .with_quant(QuantScheme::Scheme(SchemeId::I8R.to_ir()));
+        let sc_buf = TypedBuffer::from_f32(&[t, np], &scales);
+        let out1 = match combine {
+            NgramCombine::Concat => np * dn,
+            NgramCombine::Sum => dn,
+        };
+        let mut y_buf = TypedBuffer::zeros(&[t, out1], DType::F32);
+        ngram_gather(
+            &op,
+            &st_buf.as_view(),
+            &sc_buf.as_view(),
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        let expected = ngram_gather_f64_reference_staged(
+            &staging,
+            &scales.iter().map(|&s| s as f64).collect::<Vec<f64>>(),
+            t,
+            np,
+            dn,
+            combine,
+        )
+        .unwrap();
+        let tol = Tolerance::i8_weight();
+        for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("combine={combine:?} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn staged_rank1_and_f16_scales_agree() {
+    let (t, np, dn) = (3, 2, 6);
+    let staging = vec![2i8; t * np * dn];
+    let scales_f32 = vec![0.5f32; t];
+    let scales_f16: Vec<u16> = vec![0.5f32; np].iter().map(|&s| f32_to_f16(s)).collect();
+    let op = staged_op(np as u32, NgramCombine::Sum);
+    let st_buf = TypedBuffer::from_i8(&[t, np, dn], &staging)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8R.to_ir()));
+    let run = |sc: &TypedBuffer| {
+        let mut yb = TypedBuffer::zeros(&[t, dn], DType::F32);
+        ngram_gather(&op, &st_buf.as_view(), &sc.as_view(), &mut yb.as_view_mut()).unwrap();
+        yb.to_f32_vec()
+    };
+    let sc1 = TypedBuffer::from_f32(&[t], &scales_f32);
+    let sc2 = TypedBuffer::from_f16(&[t, np], &{
+        let mut v = Vec::new();
+        for _ in 0..t {
+            v.extend_from_slice(&scales_f16);
+        }
+        v
+    });
+    assert_eq!(run(&sc1), run(&sc2));
+    // 2 * 0.5 summed over 2 heads = 2.0 per element.
+    assert_eq!(run(&sc1), vec![2.0; t * dn]);
+}
+
+#[test]
+fn staged_i4_rows_fail_closed() {
+    let op = staged_op(2, NgramCombine::Concat);
+    let st_buf = TypedBuffer::from_bytes(&[2, 2, 8], DType::I4, &[0u8; 2 * 2 * 4])
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()));
+    let sc_buf = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 16], DType::F32);
+    let err = ngram_gather(
+        &op,
+        &st_buf.as_view(),
+        &sc_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, T0Error::QuantMismatch { .. }));
+}
+
+#[test]
+fn staged_multiblock_rows_fail_closed() {
+    // I8B128 with Dn != 128 has no scalar-scale rule: reject, don't invent one.
+    let op = staged_op(1, NgramCombine::Concat);
+    let st_buf = TypedBuffer::from_i8(&[2, 1, 256], &vec![1i8; 512])
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+    let sc_buf = TypedBuffer::from_f32(&[2], &[0.5, 0.5]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 256], DType::F32);
+    let err = ngram_gather(
+        &op,
+        &st_buf.as_view(),
+        &sc_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, T0Error::InvalidAttribute { .. }));
+}
+
+#[test]
+fn device_unquantized_table_matches_layout_oracle() {
+    for combine in [NgramCombine::Concat, NgramCombine::Sum] {
+        let mut rng = SeededRng::new(0xD041);
+        let (t, dn) = (5usize, 6usize);
+        let heads: u32 = 2;
+        let nh = heads as usize;
+        let sizes = [11u32, 13u32];
+        let entries = 24;
+        let table: Vec<f32> = (0..entries * dn)
+            .map(|_| next_f32(&mut rng, -1.0, 1.0))
+            .collect();
+        let tokens: Vec<u32> = (0..t).map(|_| (rng.next_u64() % 1000) as u32).collect();
+        let op = device_op(heads, &sizes, combine);
+        let hash = FakeHash { salts: vec![3, 5] };
+
+        let tok_buf = TypedBuffer::from_u32(&[t], &tokens);
+        let tab_buf = TypedBuffer::from_f32(&[entries, dn], &table);
+        let out1 = match combine {
+            NgramCombine::Concat => nh * dn,
+            NgramCombine::Sum => dn,
+        };
+        let mut y_buf = TypedBuffer::zeros(&[t, out1], DType::F32);
+        ngram_gather_device(
+            &op,
+            &tok_buf.as_view(),
+            &tab_buf.as_view(),
+            None,
+            &hash,
+            &mut y_buf.as_view_mut(),
+        )
+        .unwrap();
+
+        // Independent oracle over rows resolved by the same fake hash.
+        let bases = [0usize, 11usize];
+        let mut row_ids = vec![0u32; t * nh];
+        for row in 0..t {
+            for head in 0..nh {
+                let prow = hash.row(&tokens, row, 1, sizes[head]);
+                row_ids[row * nh + head] = (bases[head] + prow as usize) as u32;
+            }
+        }
+        let expected = ngram_gather_f64_reference_rows(
+            &table.iter().map(|&v| v as f64).collect::<Vec<f64>>(),
+            entries,
+            dn,
+            &row_ids,
+            t,
+            nh,
+            combine,
+        )
+        .unwrap();
+        let tol = Tolerance::f32();
+        for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+            tol.assert_within(actual as f64, exp, &format!("combine={combine:?} y[{i}]"));
+        }
+    }
+}
+
+#[test]
+fn device_i8_table_with_scales_matches_f64() {
+    let (t, dn) = (3usize, 4usize);
+    let heads: u32 = 2;
+    let nh = heads as usize;
+    let sizes = [5u32, 7u32];
+    let entries = 12;
+    let table_q: Vec<i8> = (0..entries * dn).map(|i| (i as i8 % 9) - 4).collect();
+    let table_bytes: Vec<u8> = table_q.iter().map(|&q| q as u8).collect();
+    let scales = vec![0.5f32; entries];
+    let scale_bytes: Vec<u8> = scales
+        .iter()
+        .flat_map(|&s| f32_to_f16(s).to_le_bytes())
+        .collect();
+    let tokens = vec![1u32, 2, 3];
+    let op = device_op(heads, &sizes, NgramCombine::Sum);
+    let hash = FakeHash { salts: vec![1, 2] };
+
+    let tok_buf = TypedBuffer::from_u32(&[t], &tokens);
+    let tab_buf = TypedBuffer::from_bytes(&[entries, dn], DType::I8, &table_bytes)
+        .with_quant(QuantScheme::PerRow);
+    let sc_buf = TypedBuffer::from_bytes(&[entries], DType::F16, &scale_bytes);
+    let mut y_buf = TypedBuffer::zeros(&[t, dn], DType::F32);
+    ngram_gather_device(
+        &op,
+        &tok_buf.as_view(),
+        &tab_buf.as_view(),
+        Some(&sc_buf.as_view()),
+        &hash,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    // Oracle: decode rows in f64, then layout.
+    let table_f64: Vec<f64> = table_q.iter().map(|&q| q as f64 * 0.5).collect();
+    let bases = [0usize, 5usize];
+    let mut row_ids = vec![0u32; t * nh];
+    for row in 0..t {
+        for head in 0..nh {
+            row_ids[row * nh + head] =
+                (bases[head] + hash.row(&tokens, row, 1, sizes[head]) as usize) as u32;
+        }
+    }
+    let expected = ngram_gather_f64_reference_rows(
+        &table_f64,
+        entries,
+        dn,
+        &row_ids,
+        t,
+        nh,
+        NgramCombine::Sum,
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("y[{i}]"));
+    }
+}
+
+#[test]
+fn staged_i8b128_dn128_accept_matches_f64() {
+    // Blocker 3: the staged I8B128 accept path (Dn == 128, one scalar row
+    // scale = the block scale) vs the f64 oracle.
+    let mut rng = SeededRng::new(0xB128);
+    let (t, np, dn) = (3usize, 2usize, 128usize);
+    let staging: Vec<i8> = (0..t * np * dn)
+        .map(|_| (rng.next_u64() % 21) as i8 - 10)
+        .collect();
+    let scales: Vec<f32> = (0..t * np).map(|_| next_f32(&mut rng, 0.05, 0.5)).collect();
+    let op = staged_op(np as u32, NgramCombine::Concat);
+    let st_buf = TypedBuffer::from_i8(&[t, np, dn], &staging)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+    let sc_buf = TypedBuffer::from_f32(&[t, np], &scales);
+    let mut y_buf = TypedBuffer::zeros(&[t, np * dn], DType::F32);
+    ngram_gather(
+        &op,
+        &st_buf.as_view(),
+        &sc_buf.as_view(),
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+    let expected = ngram_gather_f64_reference_staged(
+        &staging,
+        &scales.iter().map(|&s| s as f64).collect::<Vec<f64>>(),
+        t,
+        np,
+        dn,
+        NgramCombine::Concat,
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("staged-i8b128 y[{i}]"));
+    }
+}
+
+#[test]
+fn device_i8b128_multiblock_matches_f64() {
+    // Blocker 3: device I8B128 with Dn=256 (two blocks/row) via the canonical
+    // encoder, per-block scales in the separate [entries, 2] carrier.
+    let mut rng = SeededRng::new(0x1B82);
+    let (t, dn) = (3usize, 256usize);
+    let heads: u32 = 2;
+    let nh = heads as usize;
+    let sizes = [5u32, 7u32];
+    let entries = 12;
+    let blocks = dn / 128;
+    let mut table_q = vec![0i8; entries * dn];
+    let mut table_s = Vec::with_capacity(entries * blocks);
+    for row in 0..entries {
+        let vals: Vec<f32> = (0..dn).map(|_| next_f32(&mut rng, -1.0, 1.0)).collect();
+        let (q, sc) = r9v_format::encode_i8_block128(&vals).unwrap();
+        table_q[row * dn..(row + 1) * dn].copy_from_slice(&q);
+        table_s.extend_from_slice(&sc);
+    }
+    let table_bytes: Vec<u8> = table_q.iter().map(|&q| q as u8).collect();
+    let scale_bytes: Vec<u8> = table_s.iter().flat_map(|s| s.to_bytes()).collect();
+    let tokens = vec![4u32, 9, 2];
+    let op = device_op(heads, &sizes, NgramCombine::Sum);
+    let hash = FakeHash { salts: vec![1, 2] };
+
+    let tok_buf = TypedBuffer::from_u32(&[t], &tokens);
+    let tab_buf = TypedBuffer::from_bytes(&[entries, dn], DType::I8, &table_bytes)
+        .with_quant(QuantScheme::Scheme(SchemeId::I8B128.to_ir()));
+    let sc_buf = TypedBuffer::from_bytes(&[entries, blocks], DType::F16, &scale_bytes);
+    let mut y_buf = TypedBuffer::zeros(&[t, dn], DType::F32);
+    ngram_gather_device(
+        &op,
+        &tok_buf.as_view(),
+        &tab_buf.as_view(),
+        Some(&sc_buf.as_view()),
+        &hash,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    // Independent oracle: per-block q*s decode in f64, then layout.
+    let table_f64: Vec<f64> = table_q
+        .iter()
+        .enumerate()
+        .map(|(i, &q)| {
+            let s = table_s[(i / dn) * blocks + (i % dn) / 128];
+            q as f64 * f16_to_f32(s.bits()) as f64
+        })
+        .collect();
+    let bases = [0usize, 5usize];
+    let mut row_ids = vec![0u32; t * nh];
+    for row in 0..t {
+        for head in 0..nh {
+            row_ids[row * nh + head] =
+                (bases[head] + hash.row(&tokens, row, 1, sizes[head]) as usize) as u32;
+        }
+    }
+    let expected = ngram_gather_f64_reference_rows(
+        &table_f64,
+        entries,
+        dn,
+        &row_ids,
+        t,
+        nh,
+        NgramCombine::Sum,
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("device-i8b128 y[{i}]"));
+    }
+}
+
+#[test]
+fn device_i4k_nibble_parity_matches_f64() {
+    // Blocker 3: device I4K with Dn=256 (one superblock/row). The T0 decode
+    // packs even flat indices low; the oracle below is written against the
+    // same parity independently, and the fixture asserts mixed nibbles so a
+    // parity swap would fail loudly.
+    let mut rng = SeededRng::new(0x14B4);
+    let (t, dn) = (3usize, 256usize);
+    let heads: u32 = 2;
+    let nh = heads as usize;
+    let sizes = [5u32, 7u32];
+    let entries = 12;
+    let mut nibbles = vec![0u8; entries * dn];
+    let mut headers = Vec::with_capacity(entries);
+    for row in 0..entries {
+        let mut vals = [0.0f32; 256];
+        for v in vals.iter_mut().take(dn) {
+            *v = next_f32(&mut rng, -1.0, 1.0);
+        }
+        let (q, header) = r9v_format::encode_i4k_superblock(&vals).unwrap();
+        nibbles[row * dn..(row + 1) * dn].copy_from_slice(&q);
+        headers.push(header);
+    }
+    // Parity load-bearing: require mixed low/high nibbles in the fixture.
+    let mut mixed = 0;
+    for row in 0..entries {
+        for c in 0..dn / 2 {
+            if nibbles[row * dn + 2 * c] != nibbles[row * dn + 2 * c + 1] {
+                mixed += 1;
+            }
+        }
+    }
+    assert!(mixed > 0, "fixture must exercise nibble parity");
+    let mut packed = vec![0u8; entries * dn / 2];
+    for row in 0..entries {
+        for c in 0..dn / 2 {
+            packed[row * dn / 2 + c] =
+                (nibbles[row * dn + 2 * c] & 0x0F) | ((nibbles[row * dn + 2 * c + 1] & 0x0F) << 4);
+        }
+    }
+    let header_bytes: Vec<u8> = headers.iter().flat_map(|h| h.to_bytes()).collect();
+    let tokens = vec![7u32, 1, 11];
+    let op = device_op(heads, &sizes, NgramCombine::Concat);
+    let hash = FakeHash { salts: vec![2, 3] };
+
+    let tok_buf = TypedBuffer::from_u32(&[t], &tokens);
+    let tab_buf = TypedBuffer::from_bytes(&[entries, dn], DType::I4, &packed)
+        .with_quant(QuantScheme::Scheme(SchemeId::I4K.to_ir()));
+    let sc_buf = TypedBuffer::from_bytes(&[entries, 1, 4], DType::U32, &header_bytes);
+    let mut y_buf = TypedBuffer::zeros(&[t, nh * dn], DType::F32);
+    ngram_gather_device(
+        &op,
+        &tok_buf.as_view(),
+        &tab_buf.as_view(),
+        Some(&sc_buf.as_view()),
+        &hash,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap();
+
+    let mut table_f64 = vec![0.0f64; entries * dn];
+    for row in 0..entries {
+        let h = &headers[row];
+        let d = h.d_value(0).unwrap() as f64;
+        let dmin = h.dmin_value(0).unwrap() as f64;
+        let sc = h.scales();
+        let mn = h.mins();
+        for c in 0..dn {
+            let sub = (c % 256) / 32;
+            table_f64[row * dn + c] =
+                d * sc[sub] as f64 * nibbles[row * dn + c] as f64 - dmin * mn[sub] as f64;
+        }
+    }
+    let bases = [0usize, 5usize];
+    let mut row_ids = vec![0u32; t * nh];
+    for row in 0..t {
+        for head in 0..nh {
+            row_ids[row * nh + head] =
+                (bases[head] + hash.row(&tokens, row, 1, sizes[head]) as usize) as u32;
+        }
+    }
+    let expected = ngram_gather_f64_reference_rows(
+        &table_f64,
+        entries,
+        dn,
+        &row_ids,
+        t,
+        nh,
+        NgramCombine::Concat,
+    )
+    .unwrap();
+    let tol = Tolerance::i8_weight();
+    for (i, (&actual, &exp)) in y_buf.to_f32_vec().iter().zip(expected.iter()).enumerate() {
+        tol.assert_within(actual as f64, exp, &format!("device-i4k y[{i}]"));
+    }
+}
+
+struct BadHash;
+
+impl NgramHash for BadHash {
+    fn row(&self, _tokens: &[u32], _pos: usize, _order: u32, table_size: u32) -> u32 {
+        table_size + 3
+    }
+}
+
+#[test]
+fn device_hash_out_of_range_collected() {
+    let op = device_op(2, &[5, 7], NgramCombine::Concat);
+    let tok_buf = TypedBuffer::from_u32(&[2], &[1, 2]);
+    let tab_buf = TypedBuffer::from_f32(&[12, 4], &[0.1; 48]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 8], DType::F32);
+    let err = ngram_gather_device(
+        &op,
+        &tok_buf.as_view(),
+        &tab_buf.as_view(),
+        None,
+        &BadHash,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    match err {
+        T0Error::Multiple { problems } => assert_eq!(problems.len(), 4),
+        other => panic!("expected Multiple, got {other:?}"),
+    }
+    assert_eq!(y_buf.to_f32_vec(), vec![0.0; 16]);
+}
+
+#[test]
+fn device_orders_above_one_rejected() {
+    let op = NgramGatherOp {
+        source: NgramSource::Device,
+        orders: vec![2u32, 1].into_boxed_slice(),
+        heads: 2,
+        hash: HashId::new(7),
+        table_sizes: vec![5, 7].into_boxed_slice(),
+        combine: NgramCombine::Concat,
+        out_dtype: DType::F32,
+    };
+    let tok_buf = TypedBuffer::from_u32(&[2], &[1, 2]);
+    let tab_buf = TypedBuffer::from_f32(&[12, 4], &[0.1; 48]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 8], DType::F32);
+    let hash = FakeHash { salts: vec![1, 2] };
+    let err = ngram_gather_device(
+        &op,
+        &tok_buf.as_view(),
+        &tab_buf.as_view(),
+        None,
+        &hash,
+        &mut y_buf.as_view_mut(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        T0Error::InvalidAttribute { .. } | T0Error::Multiple { .. }
+    ));
+}
+
+#[test]
+fn dispatch_enforces_staged_arity_and_source() {
+    let staged = Op::NgramGather(staged_op(2, NgramCombine::Sum));
+    let st_buf = TypedBuffer::from_i8(&[2, 2, 4], &[1i8; 16])
+        .with_quant(QuantScheme::Scheme(SchemeId::I8R.to_ir()));
+    let sc_buf = TypedBuffer::from_f32(&[2, 2], &[0.5; 4]);
+    let mut y_buf = TypedBuffer::zeros(&[2, 4], DType::F32);
+    assert!(execute_ngram_op(&staged, &[st_buf.as_view()], &mut [y_buf.as_view_mut()]).is_err());
+    assert!(execute_ngram_op(
+        &staged,
+        &[st_buf.as_view(), sc_buf.as_view()],
+        &mut [y_buf.as_view_mut()]
+    )
+    .is_ok());
+    let device = Op::NgramGather(device_op(2, &[5, 7], NgramCombine::Sum));
+    assert!(execute_ngram_op(
+        &device,
+        &[st_buf.as_view(), sc_buf.as_view()],
+        &mut [y_buf.as_view_mut()]
+    )
+    .is_err());
+}
+
+#[test]
+fn determinism_and_batch_invariance() {
+    let (t, np, dn) = (5, 2, 6);
+    let staging: Vec<i8> = (0..t * np * dn).map(|i| (i % 17) as i8 - 8).collect();
+    let scales: Vec<f32> = (0..t * np).map(|i| 0.1 + (i as f32) * 0.01).collect();
+    let op = staged_op(np as u32, NgramCombine::Concat);
+    let run = |st: &[i8], sc: &[f32], tt: usize| {
+        let stb = TypedBuffer::from_i8(&[tt, np, dn], st)
+            .with_quant(QuantScheme::Scheme(SchemeId::I8R.to_ir()));
+        let scb = TypedBuffer::from_f32(&[tt, np], sc);
+        let mut yb = TypedBuffer::zeros(&[tt, np * dn], DType::F32);
+        ngram_gather(&op, &stb.as_view(), &scb.as_view(), &mut yb.as_view_mut()).unwrap();
+        yb.to_f32_vec()
+    };
+    let y1 = run(&staging, &scales, t);
+    let y2 = run(&staging, &scales, t);
+    assert_eq!(y1, y2);
+    // Row 3 alone.
+    let r3 = staging[3 * np * dn..4 * np * dn].to_vec();
+    let s3 = scales[3 * np..4 * np].to_vec();
+    assert_eq!(run(&r3, &s3, 1), y1[3 * np * dn..4 * np * dn]);
+}


### PR DESCRIPTION
## Card
A1.9 — t0 MoE/state/ngram/collective group   (kind: implementation; GPU: no; size: M)

## Spec sections implemented
- spec 1 §4.C: `moe_route` top-K routing and `moe_ffn` grouped expert GEMM tensor contracts.
- spec 1 §4.E: `causal_conv1d` depthwise causal convolution and `linear_attn_scan` chunked/recurrent state contracts.
- spec 1 §4.A: `ngram_gather` staged host-gather and device hash-table contracts.
- spec 1 §4.G: rank-1 `all_reduce`/`all_gather`/`reduce_scatter`/`all_to_all`/`send`/`recv`/`barrier` contracts.
- spec 1 §6.1, §6.2: f32-ascending numerics, `moe_ffn_gemm_numerics`, and tolerance-table conformance.
- spec 3 §4.1, §4.2: `ConvWindow`/`Recurrent` state kinds and the A/B slot discipline.
- spec 4 §2, §5.5, §5.6, §5.9, §10: T0 scope, scan chunking/recurrence, MoE expert parallelism, placement, and determinism.

## Deliverables
- [x] `moe_route` with stable softmax/sigmoid, lowest-index tie-break, scale-then-renormalize, and grouped-routing fail-closed.
- [x] `moe_ffn` with sorted `(expert, token, slot)` triples, gate/up GEMM reuse via `matmul_with_scales`, Branch-D-mirroring down projection, and sorted weighted combine.
- [x] `causal_conv1d` with explicit `SeqLayout` segmentation, `f16` state continuity, staged outputs, and quantized-weight fail-closed.
- [x] `linear_attn_scan_chunked` and `linear_attn_scan_recurrent` over one shared scalar recurrence with identical op order.
- [x] `ngram_gather` (staged dequantize+layout) and `ngram_gather_device` (`&dyn NgramHash`, bounds-checked rows, orders>1 fail-closed).
- [x] All rank-1 collectives as bit-exact identities through the `copy` core; `send(0)`/`barrier` no-ops; `recv` typed refusal.
- [x] Independent `f64` oracles for route/ffn/conv/scan/staged-ngram/device-layout plus exact, determinism, batch-invariance, and adversarial tests.
- [x] Public dispatch (`execute_moe_op`, `execute_state_scan_op`, `execute_ngram_op`, `execute_collective_op`) with exact arity enforcement.
- [x] SPEC-ISSUES SI-47 through SI-55 filed after the landed A1.7 entries SI-43..SI-46.

## Done-when tests
| test | location | tier | status |
|---|---|---|---|
| router oracle, tie-break, bias-shift, batch invariance, grouped/non-finite refusals, sigmoid zero-sum + post-bias-overflow adversarial refusals | crates/r9v-t0/tests/moe_route_tests.rs (13) | cpu-only | green |
| hand-computed pipeline, real moe_ffn-vs-matmul Branch-D differential (bit-exact), f16/i8 oracles, permutation invariance, duplicate slots, bounds-before-mutation, I8B128/I4K/E4M3B128 inline+separate(+attached) oracles, L1-vs-L0 bits + oracle (F16 plus I8R/I8B128/E4M3B128/I4K down inline+separate, incl. non-tile-aligned I8R), I8R gate/up, PerToken/PerBlock32, attached carriers | crates/r9v-t0/tests/moe_ffn_tests.rs (23) | cpu-only | green |
| split-vs-oneshot L0 (f16-exact), pre-rounded boundary L0, general-value f32-tolerance continuity, reset, f64 oracle, quantized-weight refusal | crates/r9v-t0/tests/causal_conv1d_tests.rs (9) | cpu-only | green |
| chunked-vs-recurrent L0 all kinds/chunks/D-Dv, f64 oracle, A/B recompute, gate refusals | crates/r9v-t0/tests/linear_attn_scan_tests.rs (6) | cpu-only | green |
| staged oracle concat/sum, staged I8B128-Dn128 accept, i4/multiblock refusals, device layout oracle, device I8B128-multiblock + I4K-parity oracles, hash-bounds, orders refusal | crates/r9v-t0/tests/ngram_gather_tests.rs (13) | cpu-only | green |
| rank-1 identity incl. u32 above 2^24, axis/counts/peer refusals, recv fail-closed, arity | crates/r9v-t0/tests/collectives_tests.rs (6) | cpu-only | green |
| public surface, Send/Sync, all four dispatchers | crates/r9v-t0/tests/api_shape.rs | cpu-only | green |

## Final-audit repair (uncommitted, this worktree)

- Blocker 1: L1 + quantized MoE down-projection now proven — four new oracle
  tests (L1 I8R non-tile-aligned, L1 I8B128 over two SoA row-blocks, L1
  E4M3B128, L1 I4K with mixed-nibble fixture), each L1-inline and L1-separate
  bit-exact vs an L0 reference plus the independent f64 oracle. No accepted L1
  quantized path remains untested.
- Blocker 2: the drift-guard test is now a real differential —
  `down_path_differential_matches_matmul_branch_d_bit_exact` invokes both
  `moe_ffn` and `matmul_with_scales` on equivalent down-projection inputs and
  asserts bit-exact output (plus exact `[153, 199]`).

## Audit repair (uncommitted, this worktree)

- Blocker 1: `moe_route` rejects zero/non-finite renormalize sums, non-finite
  post-bias scores, and non-finite staged weights per row (SI-51) before
  either output mutates; extreme-negative and post-bias-overflow adversarial
  tests added.
- Blocker 2: every accepted MoE surface now has independent-oracle coverage
  (L1, I8B128, I4K, E4M3B128, inline/separate/attached carriers, PerToken,
  PerBlock32); nothing left accepted-but-untested.
- Blocker 3: device I8B128 multi-block and I4K parity plus staged I8B128
  Dn=128 success all proven vs the f64 oracles.
- All six f64 oracles return `Result` with typed validation (no panics);
  `SeqLayout::offset_of` verified absent; conv split-vs-oneshot docs state
  the f16-representability condition with a general-value tolerance test.

## Decisions
- crates/r9v-t0/src/segments.rs:11 — sequence boundaries travel as an explicit execution-only `SeqLayout` with leading-`S` state slots; rejected fake tensor edges.
- crates/r9v-t0/src/moe_route.rs:85 — scale multiplies selected scores before renormalization; renormalization divides by the selected-K sum.
- crates/r9v-t0/src/moe_ffn.rs:64 — accept `shared_experts <= E`, ignore it for compute; rejected a second GEMM path.
- crates/r9v-t0/src/moe_ffn.rs:71 — gate rows are `[0, Dff)`, up rows `[Dff, 2·Dff)`; rejected interleaved alternation.
- crates/r9v-t0/src/moe_ffn.rs:497 — L1 expert tiles are interpreted over the flattened `[E·R, K]` row space.
- crates/r9v-t0/src/causal_conv1d.rs:49 — state slots are `f16` exactly with staged `y`/state commit; rejected wider state and in-place updates.
- crates/r9v-t0/src/linear_attn_scan.rs:8 — all three scan kinds share the gated outer-product recurrence; chunking is T0-level loop blocking only.
- crates/r9v-t0/src/ngram_gather.rs:40 — staged tables are row-major with a separate scalar `row_scales` carrier; rejected inline scale records.
- crates/r9v-t0/src/ngram_gather.rs:385 — quantized device tables require the separate scale carrier; rejected inline scale rows under hashed addressing.
- crates/r9v-t0/src/collectives.rs:11 — rank-1 data collectives are bit-exact identities through the `copy` core; rejected `f32` round-trips and zero-filled `recv`.

## SPEC-ISSUES filed
- SI-47 (scan kind equations), SI-48 (sequence boundaries), SI-49 (MoE selection semantics), SI-50 (gate/up order), SI-51 (router composition), SI-52 (scale carriers), SI-53 (n-gram hash/orders/carriers), SI-54 (rank-1 collectives), SI-55 (conv quant/act/state) — all in SPEC-ISSUES.md.

## New dependencies
- none

## Hardware
Tests run here: hosted cpu-only plus existing stub-device workspace tests
Tests pending on the runner: none
Measured numbers (if any): fingerprint none, command `cargo test --workspace --all-targets`, receipt none

## Checklist
Walked `references/acceptance-checklist.md`. Items answered "no" and why:
- Shared op-harness migration: no; A1.10 owns the later generic harness after A1.5–A1.9 exist, while this card includes the required golden, batch-invariance, determinism, malformed-input, and adversarial coverage directly.
- Performance receipt: no; this is the scalar correctness tier and has no GPU performance gate.
- Multi-rank executor coverage: no; rank>1 reduction/transport is executor scope per spec 4 §5.9, and rank-1 behavior is fully pinned here.

## Size check
Diff size vs card size class: 9,991 insertions across 16 files vs M — substantially larger than the estimate because the cohesive card owns seven operation families, six typed f64 oracles, four dispatchers, nine SPEC-ISSUES, and 70 focused behavior tests. Splitting it would leave temporary incompatible state/scale/dispatch surfaces, so the full card remains one integration unit.
